### PR TITLE
enables computations with projective systems

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ FixedPolynomials v0.3
 Juno
 ProgressMeter v0.5.5
 StaticPolynomials 0.1
-Compat 0.65
+Compat 0.61

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ FixedPolynomials v0.3
 Juno
 ProgressMeter v0.5.5
 StaticPolynomials 0.1
+Compat 0.65

--- a/src/HomotopyContinuation.jl
+++ b/src/HomotopyContinuation.jl
@@ -44,15 +44,17 @@ module HomotopyContinuation
     include("solve.jl")
 
 
-    import .Solving: nresults,
-        nfinite, nsingular, natinfinity, nfailed,
-        finite, results, failed, atinfinity, singular,
-        solution, residual, start_solution, issuccess,
-        isfailed, isatinfinity, issingular
+    import .Solving: solution,
+        residual, start_solution, issuccess,
+        isfailed, isaffine, isprojective,
+        isatinfinity, issingular, issmooth,
+        nresults, nfinite, nsingular, natinfinity, nfailed, nsmooth,
+        finite, results, failed, atinfinity, singular, smooth
 
-    export nresults,
-        nfinite, nsingular, natinfinity, nfailed,
-        finite, results, failed, atinfinity, singular,
-        solution, residual, start_solution, issuccess,
-        isfailed, isatinfinity, issingular
+    export solution,
+        residual, start_solution, issuccess,
+        isfailed, isaffine, isprojective,
+        isatinfinity, issingular, issmooth,
+        nresults, nfinite, nsingular, natinfinity, nfailed, nsmooth,
+        finite, results, failed, atinfinity, singular, smooth
 end #

--- a/src/affine_patches/embedding_patch.jl
+++ b/src/affine_patches/embedding_patch.jl
@@ -21,12 +21,12 @@ function precondition!(state::EmbeddingPatchState, x::AbstractProjectiveVector)
     ProjectiveVectors.affine!(x)
 end
 
-function evaluate!(u, state::EmbeddingPatchState, x::PVector{T}) where T
+function evaluate!(u, state::EmbeddingPatchState, x::PVector{T, Int}) where T
     u[end] = x[ProjectiveVectors.homvar(x)] - one(T)
     nothing
 end
 
-function jacobian!(U, state::EmbeddingPatchState, x::PVector{T}) where T
+function jacobian!(U, state::EmbeddingPatchState, x::PVector{T, Int}) where T
     i = ProjectiveVectors.homvar(x)
     for j=1:size(U, 2)
         U[end, j] = j == i ? one(T) : zero(T)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -6,7 +6,7 @@ const MP = MultivariatePolynomials
 
 import ..Homotopies: AbstractHomotopy, StraightLineHomotopy
 import ..ProjectiveVectors
-import ..Systems: SPSystem
+import ..Systems: SPSystem, FPSystem
 
 using ..Utilities
 
@@ -102,7 +102,7 @@ struct DefaultHomogenization <: AbstractHomogenizationStrategy end
 
 Construct a `ProjectiveStartTargetProblem`. This steps constructs a homotopy and homogenizes
 the systems if necessary. The options are
-* `system=SPSystem`: A constructor to assemble a [`Systems.AbstractSystem`](@ref). The constructor
+* `system=FPSystem`: A constructor to assemble a [`Systems.AbstractSystem`](@ref). The constructor
 is called with `system(polys, variables)` where `variables` determines the variable ordering.
 * `homotopy=StraightLineHomotopy`: A constructor to construct a [`Homotopies.AbstractHomotopy`](@ref) an `Systems.AbstractSystem`. The constructor
 is called with `homotopy(start, target)` where `start` and `target` are systems constructed
@@ -127,7 +127,7 @@ end
 function ProjectiveStartTargetProblem(
     s::Vector{<:MP.AbstractPolynomialLike},
     t::Vector{<:MP.AbstractPolynomialLike};
-    system=SPSystem,
+    system=FPSystem,
     homotopy=StraightLineHomotopy)
 
     if ishomogenous(s)
@@ -174,7 +174,7 @@ Embed the solution `x` into projective space if necessary.
 function embed(prob::ProjectiveStartTargetProblem{<:AbstractHomotopy, NullHomogenization}, x)
     M, N = size(homotopy(prob))
     length(x) != N && throw(error("The length of the intial solution is $(length(x)) but expected length $N."))
-    return x
+    return ProjectiveVectors.PVector(x, indmax(abs2.(x)))
 end
 function embed(prob::ProjectiveStartTargetProblem{<:AbstractHomotopy, DefaultHomogenization}, x)
     M, N = size(homotopy(prob))

--- a/src/projective_vectors.jl
+++ b/src/projective_vectors.jl
@@ -3,6 +3,8 @@ module ProjectiveVectors
 import Base: ==
 import ..Utilities: infinity_norm, unsafe_infinity_norm
 
+using Compat
+
 export AbstractProjectiveVector,
     PVector,
     ProdPVector,
@@ -29,18 +31,24 @@ Note that the constructor *does not* perform the embedding but rather
 is a simple wrapper. In order to embed an affine vector use
 [`embed`](@ref).
 """
-struct PVector{T, V<:AbstractVector{T}} <: AbstractProjectiveVector{T}
+struct PVector{T, H<:Union{Nothing, Int}, V<:AbstractVector{T}} <: AbstractProjectiveVector{T}
     data::V
-    homvar::Int
+    homvar::H
 
-    function PVector{T, V}(data, homvar) where {T, V}
+    function PVector{T, Int, V}(data, homvar::Int) where {T, V}
         @assert 1 ≤ homvar ≤ length(data)
         new(data, homvar)
     end
-end
-PVector(x::V, homvar::Int) where {T, V<:AbstractVector{T}} = PVector{T, V}(x, homvar)
 
-Base.copy(z::PVector{T, V}) where {T, V} = PVector{T, V}(copy(z.data), z.homvar)
+    function PVector{T, Nothing, V}(data, homvar::Nothing) where {T, V}
+        new(data, nothing)
+    end
+end
+function PVector(x::V, homvar::H=nothing) where {T, H<:Union{Nothing, Int}, V<:AbstractVector{T}}
+    PVector{T, H, V}(x, homvar)
+end
+
+Base.copy(z::PVector) = PVector(copy(z.data), z.homvar)
 
 """
     raw(z::PVector)
@@ -60,8 +68,6 @@ Get the index of the homogenous variable.
 homvar(z::PVector) = z.homvar
 
 (==)(v::PVector, w::PVector) = v.homvar == w.homvar && v.data == w.data
-
-Base.copy(z::PVector) = PVector(copy(z.data), z.homvar)
 
 """
     converteltype(v::PVector, T)
@@ -90,56 +96,61 @@ end
 
 Returns a scalar to bring `z` on its affine patch.
 """
-affine_normalizer(z::PVector) = inv(z.data[z.homvar])
+affine_normalizer(z::PVector{T, Int}) where T = inv(z.data[z.homvar])
 """
     abs2_ffine_normalizer(z::PVector)
 
 Returns the squared absolute value of the normalizer.
 """
-abs2_affine_normalizer(z::PVector) = inv(abs2(z.data[z.homvar]))
+abs2_affine_normalizer(z::PVector{T, Int}) where T = inv(abs2(z.data[z.homvar]))
 
 """
-    affine(z::PVector)::Vector
+    affine(z::PVector{T, Int})::Vector
 
-Return the corresponding affine vector.
+Return the corresponding affine vector with respect to the standard patch.
+
+    affine(z::PVector, i::Int)::Vector
+
+Return the corresponding affine vector with xᵢ=1.
 """
-function affine(z::PVector{T}) where {T}
+affine(z::PVector{T, Int}) where {T} = affine(z, z.homvar)
+function affine(z::PVector{T}, i::Int) where T
     x = Vector{T}(length(z) - 1)
-    normalizer = affine_normalizer(z)
+    normalizer = inv(z.data[i])
     for k in 1:length(z)
-        if k == z.homvar
+        if k == i
             continue
         end
-        i = k < z.homvar ? k : k - 1
+        i = k < i ? k : k - 1
         x[i] = z.data[k] * normalizer
     end
     x
 end
 
 """
-    affine!(z::PVector)
+    affine!(z::PVector{T, Int})
 
 Bring the projective vector on associated affine patch.
 """
-affine!(z::PVector) = scale!(z.data, affine_normalizer(z))
+affine!(z::PVector{T, Int}) where T = scale!(z.data, affine_normalizer(z))
 
 """
-    infinity_norm(z::PVector)
+    infinity_norm(z::PVector{T, Int})
 
 Compute the ∞-norm of `z`. If `z` is a complex vector this is more efficient
 than `norm(z, Inf)`.
 
-    infinity_norm(z₁::PVector, z₂::PVector)
+    infinity_norm(z₁::PVector{T, Int}, z₂::PVector{T, Int})
 
 Compute the ∞-norm of `z₁-z₂` by bringing both vectors first on their respective
 affine patch. This therefore only makes sense if both vectors have the
 same affine patch.
 """
-function infinity_norm(z::PVector{<:Complex})
+function infinity_norm(z::PVector{<:Complex, Int})
     sqrt(maximum(abs2, raw(z)) * abs2_affine_normalizer(z))
 end
 
-function infinity_norm(z₁::PVector{<:Complex}, z₂::PVector{<:Complex})
+function infinity_norm(z₁::PVector{<:Complex, Int}, z₂::PVector{<:Complex, Int})
     normalizer₁ = affine_normalizer(z₁)
     normalizer₂ = -affine_normalizer(z₂)
     m = abs2(muladd(z₁[1], normalizer₁, z₂[1] * normalizer₂))
@@ -172,13 +183,13 @@ function unsafe_infinity_norm(z₁::PVector{<:Complex}, z₂::PVector{<:Complex}
 end
 
 """
-    at_infinity(z::PVector, maxnorm)
+    at_infinity(z::PVector{T, Int}, maxnorm)
 
 Check whether `z` represents a point at infinity.
 We declare `z` at infinity if the infinity norm of
 its affine vector is larger than `maxnorm`.
 """
-function at_infinity(z::PVector{<:Complex}, maxnorm)
+function at_infinity(z::PVector{<:Complex, Int}, maxnorm)
     at_inf = false
     tol = maxnorm * maxnorm * abs2(z.data[z.homvar])
     for k in 1:length(z)
@@ -191,7 +202,7 @@ function at_infinity(z::PVector{<:Complex}, maxnorm)
     end
     false
 end
-function at_infinity(z::PVector{<:Real}, maxnorm)
+function at_infinity(z::PVector{<:Real, Int}, maxnorm)
     at_inf = false
     tol = maxnorm * abs(z.data[z.homvar])
     for k in 1:length(z)
@@ -213,129 +224,129 @@ end
 Base.LinAlg.dot(v::PVector, w::PVector) = dot(v.data, w.data)
 
 const VecView{T} = SubArray{T,1,Vector{T},Tuple{UnitRange{Int64}},true}
-
-"""
-    ProdPVector(pvectors)
-
-Construct a product of `PVector`s. This
-"""
-struct ProdPVector{T} <: AbstractProjectiveVector{T}
-    data::Vector{T}
-    # It is faster to use a tuple instead but this puts
-    # additional stress on the compiler and makes things
-    # not inferable, so we do this not for now.
-    # But we should be able to change this easily later
-    pvectors::Vector{PVector{T, VecView{T}}}
-end
-
-function ProdPVector(vs)
-    data = copy(vs[1].data);
-    for k=2:length(vs)
-        append!(data, vs[k].data)
-    end
-    pvectors = _create_pvectors(data, vs)
-    ProdPVector(data, pvectors)
-end
-
-function (==)(v::ProdPVector, w::ProdPVector)
-    for (vᵢ, wᵢ) in zip(pvectors(v), pvectors(w))
-        if vᵢ != wᵢ
-            return false
-        end
-    end
-    true
-end
-
-function _create_pvectors(data, vs)
-    pvectors = Vector{PVector{eltype(data), VecView{eltype(data)}}}()
-    k = 1
-    for i = 1:length(vs)
-        n = length(vs[i])
-        vdata = view(data, k:k+n-1)
-        push!(pvectors, PVector(vdata, homvar(vs[i])))
-        k += n
-    end
-    pvectors
-end
-
-function Base.copy(z::ProdPVector)
-    data = copy(z.data)
-    new_pvectors = _create_pvectors(data, pvectors(z))
-    ProdPVector(data, new_pvectors)
-end
-
-function Base.similar(v::ProdPVector, ::Type{T}) where T
-    data = convert.(T, v.data)
-    ProdPVector(data, _create_pvectors(data, pvectors(v)))
-end
-
-"""
-    pvectors(z::ProdPVector)
-
-Return the `PVector`s out of which the product `z` exists.
-"""
-pvectors(z::ProdPVector) = z.pvectors
-
-"""
-    raw(z::ProdPVector)
-
-Access the underlying vector of the product `z`. Note that this
-is only a single vector. This is useful to pass
-the vector into some function which does not know the
-projective structure.
-"""
-raw(v::ProdPVector) = v.data
-
-"""
-    at_infinity(z::ProdPVector, maxnorm)
-
-Returns `true` if any vector of the product is at infinity.
-"""
-function at_infinity(v::ProdPVector, maxnorm)
-    for vᵢ in pvectors(v)
-        if at_infinity(vᵢ, maxnorm)
-            return true
-        end
-    end
-    false
-end
-
-"""
-    affine(z::ProdPVector)
-
-For each projective vector of the product return associated affine patch.
-"""
-affine(z::ProdPVector) = affine.(z.pvectors)
-
-"""
-    affine!(z::ProdPVector)
-
-Bring each projective vector of the product on the associated affine patch.
-"""
-function affine!(v::ProdPVector)
-    for w in pvectors(v)
-        affine!(w)
-    end
-    v
-end
-
-function Base.LinAlg.normalize!(v::ProdPVector, p::Real=2)
-    for w in pvectors(v)
-        normalize!(w, p)
-    end
-    v
-end
-
-infinity_norm(z::ProdPVector) = maximum(infinity_norm, pvectors(z))
-function infinity_norm(v::ProdPVector, w::ProdPVector)
-    p₁ = pvectors(v)
-    p₂ = pvectors(w)
-    m = infinity_norm(p₁[1], p₂[1])
-    for k=2:length(p₁)
-        m = max(m, infinity_norm(p₁[k], p₂[k]))
-    end
-    m
-end
+#
+# """
+#     ProdPVector(pvectors)
+#
+# Construct a product of `PVector`s. This
+# """
+# struct ProdPVector{T, H<:Union{Nothing, Int}} <: AbstractProjectiveVector{T}
+#     data::Vector{T}
+#     # It is faster to use a tuple instead but this puts
+#     # additional stress on the compiler and makes things
+#     # not inferable, so we do this not for now.
+#     # But we should be able to change this easily later
+#     pvectors::Vector{PVector{T, H, VecView{T}}}
+# end
+#
+# function ProdPVector(vs)
+#     data = copy(vs[1].data);
+#     for k=2:length(vs)
+#         append!(data, vs[k].data)
+#     end
+#     pvectors = _create_pvectors(data, vs)
+#     ProdPVector(data, pvectors)
+# end
+#
+# function (==)(v::ProdPVector, w::ProdPVector)
+#     for (vᵢ, wᵢ) in zip(pvectors(v), pvectors(w))
+#         if vᵢ != wᵢ
+#             return false
+#         end
+#     end
+#     true
+# end
+#
+# function _create_pvectors(data, vs)
+#     pvectors = Vector{PVector{eltype(data), VecView{eltype(data)}}}()
+#     k = 1
+#     for i = 1:length(vs)
+#         n = length(vs[i])
+#         vdata = view(data, k:k+n-1)
+#         push!(pvectors, PVector(vdata, homvar(vs[i])))
+#         k += n
+#     end
+#     pvectors
+# end
+#
+# function Base.copy(z::ProdPVector)
+#     data = copy(z.data)
+#     new_pvectors = _create_pvectors(data, pvectors(z))
+#     ProdPVector(data, new_pvectors)
+# end
+#
+# function Base.similar(v::ProdPVector, ::Type{T}) where T
+#     data = convert.(T, v.data)
+#     ProdPVector(data, _create_pvectors(data, pvectors(v)))
+# end
+#
+# """
+#     pvectors(z::ProdPVector)
+#
+# Return the `PVector`s out of which the product `z` exists.
+# """
+# pvectors(z::ProdPVector) = z.pvectors
+#
+# """
+#     raw(z::ProdPVector)
+#
+# Access the underlying vector of the product `z`. Note that this
+# is only a single vector. This is useful to pass
+# the vector into some function which does not know the
+# projective structure.
+# """
+# raw(v::ProdPVector) = v.data
+#
+# """
+#     at_infinity(z::ProdPVector, maxnorm)
+#
+# Returns `true` if any vector of the product is at infinity.
+# """
+# function at_infinity(v::ProdPVector, maxnorm)
+#     for vᵢ in pvectors(v)
+#         if at_infinity(vᵢ, maxnorm)
+#             return true
+#         end
+#     end
+#     false
+# end
+#
+# """
+#     affine(z::ProdPVector)
+#
+# For each projective vector of the product return associated affine patch.
+# """
+# affine(z::ProdPVector) = affine.(z.pvectors)
+#
+# """
+#     affine!(z::ProdPVector)
+#
+# Bring each projective vector of the product on the associated affine patch.
+# """
+# function affine!(v::ProdPVector)
+#     for w in pvectors(v)
+#         affine!(w)
+#     end
+#     v
+# end
+#
+# function Base.LinAlg.normalize!(v::ProdPVector, p::Real=2)
+#     for w in pvectors(v)
+#         normalize!(w, p)
+#     end
+#     v
+# end
+#
+# infinity_norm(z::ProdPVector) = maximum(infinity_norm, pvectors(z))
+# function infinity_norm(v::ProdPVector, w::ProdPVector)
+#     p₁ = pvectors(v)
+#     p₂ = pvectors(w)
+#     m = infinity_norm(p₁[1], p₂[1])
+#     for k=2:length(p₁)
+#         m = max(m, infinity_norm(p₁[k], p₂[k]))
+#     end
+#     m
+# end
 
 
 # AbstractVector interface

--- a/src/solving/path_result.jl
+++ b/src/solving/path_result.jl
@@ -21,14 +21,14 @@ end
 
 
 """
-    PathResult(startvalue, pathtracker_result, endgame_result, solver)
+    PathResult(startvalue, pathtracker_result, endgamer_result, solver)
 
 Construct a `PathResult` for a given `startvalue`. `pathtracker_result` is the
-[`PathtrackerResult`](@ref) until the endgame radius is reached. `endgame_result`
-is the [`Result`](@ref) resulting from the corresponding endgame.
+[`PathtrackerResult`](@ref) until the endgame radius is reached. `endgamer_result`
+is the [`EndgamerResult`](@ref) resulting from the corresponding endgame.
 
 A `PathResult` contains:
-* `returncode`: One of `:success`, `:at_infinity` or any error code from the `Result`
+* `returncode`: One of `:success`, `:at_infinity` or any error code from the `EndgamerResult`
 * `solution::Vector{T}`: The solution vector. If the algorithm computed in projective space
 and the solution is at infinity then the projective solution is given. Otherwise
 an affine solution is given if the startvalue was affine and a projective solution
@@ -41,9 +41,9 @@ is given if the startvalue was projective.
 * `real_solution`: Indicates whether the solution is real given the defined tolerance `at_infinity_tol` (from the solver options).
 * `startvalue`: The startvalue of the path
 * `iterations`: The number of iterations the pathtracker needed.
-* `endgame_iterations`: The number of steps in the geometric series the endgame did.
-* `npredictions`: The number of predictions the endgame did.
-* `predictions`: The predictions of the endgame.
+* `endgame_iterations`: The number of steps in the geometric series the endgamer did.
+* `npredictions`: The number of predictions the endgamer did.
+* `predictions`: The predictions of the endgamer.
 """
 struct PathResult{T1, T2, T3}
     returncode::Symbol
@@ -69,7 +69,7 @@ function PathResult(prob::Problems.AbstractProblem, k, x₁, x_e, t₀, r, cache
 end
 function PathResult(::Problems.NullHomogenization, k, x₁, x_e, t₀, r, cache::PathResultCache, patchswitcher)
     returncode, returncode_detail = makereturncode(r.returncode)
-    x = raw(r.x)
+    x = raw(align_axis!(copy(r.x)))
     Homotopies.evaluate_and_jacobian!(cache.v, cache.J, cache.H, x, t₀)
     res = infinity_norm(cache.v)
 
@@ -93,13 +93,16 @@ function PathResult(::Problems.DefaultHomogenization, k, x₁, x_e, t₀, r, cac
 
     Homotopies.evaluate_and_jacobian!(cache.v, cache.J, cache.H, raw(r.x), t₀)
     res = infinity_norm(cache.v)
+    if res > 0.1 && r.t == t₀ && returncode == :success
+        returncode = :at_infinity
+    end
 
     returncode, returncode_detail = makereturncode(returncode)
 
     intermediate_sol = ProjectiveVectors.affine(x_e)
 
     if returncode != :success
-        solution = raw(r.x)
+        solution = copy(raw(r.x))
         condition = 0.0
     else
         solution = ProjectiveVectors.affine(r.x)
@@ -128,7 +131,31 @@ function switch_to_affine!(x::ProjectiveVectors.PVector, returncode, windingnumb
     x
 end
 
-windingnumber_npredictions(r::Endgaming.Result) = (r.windingnumber, r.npredictions)
+"""
+    align_axis!(x)
+
+Multiplies `x` with a complex number of norm 1 such that the largest
+entry is real.
+"""
+function align_axis!(x)
+    maxval = abs2(x[1])
+    maxind = 1
+    for i=2:length(x)
+        val = abs2(x[i])
+        if val > maxval
+            maxval = val
+            maxind = i
+        end
+    end
+
+    v = conj(x[maxind]) / sqrt(maxval)
+    for i=1:length(x)
+        x[i] *= v
+    end
+    x
+end
+
+windingnumber_npredictions(r::Endgame.EndgamerResult) = (r.windingnumber, r.npredictions)
 windingnumber_npredictions(r::PathTracking.PathTrackerResult) = (0, 0)
 
 function Base.show(io::IO, r::PathResult)

--- a/src/solving/path_result.jl
+++ b/src/solving/path_result.jl
@@ -93,9 +93,6 @@ function PathResult(::Problems.DefaultHomogenization, k, x₁, x_e, t₀, r, cac
 
     Homotopies.evaluate_and_jacobian!(cache.v, cache.J, cache.H, raw(r.x), t₀)
     res = infinity_norm(cache.v)
-    if res > 0.1 && r.t == t₀ && returncode == :success
-        returncode = :at_infinity
-    end
 
     returncode, returncode_detail = makereturncode(returncode)
 
@@ -122,7 +119,7 @@ function makereturncode(retcode)
     end
 end
 
-function switch_to_affine!(x::ProjectiveVectors.PVector, returncode, windingnumber, patchswitcher)
+function switch_to_affine!(x::ProjectiveVectors.PVector{<:Complex, Int}, returncode, windingnumber, patchswitcher)
     if returncode == :success && windingnumber == 1 && abs2(x[x.homvar]) < 1.0
         PatchSwitching.switch!(x, patchswitcher)
     elseif returncode != :at_infinity
@@ -155,7 +152,7 @@ function align_axis!(x)
     x
 end
 
-windingnumber_npredictions(r::Endgame.EndgamerResult) = (r.windingnumber, r.npredictions)
+windingnumber_npredictions(r::Endgaming.Result) = (r.windingnumber, r.npredictions)
 windingnumber_npredictions(r::PathTracking.PathTrackerResult) = (0, 0)
 
 function Base.show(io::IO, r::PathResult)

--- a/src/solving/path_result.jl
+++ b/src/solving/path_result.jl
@@ -67,19 +67,20 @@ end
 function PathResult(prob::Problems.AbstractProblem, k, x₁, x_e, t₀, r, cache::PathResultCache, patchswitcher)
     PathResult(prob.homogenization_strategy, k, x₁, x_e, t₀, r, cache, patchswitcher)
 end
-function PathResult(::Problems.NullHomogenization, k, x₁, x_e, t₀, r, cache::PathResultCache, ::Compat.Nothing)
+function PathResult(::Problems.NullHomogenization, k, x₁, x_e, t₀, r, cache::PathResultCache, patchswitcher)
     returncode, returncode_detail = makereturncode(r.returncode)
     x = raw(r.x)
     Homotopies.evaluate_and_jacobian!(cache.v, cache.J, cache.H, x, t₀)
-    res = infinity_norm(v)
+    res = infinity_norm(cache.v)
 
     if returncode != :success
         condition = 0.0
     else
-        condition = cond(J)
+        condition = cond(cache.J)
     end
 
     windingnumber, npredictions = windingnumber_npredictions(r)
+
 
     PathResult(returncode, returncode_detail, x, real(r.t), res, condition,
         windingnumber, k, x₁, raw(x_e), r.iters, npredictions)

--- a/src/solving/result.jl
+++ b/src/solving/result.jl
@@ -1,19 +1,16 @@
-export nresults, nfinite, nsingular, natinfinity, nfailed,
-    finite, results, failed, atinfinity, singular
+export nresults, nfinite, nsingular, natinfinity, nfailed, nsmooth,
+    finite, results, failed, atinfinity, singular, smooth
 
 abstract type Result end
 
 """
     Result(Vector{PathResult})
 
-Constructs a summary of `PathResult`s.  A `Result` contains:
-* `PathResults` the vector of PathResults
-* `tracked`: length of `PathResults`
-* `finite`: Number of finite_results.
-* `at_infinity`: Number of results at infinity.
-* `singular`: Number of singular results.
-* `failed`: Number of failed paths.
+Constructs a summary of `PathResult`s.
 """
+struct ProjectiveResult{T1, T2, T3} <: Result
+    pathresults::Vector{PathResult{T1, T2, T3}}
+end
 struct AffineResult{T1, T2, T3} <: Result
     pathresults::Vector{PathResult{T1, T2, T3}}
 end
@@ -28,6 +25,9 @@ Base.endof(r::Result) = endof(r.pathresults)
 function Base.iteratorsize(::Type{AffineResult{T1,T2,T3}}) where {T1, T2, T3}
     Base.HasLength()
 end
+function Base.iteratorsize(::Type{ProjectiveResult{T1,T2,T3}}) where {T1, T2, T3}
+    Base.HasLength()
+end
 Base.eltype(r::Result) = eltype(r.pathresults)
 
 """
@@ -35,14 +35,19 @@ Base.eltype(r::Result) = eltype(r.pathresults)
 
 The number of proper solutions.
 """
-nresults(R::AffineResult) = count(isfinite, R)
+nresults(R::Result) = count(issuccess, R)
 
 """
     nresults(result)
 
-The number of finite (isolated) solutions.
+The number of finite solutions.
 """
-nfinite(R::AffineResult) = count(isfinite, R)
+function nfinite(R::Result)
+    if typeof(R)<:ProjectiveResult
+        warn("Results are projective")
+    end
+    count(isfinite, R)
+end
 
 """
     nsingular(result; tol=1e10)
@@ -51,7 +56,7 @@ The number of singular solutions. A solution is considered singular
 if its windingnumber is larger than 1 or the condition number is larger than `tol`.
 """
 nsingular(R::Result; tol=1e10) = count(R) do r
-    isfinite(r) && issingular(r, tol)
+    issingular(r, tol)
 end
 
 """
@@ -59,23 +64,39 @@ end
 
 The number of solutions at infinity.
 """
-natinfinity(R::AffineResult) = count(isatinfinity, R)
+function natinfinity(R::Result)
+    if typeof(R)<:ProjectiveResult
+        warn("Results are projective")
+    end
+    count(isatinfinity, R)
+end
 
 """
-    natinfinity(result)
+    nafailed(result)
 
 The number of failed paths.
 """
 nfailed(R::Result) = count(isfailed, R)
 
+"""
+    smooth(result)
+
+The number of smooth solutions.
+"""
+nsmooth(R::Result; tol = 1e10) = count(R) do r
+    issmooth(r, tol)
+end
+
+
 const AffineResults = Union{AffineResult, Vector{<:PathResult}}
+const ProjectiveResults = Union{ProjectiveResult, Vector{<:PathResult}}
 const Results = Union{Result, Vector{<:PathResult}}
 
 # Filtering
 """
     results(result; only_real=false, realtol=1e-6,
-        include_singular=true, singulartol=1e10,
-        include_atinfinity=false)
+        onlysmooth=true, singulartol=1e10,
+        onlyfinite=true)
 
 Return all `PathResult`s for which the given conditions apply.
 
@@ -91,16 +112,25 @@ R = solve(F)
 # This gives us all solutions considered real (but still as a complex vector).
 realsolutions = results(solution, R, only_real=true)
 """
-results(R::AffineResult; kwargs...) = results(identity, R; kwargs...)
-function results(f::Function, R::AffineResult;
-    onlyreal=false, realtol=1e-6, includesingular=true, singulartol=1e10,
-    includeatinfinity=false)
+results(R::Result; kwargs...) = results(identity, R; kwargs...)
+function results(f::Function, R::Result;
+    onlyreal=false, realtol=1e-6, onlysmooth=false, singulartol=1e10,
+    onlyfinite=true)
     [f(r) for r in R if
         (!onlyreal || isreal(r, realtol)) &&
-        (includesingular || !issingular(r, singulartol)) &&
-        (includeatinfinity || isfinite(r))]
+        (!onlysmooth || issmooth(r, singulartol)) &&
+        (!onlyfinite || isfinite(r) || isprojective(r))]
 end
 
+"""
+    smooth(result::AffineResult)
+
+Return all `PathResult`s for which the solution is smooth.
+"""
+smooth(R::Results; kwargs...) = smooth(identity, R; kwargs...)
+function smooth(f::Function, R::Results; tol=1e10)
+    [f(r) for r in R if issmooth(r, tol)]
+end
 
 """
     finite(result::AffineResult)
@@ -111,26 +141,19 @@ the contained `solution` is indeed a solution of the system.
     finite(f::Function, result)
 
 Additionally you can apply a transformation `f` on each result.
-
-## Example
-
-```julia
-R = solve(F)
-
-# This gives us the actual solutions.
-solutions = results(solution, R)
-
-# We also want to get an overview over the condition numbers
-condition_numbers = results(condition_number, R)
 """
-finite(R::AffineResults; kwargs...) = finite(identity, R; kwargs...)
-function finite(f::Function, R::AffineResults; include_singular=true, tol=1e10)
-    if include_singular
+finite(R::Results; kwargs...) = finite(identity, R; kwargs...)
+function finite(f::Function, R::Results; onlysmooth=false, tol=1e10)
+    if typeof(R)<:ProjectiveResult
+        warn("Results are projective")
+    end
+    if !onlysmooth
         [f(r) for r in R if isfinite(r)]
     else
-        [f(r) for r in R if isfinite(r) && !issingular(r, tol)]
+        [f(r) for r in R if isfinite(r) && issmooth(r, tol)]
     end
 end
+
 
 """
     singular(result; tol=1e10)
@@ -138,7 +161,7 @@ end
 Get all singular solutions. A solution is considered singular
 if its windingnumber is larger than 1 or the condition number is larger than `tol`.
 """
-singular(R::Result; tol=1e10) = [r for r in R if (isfinite(r) && issingular(r, tol))]
+singular(R::Result; tol=1e10) = [r for r in R if (issuccess(r) && issingular(r, tol))]
 
 
 """
@@ -161,14 +184,28 @@ failed(R::Result) = [r for r in R if isfailed(r)]
 
 Get all results where the solutions is at infinity.
 """
-atinfinity(R::Result) = [r for r in R if isatinfinity(r)]
+function atinfinity(R::Result)
+    if typeof(R)<:ProjectiveResult
+        warn("Results are projective")
+    end
+    [r for r in R if isatinfinity(r)]
+end
 
 function Base.show(io::IO, r::AffineResult)
     println(io, "-----------------------------------------------")
     println(io, "Paths tracked: $(length(r))")
-    println(io, "# finite (isolated) solutions:  $(nfinite(r))")
+    println(io, "# smooth finite solutions:  $(nsmooth(r))")
     println(io, "# singular finite solutions:  $(nsingular(r))")
     println(io, "# solutions at infinity:  $(natinfinity(r))")
+    println(io, "# failed paths:  $(nfailed(r))")
+    println(io, "-----------------------------------------------")
+end
+
+function Base.show(io::IO, r::ProjectiveResult)
+    println(io, "-----------------------------------------------")
+    println(io, "Paths tracked: $(length(r))")
+    println(io, "# smooth solutions:  $(nsmooth(r))")
+    println(io, "# singular solutions:  $(nsingular(r))")
     println(io, "# failed paths:  $(nfailed(r))")
     println(io, "-----------------------------------------------")
 end
@@ -179,10 +216,17 @@ function Juno.render(i::Juno.Inline, r::AffineResult)
         t[:children] = [
             Juno.render(i, Text("Paths tracked → $(length(r))"))]
         #
-        n = nfinite(r)
+        n = nsmooth(r)
         if n > 0
             t_result = Juno.render(i, finite(r))
-            t_result[:head] = Juno.render(i, Text("$n finite solutions"))
+            t_result[:head] = Juno.render(i, Text("$n finite smooth solutions"))
+            push!(t[:children], t_result)
+        end
+
+        n = nsingular(r)
+        if n > 0
+            t_result = Juno.render(i, finite(r))
+            t_result[:head] = Juno.render(i, Text("$n finite singular solutions"))
             push!(t[:children], t_result)
         end
 
@@ -201,7 +245,33 @@ function Juno.render(i::Juno.Inline, r::AffineResult)
         end
 
         return t
-    end
+end
 
-#
-#
+function Juno.render(i::Juno.Inline, r::ProjectiveResult)
+        t = Juno.render(i, Juno.defaultrepr(r))
+        t[:children] = [
+            Juno.render(i, Text("Paths tracked → $(length(r))"))]
+        #
+        n = nsmooth(r)
+        if n > 0
+            t_result = Juno.render(i, finite(r))
+            t_result[:head] = Juno.render(i, Text("$n smooth solutions"))
+            push!(t[:children], t_result)
+        end
+
+        n = nsingular(r)
+        if n > 0
+            t_result = Juno.render(i, atinfinity(r))
+            t_result[:head] = Juno.render(i, Text("$n singular solutions"))
+            push!(t[:children], t_result)
+        end
+
+        n = nfailed(r)
+        if n > 0
+            t_result = Juno.render(i, failed(r))
+            t_result[:head] = Juno.render(i, Text("$n paths failed"))
+            push!(t[:children], t_result)
+        end
+
+        return t
+end

--- a/src/solving/solve.jl
+++ b/src/solving/solve.jl
@@ -13,8 +13,11 @@ function solve(solvers, start_solutions::AbstractVector)
 
     BLAS.set_num_threads(nblas_threads)
 
-    # TODO: Check problem
-    AffineResult(results)
+    if results[1].solution_type == :affine
+        AffineResult(results)
+    else
+        ProjectiveResult(results)
+    end
 end
 
 """

--- a/src/solving/solve.jl
+++ b/src/solving/solve.jl
@@ -13,9 +13,12 @@ function solve(solvers, start_solutions::AbstractVector)
 
     BLAS.set_num_threads(nblas_threads)
 
-    if results[1].solution_type == :affine
+    if all(r -> r.solution_type == :affine, results)
         AffineResult(results)
+    elseif all(r -> r.solution_type == :projective, results)
+        ProjectiveResult(results)
     else
+        warn("Something went wrong. There are both affine and projective solutions.")
         ProjectiveResult(results)
     end
 end

--- a/test/path_result_test.jl
+++ b/test/path_result_test.jl
@@ -5,13 +5,13 @@
     @test nfinite(R) == 4
     @test finite(R) isa Vector{<:Solving.PathResult}
 
-    @test length(finite(R, include_singular=false)) == 4
+    @test length(finite(R, onlysmooth=false)) == 4
     @test isempty(failed(R))
     @test length(real(R, tol=1e-7)) == 2
     @test length(atinfinity(R)) == 572
     @test length(results(R, onlyreal=true, realtol=1e-8)) == 2
-    @test length(results(R, includesingular=false, singulartol=1e9)) == 4
-    @test length(results(R, includeatinfinity=true)) == 576
+    @test length(results(R, onlysmooth=true, singulartol=1e9)) == 4
+    @test length(results(R, onlyfinite=false)) == 576
 
     @test_nowarn results(solution, R)
     @test_nowarn results(start_solution, R)

--- a/test/projective_vectors_test.jl
+++ b/test/projective_vectors_test.jl
@@ -1,6 +1,4 @@
-using HomotopyContinuation
 using HomotopyContinuation.ProjectiveVectors
-using Compat.Test
 
 @testset "ProjectiveVectors" begin
     x = rand(Complex{Float64}, 4)
@@ -33,30 +31,35 @@ using Compat.Test
     @test at_infinity(PVector([2.3 + 0.2im, 1e-5, 4], 2), 1e5) == true
     @test at_infinity(PVector([2.3 + 0.2im, 1e-4, 4], 2), 1e5) == false
 
-    x1 = PVector(rand(Complex{Float64}, 3), 2)
-    x2 = PVector(rand(Complex{Float64}, 7), 3)
-    z2 = ProdPVector([x1, x2])
-    @test affine(z2) == [affine(x1), affine(x2)]
+    z2 = PVector(x)
+    @test z2 isa PVector{<:Complex, Nothing}
+    @test_throws MethodError affine(z2)
+    @test affine(z2, 1) == affine(z)
 
-    @test length.(pvectors(z2)) == [3, 7]
-    @test homvar.(pvectors(z2)) == [2, 3]
-
-    @test at_infinity(z2, 1e5) == false
-    @test at_infinity(z2, 1e-1) == true
-    normalize!(z2)
-    all(v -> norm(v) ≈ 1.0, pvectors(z2))
-
-    infnorm = infinity_norm(z2)
-    affine!(z2)
-    @test sqrt(maximum(abs2, raw(z2))) ≈ infnorm
-    normalize!(z2)
-    @test infinity_norm(z2) ≈ infnorm
-
-    @test z2 == copy(z2)
-
-    @test abs(infinity_norm(z2, z2)) < 1e-14
-
-
-    converted = similar(ProdPVector([PVector(rand(Float64, 3), 2), PVector(rand(Float64, 7), 3)]), Complex{Float64})
-    @test converted isa ProdPVector{Complex{Float64}}
+    # x1 = PVector(rand(Complex{Float64}, 3), 2)
+    # x2 = PVector(rand(Complex{Float64}, 7), 3)
+    # z2 = ProdPVector([x1, x2])
+    # @test affine(z2) == [affine(x1), affine(x2)]
+    #
+    # @test length.(pvectors(z2)) == [3, 7]
+    # @test homvar.(pvectors(z2)) == [2, 3]
+    #
+    # @test at_infinity(z2, 1e5) == false
+    # @test at_infinity(z2, 1e-1) == true
+    # normalize!(z2)
+    # all(v -> norm(v) ≈ 1.0, pvectors(z2))
+    #
+    # infnorm = infinity_norm(z2)
+    # affine!(z2)
+    # @test sqrt(maximum(abs2, raw(z2))) ≈ infnorm
+    # normalize!(z2)
+    # @test infinity_norm(z2) ≈ infnorm
+    #
+    # @test z2 == copy(z2)
+    #
+    # @test abs(infinity_norm(z2, z2)) < 1e-14
+    #
+    #
+    # converted = similar(ProdPVector([PVector(rand(Float64, 3), 2), PVector(rand(Float64, 7), 3)]), Complex{Float64})
+    # @test converted isa ProdPVector{Complex{Float64}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using HomotopyContinuation
 using Compat.Test
+using Compat
 using PolynomialTestSystems
 import Juno
 using Atom

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -53,3 +53,15 @@ end
     srand(120)
     @test nfinite(solve(F, tol=1e-1, threading=false)) == 32
 end
+
+@testset "Affine vs projective" begin
+    @polyvar x y z
+    f = [x-y, y-z]
+    g = [x-1, y-1]
+
+    F = solve(f)
+    G = solve(g)
+
+    @test length(F[1].solution) == 3
+    @test length(G[1].solution) == 2
+end

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -64,4 +64,6 @@ end
 
     @test length(F[1].solution) == 3
     @test length(G[1].solution) == 2
+    @test F[1].solution_type == :projective
+    @test G[1].solution_type == :affine
 end

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -56,8 +56,8 @@ end
 
 @testset "Affine vs projective" begin
     @polyvar x y z
-    f = [x-y, y-z]
-    g = [x-1, y-1]
+    f = [x-2y, y-2z]
+    g = [x-2, y-2]
 
     F = solve(f)
     G = solve(g)


### PR DESCRIPTION
I started to implement projective systems. The current implementation basically defines a projective start solutions as type ProjectiveVector with homogenizing variable x_i, for which x_i has the largest absolute value. Next to this I only had to adjust the PathResult() function. 

Currently, projective vectors are returned having norm one. We can discuss whether they should be scaled such that one entry is 1 (better for detecting reality, but problematic for ill-posed solutions). The PathResult show function must also be adapted.

What do you think?