### PR TITLE
Add ProjectiveVectors

### DIFF
--- a/src/HomotopyContinuation.jl
+++ b/src/HomotopyContinuation.jl
@@ -12,11 +12,13 @@ module HomotopyContinuation
         PathTracking,
         Predictors,
         Problems,
+        ProjectiveVectors,
         StepSize,
         Systems,
         Utilities
 
     include("utilities.jl")
+    include("projective_vectors.jl")
     include("systems.jl")
     include("homotopies.jl")
     include("problems.jl")

--- a/src/affine_patches.jl
+++ b/src/affine_patches.jl
@@ -1,5 +1,7 @@
 module AffinePatches
 
+import ..ProjectiveVectors: PVector, raw
+
 export AbstractPatch,
     AbstractLocalAffinePatch,
     precondition!,

--- a/src/endgame.jl
+++ b/src/endgame.jl
@@ -29,12 +29,12 @@ end
 
 include("endgames/cauchy.jl")
 
-mutable struct EndgamerState{T}
-    xs::NTuple{3, Vector{T}}
+mutable struct EndgamerState{V}
+    xs::NTuple{3, V}
     R::Float64
 
-    p::Vector{T}
-    pprev::Vector{T}
+    p::V
+    pprev::V
 
     npredictions::Int
     iter::Int
@@ -100,9 +100,9 @@ end
 * `npredictions`: The number of predictions.
 * `iters`: The number of iterations.
 """
-struct EndgamerResult{T}
+struct EndgamerResult{V}
     returncode::Symbol
-    x::Vector{T}
+    x::V
     t::Float64
     windingnumber_estimate::Int
     npredictions::Int
@@ -165,7 +165,7 @@ Try to predict the value of the path `x(t)` and `t=0.0`.
     if retcode == :success
         state.npredictions += 1
         state.windingnumber_estimate = windingnumber
-        if infinity_norm(p, 1) > endgamer.options.maxnorm
+        if infinity_norm(p) > endgamer.options.maxnorm
             endgamer.state.status = :at_infinity
         end
     elseif retcode ≠ :heuristic_failed
@@ -218,7 +218,7 @@ function moveforward!(endgamer::Endgamer)
         state.status = :ill_conditioned_zone
         return nothing
     end
-    if infinity_norm(x, 1) > endgamer.options.maxnorm
+    if infinity_norm(x) > endgamer.options.maxnorm
         state.status = :at_infinity
         state.p .= x
     end

--- a/src/endgames/cauchy.jl
+++ b/src/endgames/cauchy.jl
@@ -51,8 +51,8 @@ with `samples_per_loop + 1`.
 * `unitroots::Vector{Complex{Float64}}` Vector of length `samples_per_loop`
 holding the values ``exp(i2π k/N)`` for ``k=0,..,N-1`` where ``N`` is `samples_per_loop`.
 """
-struct CauchyCache{T}
-    samples::Vector{Vector{T}}
+struct CauchyCache{V<:AbstractVector}
+    samples::Vector{V}
     unitroots::Vector{Complex{Float64}}
 end
 
@@ -146,7 +146,7 @@ function loop!(cache::CauchyCache, alg::Cauchy, tracker, x, R, samples_per_loop,
         end
         if (k - 1) % samples_per_loop == 0
             # Check wether the loop is closed
-            Δ = infinity_norm(samples_buffer[1], xk)
+            Δ = unsafe_infinity_norm(samples_buffer[1], xk)
             isclosed = Δ < PathTracking.tol(tracker) * 1e3
             if isclosed
                 return (:success, c)

--- a/src/path_trackers/projective/patched_homotopy.jl
+++ b/src/path_trackers/projective/patched_homotopy.jl
@@ -6,6 +6,7 @@ import ..Homotopies: AbstractHomotopy, AbstractHomotopyCache, HomotopyWithCache,
     dt!, dt,
     jacobian_and_dt!, jacobian_and_dt
 import ..Homotopies
+import ..ProjectiveVectors: AbstractProjectiveVector, raw
 
 """
     PatchedHomotopy(H::AbstractHomotopy, v::Vector)
@@ -13,7 +14,7 @@ import ..Homotopies
 Augment the homotopy `H` with the given patch. This results in the system `[H(x,t); v ⋅ x - 1]`
 where `v` is defined by `patch`.
 """
-struct PatchedHomotopy{M, N, H<:AbstractHomotopy, V<:AbstractVector} <: AbstractHomotopy{M, N}
+struct PatchedHomotopy{M, N, H<:AbstractHomotopy, V<:AbstractProjectiveVector} <: AbstractHomotopy{M, N}
     homotopy::H
     patch::V
 end

--- a/src/path_tracking.jl
+++ b/src/path_tracking.jl
@@ -41,11 +41,11 @@ end
 function PathTracker(prob::Problems.AbstractProblem, x₁::AbstractVector{<:Number}, t₁, t₀; kwargs...)
      PathTracker(prob.homotopy, Problems.embed(prob, x₁), t₁, t₀; kwargs...)
 end
-function PathTracker(H::AbstractHomotopy, x::AbstractVector{<:Number}, start, target; options=PathTrackers.Options(), method=Projective, kwargs...)
+function PathTracker(H::AbstractHomotopy, x, start, target; options=PathTrackers.Options(), method=Projective, kwargs...)
     PathTracker(method(H; kwargs...), x, start, target, options)
 end
 
-function PathTracker(method::AbstractPathTrackerMethod, x::AbstractVector{<:Number}, start, target, options=PathTrackers.Options())
+function PathTracker(method::AbstractPathTrackerMethod, x, start, target, options=PathTrackers.Options())
     tracker_state = PathTrackers.state(method, x, start, target)
     tracker_cache = PathTrackers.cache(method, tracker_state)
     PathTracker(method, options, tracker_state, tracker_cache)
@@ -219,12 +219,8 @@ function result(tracker::PathTracker)
      else
           res = NaN
      end
-     x = final_x(tracker)
-     PathTrackerResult(successfull, returncode, x, current_t(tracker), res, current_iter(tracker))
+     PathTrackerResult(successfull, returncode, copy(tracker.state.x), current_t(tracker), res, current_iter(tracker))
 end
-
-final_x(tracker) = copy(current_x(tracker))
-final_x(tracker::PathTracker{<:Projective}) = ProjectiveVector(copy(current_x(tracker)))
 
 """
     current_t(tracker::PathTracker)

--- a/src/prediction_correction.jl
+++ b/src/prediction_correction.jl
@@ -51,19 +51,19 @@ Perform a prediction-correction step and store the result in `x` if successfull.
 the correction was sucessfull, otherwise `(false, status)` where `status` is either `:ok` or an error code.
 """
 @inline function predict_correct!(x, PC::PredictorCorrector, cache::PredictorCorrectorCache, H, t, Δt, tol, maxiters)
-    try
-        xnext = cache.xnext
-        Predictors.predict!(xnext, PC.predictor, cache.predictor, H, x, t, Δt)
-        result = Correctors.correct!(xnext, PC.corrector, cache.corrector, H, xnext, t + Δt, tol, maxiters)
-        if result.converged
-            x .= xnext
-            return (true, :ok)
-        else
-            return (false, :ok)
-        end
-    catch
-        return (false, :predictor_corrector_failed)
+    # try
+    xnext = cache.xnext
+    Predictors.predict!(xnext, PC.predictor, cache.predictor, H, x, t, Δt)
+    result = Correctors.correct!(xnext, PC.corrector, cache.corrector, H, xnext, t + Δt, tol, maxiters)
+    if result.converged
+        x .= xnext
+        return (true, :ok)
+    else
+        return (false, :ok)
     end
+    # catch err
+    #     return (false, :predictor_corrector_failed)
+    # end
 end
 
 """

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -1,11 +1,14 @@
 module Problems
 
-using ..Utilities
-import ..Systems: SPSystem
-import ..Homotopies: AbstractHomotopy, AbstractStartTargetHomotopy, StraightLineHomotopy
-
 import MultivariatePolynomials
 const MP = MultivariatePolynomials
+
+
+import ..Homotopies: AbstractHomotopy, AbstractStartTargetHomotopy, StraightLineHomotopy
+import ..ProjectiveVectors
+import ..Systems: SPSystem
+
+using ..Utilities
 
 # STAGE 1 exports
 export AbstractDynamicProblem,
@@ -23,9 +26,7 @@ export AbstractProblem,
     ProjectiveStartTargetProblem,
     homotopy,
     homogenization_strategy,
-    emebd
-
-
+    embed
 
 # STAGE 1
 
@@ -177,9 +178,9 @@ function embed(prob::ProjectiveStartTargetProblem{<:AbstractHomotopy{M, N}, Null
 end
 function embed(prob::ProjectiveStartTargetProblem{<:AbstractHomotopy{M, N}, DefaultHomogenization}, x) where {M, N}
     if length(x) == N
-        return x
+        return ProjectiveVectors.PVector(x, 1)
     elseif length(x) == N - 1
-        return [one(eltype(x)); x]
+        return ProjectiveVectors.embed(x, 1)
     end
     throw(error("The length of the intial solution is $(length(x)) but expected length $N or $(N-1)."))
 end

--- a/src/projective_vectors.jl
+++ b/src/projective_vectors.jl
@@ -269,8 +269,7 @@ end
 """
 function converteltype(v::ProdPVector, ::Type{T}) where T
     data = convert.(T, v.data)
-    pvectors = _create_pvectors(data, vs)
-    ProdPVector(data, pvectors)
+    ProdPVector(data, _create_pvectors(data, pvectors(v)))
 end
 converteltype(v::ProdPVector{T}, ::Type{T}) where T = v
 
@@ -310,7 +309,7 @@ end
 
 For each projective vector of the product return associated affine patch.
 """
-affine(z::ProdPVector) = affine.(v.pvectors)
+affine(z::ProdPVector) = affine.(z.pvectors)
 
 """
     affine!(z::ProdPVector)
@@ -336,7 +335,7 @@ function infinity_norm(v::ProdPVector, w::ProdPVector)
     p₁ = pvectors(v)
     p₂ = pvectors(w)
     m = infinity_norm(p₁[1], p₂[1])
-    for k=2:length(p1)
+    for k=2:length(p₁)
         m = max(m, infinity_norm(p₁[k], p₂[k]))
     end
     m

--- a/src/projective_vectors.jl
+++ b/src/projective_vectors.jl
@@ -195,7 +195,6 @@ end
 function at_infinity(z::PVector{<:Real}, maxnorm)
     at_inf = false
     tol = maxnorm * abs(z.data[z.homvar])
-    @show tol
     for k in 1:length(z)
         if k == z.homvar
             continue
@@ -229,13 +228,22 @@ struct ProdPVector{T} <: AbstractProjectiveVector{T}
     pvectors::Vector{PVector{T, VecView{T}}}
 end
 
-function ProdPVector(vs) where T
+function ProdPVector(vs)
     data = copy(vs[1].data);
     for k=2:length(vs)
         append!(data, vs[k].data)
     end
     pvectors = _create_pvectors(data, vs)
     ProdPVector(data, pvectors)
+end
+
+function (==)(v::ProdPVector, w::ProdPVector)
+    for (vᵢ, wᵢ) in zip(pvectors(v), pvectors(w))
+        if vᵢ != wᵢ
+            return false
+        end
+    end
+    true
 end
 
 function _create_pvectors(data, vs)
@@ -250,10 +258,10 @@ function _create_pvectors(data, vs)
     pvectors
 end
 
-function Base.copy(z::PVector{T, V}) where {T, V}
+function Base.copy(z::ProdPVector)
     data = copy(z.data)
-    pvectors = _create_pvectors(data, vs)
-    PVector{T, V}(data, z.homvar)
+    new_pvectors = _create_pvectors(data, pvectors(z))
+    ProdPVector(data, new_pvectors)
 end
 
 """

--- a/src/projective_vectors.jl
+++ b/src/projective_vectors.jl
@@ -1,0 +1,311 @@
+module ProjectiveVectors
+
+import Base: ==
+
+export PVector,
+    ProdPVector,
+    raw,
+    homvar,
+    affine,
+    affine!,
+    embed,
+    at_infinity,
+    raw,
+    pvectors,
+    infinity_norm,
+    infinity_norm_fast,
+    unsafe_infinity_norm
+
+abstract type ProjectiveVector{T} end
+
+"""
+    PVector(z, homvar)
+
+A `PVector` represents a projective vector `z` which is the result
+of the embedding of an affine vector `x` into projective space.
+Note that the constructor *does not* perform the embedding but rather
+is a simple wrapper. In order to embed an affine vector use
+[`embed`](@ref).
+"""
+struct PVector{T, V<:AbstractVector{T}} <: ProjectiveVector{T}
+    data::V
+    homvar::Int
+
+    function PVector{T, V}(data, homvar) where {T, V}
+        @assert 1 ≤ homvar ≤ length(data)
+        new(data, homvar)
+    end
+end
+PVector(x::V, homvar::Int) where {T, V<:AbstractVector{T}} = PVector{T, V}(x, homvar)
+
+"""
+    raw(z::PVector)
+
+Access the underlying vector of `z`. This is useful to pass
+the vector into some function which does not know the
+projective structure.
+"""
+raw(z::PVector) = z.data
+
+"""
+    homvar(z::PVector)
+
+Get the index of the homogenous variable.
+"""
+homvar(z::PVector) = z.homvar
+
+Base.length(z::PVector) = length(z.data)
+Base.getindex(z::PVector, i) = getindex(z.data, i)
+Base.getindex(z::PVector, i...) = getindex(z.data, i...)
+Base.endof(z::PVector) = endof(z.data)
+
+(==)(v::PVector, w::PVector) = v.homvar == w.homvar && v.data == w.data
+
+Base.copy(z::PVector) = PVector(copy(z.data), z.homvar)
+
+"""
+    embed(x::Vector, homvar)::PVector
+"""
+function embed(x::Vector{T}, homvar) where T
+    k = 1
+    data = Vector{T}(length(x) + 1)
+    for k in 1:length(data)
+        if k == homvar
+            data[k] = one(T)
+        else
+            i = k < homvar ? k : k - 1
+            data[k] = x[i]
+        end
+    end
+    PVector(data, homvar)
+end
+
+"""
+    affine_normalizer(z::PVector)
+
+Returns a scalar to bring `z` on its affine patch.
+"""
+affine_normalizer(z::PVector) = inv(z.data[z.homvar])
+"""
+    abs2_ffine_normalizer(z::PVector)
+
+Returns the squared absolute value of the normalizer.
+"""
+abs2_affine_normalizer(z::PVector) = inv(abs2(z.data[z.homvar]))
+
+"""
+    affine(z::PVector)::Vector
+
+Return the corresponding affine vector.
+"""
+function affine(z::PVector{T}) where {T}
+    x = Vector{T}(length(z) - 1)
+    normalizer = affine_normalizer(z)
+    for k in 1:length(z)
+        if k == z.homvar
+            continue
+        end
+        i = k < z.homvar ? k : k - 1
+        x[i] = z.data[k] * normalizer
+    end
+    x
+end
+
+"""
+    affine!(z::PVector)
+
+Bring the projective vector on associated affine patch.
+"""
+affine!(z::PVector) = scale!(z.data, affine_normalizer(z))
+
+"""
+    infinity_norm(z::PVector)
+
+Compute the ∞-norm of `z`. If `z` is a complex vector this is more efficient
+than `norm(z, Inf)`.
+
+    infinity_norm(z₁::PVector, z₂::PVector)
+
+Compute the ∞-norm of `z₁-z₂` by bringing both vectors first on their respective
+affine patch. This therefore only makes sense if both vectors have the
+same affine patch.
+"""
+function infinity_norm(z::PVector{<:Complex})
+    sqrt(maximum(abs2, raw(z)) * abs2_affine_normalizer(z))
+end
+
+function infinity_norm(z₁::PVector{<:Complex}, z₂::PVector{<:Complex})
+    normalizer₁ = affine_normalizer(z₁)
+    normalizer₂ = -affine_normalizer(z₂)
+    m = abs2(muladd(z₁[1], normalizer₁, z₂[1] * normalizer₂))
+    n₁, n₂ = length(z₁), length(z₂)
+    if n₁ ≠ n₂
+        return convert(typeof(m), Inf)
+    end
+    @inbounds for k=2:n₁
+        m = max(m, abs2(muladd(z₁[k], normalizer₁, z₂[k] * normalizer₂)))
+    end
+    sqrt(m)
+end
+
+"""
+    unsafe_infinity_norm(z₁::PVector, z₂::PVector)
+
+Compute the ∞-norm of `z₁-z₂`. This *does not* bring both vectors on their respective
+affine patch before computing the norm.
+"""
+function unsafe_infinity_norm(z₁::PVector{<:Complex}, z₂::PVector{<:Complex})
+    m = abs2(z₁[1] - z₂[1])
+    n₁, n₂ = length(z₁), length(z₂)
+    if n₁ ≠ n₂
+        return convert(typeof(m), Inf)
+    end
+    @inbounds for k=2:n₁
+        m = max(m, abs2(z₁[k] - z₂[k]))
+    end
+    sqrt(m)
+end
+
+"""
+    at_infinity(z::PVector, maxnorm)
+
+Check whether `z` represents a point at infinity.
+We declare `z` at infinity if the infinity norm of
+its affine vector is larger than `maxnorm`.
+"""
+function at_infinity(z::PVector{<:Complex}, maxnorm)
+    at_inf = false
+    tol = maxnorm * maxnorm * abs2(z.data[z.homvar])
+    for k in 1:length(z)
+        if k == z.homvar
+            continue
+        # we avoid the sqrt here by using the squared comparison
+        elseif abs2(z.data[k]) > tol
+            return true
+        end
+    end
+    false
+end
+function at_infinity(z::PVector{<:Real}, maxnorm)
+    at_inf = false
+    tol = maxnorm * abs(z.data[z.homvar])
+    @show tol
+    for k in 1:length(z)
+        if k == z.homvar
+            continue
+        elseif abs(z.data[k]) > tol
+            return true
+        end
+    end
+    false
+end
+
+Base.LinAlg.norm(v::PVector, p=2) = norm(v.data, p)
+function Base.LinAlg.normalize!(v::PVector, p=2)
+    normalize!(v.data, p)
+    v
+end
+
+
+
+const VecView{T} = SubArray{T,1,Vector{T},Tuple{UnitRange{Int64}},true}
+
+"""
+    ProdPVector(pvectors)
+
+Construct a product of `PVector`s. This
+"""
+struct ProdPVector{T} <: ProjectiveVector{T}
+    data::Vector{T}
+    # It is faster to use a tuple instead but this puts
+    # additional stress on the compiler and makes things
+    # not inferable, so we do this not for now.
+    # But we should be able to change this easily later
+    pvectors::Vector{PVector{T, VecView{T}}}
+end
+
+function ProdPVector(vs::Vector{PVector{T, Vector{T}}}) where T
+    data = copy(vs[1].data);
+    for k=2:length(vs)
+        append!(data, vs[k].data)
+    end
+    pvectors = Vector{PVector{T, VecView{T}}}()
+    k = 1
+    for i = 1:length(vs)
+        n = length(vs[i])
+        vdata = view(data, k:k+n-1)
+        push!(pvectors, PVector(vdata, homvar(vs[i])))
+        k += n
+    end
+    ProdPVector(data, pvectors)
+end
+
+"""
+    pvectors(z::ProdPVector)
+
+Return the `PVector`s out of which the product `z` exists.
+"""
+pvectors(z::ProdPVector) = z.pvectors
+
+"""
+    raw(z::ProdPVector)
+
+Access the underlying vector of the product `z`. Note that this
+is only a single vector. This is useful to pass
+the vector into some function which does not know the
+projective structure.
+"""
+raw(v::ProdPVector) = v.data
+
+"""
+    at_infinity(z::ProdPVector, maxnorm)
+
+Returns `true` if any vector of the product is at infinity.
+"""
+function at_infinity(v::ProdPVector, maxnorm)
+    for vᵢ in pvectors(v)
+        if at_infinity(vᵢ, maxnorm)
+            return true
+        end
+    end
+    false
+end
+
+"""
+    affine(z::ProdPVector)
+
+For each projective vector of the product return associated affine patch.
+"""
+affine(z::ProdPVector) = affine.(v.pvectors)
+
+"""
+    affine!(z::ProdPVector)
+
+Bring each projective vector of the product on the associated affine patch.
+"""
+function affine!(v::ProdPVector)
+    for w in pvectors(v)
+        affine!(w)
+    end
+    v
+end
+
+function Base.LinAlg.normalize!(v::ProdPVector, p=2)
+    for w in pvectors(v)
+        normalize!(w, p)
+    end
+    v
+end
+
+infinity_norm(z::ProdPVector) = maximum(infinity_norm, pvectors(z))
+function infinity_norm(v::ProdPVector, w::ProdPVector)
+    p₁ = pvectors(v)
+    p₂ = pvectors(w)
+    m = infinity_norm(p₁[1], p₂[1])
+    for k=2:length(p1)
+        m = max(m, infinity_norm(p₁[k], p₂[k]))
+    end
+    m
+end
+
+end

--- a/src/solving/path_crossing.jl
+++ b/src/solving/path_crossing.jl
@@ -1,4 +1,5 @@
 using ..Utilities
+import ..ProjectiveVectors
 
 """
     pathcrossing_check!(tracked_paths, solver)
@@ -73,7 +74,7 @@ function check_crossed_paths(paths, tol)
         x = paths[i].x
         crossing = false
         for j=i+1:length(paths)
-            if !path_handled[j] && distance(x, paths[j].x) < tol
+            if !path_handled[j] && ProjectiveVectors.infinity_norm(x, paths[j].x) < tol
                 push!(crossed_path_indices, j)
                 crossing = true
                 path_handled[j] = true

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -10,12 +10,8 @@ export allvariables,
     homogenize,
     totaldegree,
     solve_with_lu_inplace!,
-    ProjectiveVector,
-    sine_distance,
-    dsin,
-    riemann_distance,
-    distance,
     infinity_norm,
+    unsafe_infinity_norm,
     batches
 
 
@@ -257,15 +253,7 @@ function infinity_norm(z₁::AbstractVector{<:Complex}, z₂::AbstractVector{<:C
     end
     sqrt(m)
 end
-function infinity_norm(z::AbstractVector{<:Complex}, eᵢ::Int)
-    normalizer = inv(z[eᵢ])
-    m = abs2(z[1] * normalizer)
-    @inbounds for k=2:length(z)
-        m = max(m, abs2(z[k] * normalizer))
-    end
-    sqrt(m)
-end
-infinity_norm(z) = norm(z, Inf) # fallback
+unsafe_infinity_norm(v, w) = infinity_norm(v, w)
 
 
 function Base.findmax(f, xs)

--- a/test/projective_path_tracker_test.jl
+++ b/test/projective_path_tracker_test.jl
@@ -1,5 +1,6 @@
+const PathTrackers = HomotopyContinuation.PathTrackers
+
 @testset "Projective Tracker" begin
-    const PathTrackers = HomotopyContinuation.PathTrackers
     p1 = Problems.TotalDegreeProblem(equations(katsura7()))
     P = Problems.ProjectiveStartTargetProblem(p1)
 
@@ -11,9 +12,9 @@
 
     @test PathTracking.current_status(tracker) == :ok
 
-    tracker = PathTracking.PathTracker(P.homotopy, collect(1:9), 1.0, 0.0)
-    @test PathTracking.current_x(tracker) isa Vector{Complex{Float64}}
+    tracker = PathTracking.PathTracker(P.homotopy, Problems.embed(P, collect(1:9)), 1.0, 0.0)
+    @test PathTracking.current_x(tracker) isa ProjectiveVectors.PVector{Complex{Float64}}
     @test PathTracking.current_status(tracker) == :invalid_startvalue
 
-    @test_throws ErrorException PathTracking.PathTracker(P.homotopy, ones(Int, 8), 1.0, 0.0)
+    @test_throws ErrorException PathTracking.PathTracker(P.homotopy, Problems.embed(P, collect(1:7)), 1.0, 0.0)
 end

--- a/test/projective_vectors_test.jl
+++ b/test/projective_vectors_test.jl
@@ -23,6 +23,10 @@ using Compat.Test
     @test all(affine(z) .≈ (z[2:end] ./ z[1]))
     normalize!(z)
 
+    inf_z = infinity_norm(z)
+    affine!(z)
+    @test unsafe_infinity_norm(z, z) ≈ 0.0
+
     @test at_infinity(z, 1e5) == false
     @test at_infinity(PVector([2, 1e-7, 4], 2), 1e5) == true
     @test at_infinity(PVector([2, 1e-7, 4], 2), 5e7) == false
@@ -32,6 +36,8 @@ using Compat.Test
     x1 = PVector(rand(Complex{Float64}, 3), 2)
     x2 = PVector(rand(Complex{Float64}, 7), 3)
     z2 = ProdPVector([x1, x2])
+    @test affine(z2) == [affine(x1), affine(x2)]
+
     @test length.(pvectors(z2)) == [3, 7]
     @test homvar.(pvectors(z2)) == [2, 3]
 
@@ -47,4 +53,10 @@ using Compat.Test
     @test infinity_norm(z2) ≈ infnorm
 
     @test z2 == copy(z2)
+
+    @test abs(infinity_norm(z2, z2)) < 1e-15
+
+
+    converted = converteltype(ProdPVector([PVector(rand(Float64, 3), 2), PVector(rand(Float64, 7), 3)]), Complex{Float64})
+    @test converted isa ProdPVector{Complex{Float64}}
 end

--- a/test/projective_vectors_test.jl
+++ b/test/projective_vectors_test.jl
@@ -7,7 +7,6 @@ using Compat.Test
 
     z = PVector(x, 1)
     infinity_norm(z)
-
     @test z isa PVector{Complex{Float64}}
     @test z.homvar == 1
     @test PVector(x, 3).homvar == 3
@@ -46,4 +45,6 @@ using Compat.Test
     @test sqrt(maximum(abs2, raw(z2))) ≈ infnorm
     normalize!(z2)
     @test infinity_norm(z2) ≈ infnorm
+
+    @test z2 == copy(z2)
 end

--- a/test/projective_vectors_test.jl
+++ b/test/projective_vectors_test.jl
@@ -1,0 +1,49 @@
+using HomotopyContinuation
+using HomotopyContinuation.ProjectiveVectors
+using Compat.Test
+
+@testset "ProjectiveVectors" begin
+    x = rand(Complex{Float64}, 4)
+
+    z = PVector(x, 1)
+    infinity_norm(z)
+
+    @test z isa PVector{Complex{Float64}}
+    @test z.homvar == 1
+    @test PVector(x, 3).homvar == 3
+    @test_throws AssertionError PVector(x, 5)
+
+    @test embed([2, 2, 2], 1) == PVector([1, 2, 2, 2], 1)
+    @test embed([2, 2, 2], 3) == PVector([2, 2, 1, 2], 3)
+
+    @test length(z) == 4
+    @test z[3] == x[3]
+    @test z[2:4] == x[2:4]
+    @test z[2:end] == x[2:end]
+
+    @test all(affine(z) .≈ (z[2:end] ./ z[1]))
+    normalize!(z)
+
+    @test at_infinity(z, 1e5) == false
+    @test at_infinity(PVector([2, 1e-7, 4], 2), 1e5) == true
+    @test at_infinity(PVector([2, 1e-7, 4], 2), 5e7) == false
+    @test at_infinity(PVector([2.3 + 0.2im, 1e-5, 4], 2), 1e5) == true
+    @test at_infinity(PVector([2.3 + 0.2im, 1e-4, 4], 2), 1e5) == false
+
+    x1 = PVector(rand(Complex{Float64}, 3), 2)
+    x2 = PVector(rand(Complex{Float64}, 7), 3)
+    z2 = ProdPVector([x1, x2])
+    @test length.(pvectors(z2)) == [3, 7]
+    @test homvar.(pvectors(z2)) == [2, 3]
+
+    @test at_infinity(z2, 1e5) == false
+    @test at_infinity(z2, 1e-1) == true
+    normalize!(z2)
+    all(v -> norm(v) ≈ 1.0, pvectors(z2))
+
+    infnorm = infinity_norm(z2)
+    affine!(z2)
+    @test sqrt(maximum(abs2, raw(z2))) ≈ infnorm
+    normalize!(z2)
+    @test infinity_norm(z2) ≈ infnorm
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using TestSystems
 
 # We order the tests such that isolated things are tested first
 include("utilities_test.jl")
+include("projective_vectors_test.jl")
 include("systems_test.jl")
 include("homotopies_test.jl")
 include("problem_test.jl")


### PR DESCRIPTION
So far we represented a projective vector by a simple `Vector`. This worked so far, but things got complicated since we implicitly set the first coordinate to be the homogenous variable. Furthermore, this wouldn't fly for multi-homogenous polynomials.