### PR TITLE
Use by default generic lu factorization since it is faster.

### DIFF
--- a/src/correctors/newton.jl
+++ b/src/correctors/newton.jl
@@ -22,7 +22,7 @@ end
 function correct!(xnext, ::Newton, cache::NewtonCache, H::HomotopyWithCache, x, t, tol, maxiters)
     A, b = cache.A, cache.b
     evaluate_and_jacobian!(b, A, H, x, t)
-    solve_with_lu_inplace!(A, b)
+    ldiv_lu!(A, b)
     @. xnext = x - b
     k = 1
     while true
@@ -39,7 +39,7 @@ function correct!(xnext, ::Newton, cache::NewtonCache, H::HomotopyWithCache, x, 
         # put jacobian in A
         jacobian!(A, H, xnext, t)
 
-        solve_with_lu_inplace!(A, b)
+        ldiv_lu!(A, b)
         @. xnext = xnext - b
     end
 end

--- a/src/predictors/base.jl
+++ b/src/predictors/base.jl
@@ -50,6 +50,6 @@ to be able to store the Jacobian of `H`.
 """
 function minus_x_prime!(out, H, x, t, A)
     jacobian_and_dt!(A, out, H, x, t)
-    solve_with_lu_inplace!(A, out)
+    ldiv_lu!(A, out)
     out
 end

--- a/test/path_result_test.jl
+++ b/test/path_result_test.jl
@@ -14,6 +14,10 @@
     @test length(results(R, includesingular=false, singulartol=1e9)) == 32
     @test length(results(R, includeatinfinity=true)) == 32
 
+end
+
+@testset "PathResult Juno" begin
+    R = solve(equations(katsura5()))
     @test_nowarn Juno.render(Juno.Inline(), R)
     @test_nowarn Juno.render(Juno.Inline(), R[1])
 end

--- a/test/utilities_test.jl
+++ b/test/utilities_test.jl
@@ -10,4 +10,13 @@
 
     @test Utilities.ishomogenous(Utilities.homogenize([x^2+y^2+x*y, x^4+1]))
     @test Utilities.nvariables(Utilities.homogenize([x^2+y^2+x*y, x^4+1])) == 3
+
+    A = rand(Complex{Float64}, 12, 12)
+    b = rand(Complex{Float64}, 12)
+    C = zero(A)
+    d = zero(b)
+
+    C .= A
+    d .= b
+    @test norm(Utilities.ldiv_lu!(C, d) - A \ b) < 1e-13
 end


### PR DESCRIPTION
This starts to use the pure Julia lu factorization instead of the LAPACK version.
Here is a small benchmark for square complex matrices. The LAPACK factorization seems to be more precise but also slower. Especially for `n>16` it seems that they start to use blocking techniques
which make things much slower.

```
Size - generic - blas - difference
4 - 0.508μs - 0.652μs - 1.352e-15
5 - 0.641μs - 0.856μs - 4.131e-16
6 - 0.801μs - 1.031μs - 2.277e-15
7 - 0.974μs - 1.291μs - 1.337e-15
8 - 1.211μs - 1.433μs - 8.709e-15
9 - 1.427μs - 1.752μs - 5.333e-15
10 - 1.669μs - 2.285μs - 3.211e-15
11 - 1.970μs - 2.781μs - 7.021e-15
12 - 2.319μs - 2.955μs - 6.036e-15
13 - 2.748μs - 3.627μs - 7.234e-15
14 - 3.130μs - 3.678μs - 2.297e-14
15 - 3.599μs - 4.265μs - 2.805e-15
16 - 4.091μs - 4.445μs - 1.039e-14
17 - 4.592μs - 7.034μs - 7.356e-15
18 - 5.169μs - 9.022μs - 1.576e-14
19 - 5.840μs - 11.238μs - 2.088e-14
20 - 6.528μs - 13.371μs - 4.375e-15
```