### PR TITLE
Use PVector with homogenous systems as intended

### DIFF
--- a/src/problems.jl
+++ b/src/problems.jl
@@ -174,7 +174,7 @@ Embed the solution `x` into projective space if necessary.
 function embed(prob::ProjectiveStartTargetProblem{<:AbstractHomotopy, NullHomogenization}, x)
     M, N = size(homotopy(prob))
     length(x) != N && throw(error("The length of the intial solution is $(length(x)) but expected length $N."))
-    return ProjectiveVectors.PVector(x, indmax(abs2.(x)))
+    return ProjectiveVectors.PVector(x, nothing)
 end
 function embed(prob::ProjectiveStartTargetProblem{<:AbstractHomotopy, DefaultHomogenization}, x)
     M, N = size(homotopy(prob))

--- a/src/solving/path_result.jl
+++ b/src/solving/path_result.jl
@@ -4,6 +4,7 @@ export solution,
     isatinfinity, issingular, issmooth
 
 
+using Compat
 
 import ..Homotopies
 import ..ProjectiveVectors
@@ -71,7 +72,7 @@ end
 function PathResult(prob::Problems.AbstractProblem, k, x₁, x_e, t₀, r, cache::PathResultCache, patchswitcher)
     PathResult(prob.homogenization_strategy, k, x₁, x_e, t₀, r, cache, patchswitcher)
 end
-function PathResult(::Problems.NullHomogenization, k, x₁, x_e, t₀, r, cache::PathResultCache, patchswitcher)
+function PathResult(::Problems.NullHomogenization, k, x₁, x_e, t₀, r, cache::PathResultCache, ::Nothing)
     returncode, returncode_detail = makereturncode(r.returncode)
     x = raw(align_axis!(copy(r.x)))
     Homotopies.evaluate_and_jacobian!(cache.v, cache.J, cache.H, x, t₀)

--- a/src/solving/types.jl
+++ b/src/solving/types.jl
@@ -14,7 +14,7 @@ function SolverCache(prob, tracker)
 end
 
 struct Solver{P<:Problems.AbstractProblem, T<:PathTracking.PathTracker,
-        E<:Endgaming.Endgame, PS<:PatchSwitching.PatchSwitcher, C<:SolverCache}
+        E<:Endgaming.Endgame, PS<:Union{Nothing,PatchSwitching.PatchSwitcher}, C<:SolverCache}
     prob::P
     tracker::T
     endgame::E
@@ -96,6 +96,9 @@ function pathtracker(prob::Problems.ProjectiveStartTargetProblem, x, t₁, t₀;
         # filterkwargs(kwargs, PathTracking.PATH_TRACKER_KWARGS)...)
 end
 
+function patchswitcher(prob::Problems.ProjectiveStartTargetProblem{H, Problems.NullHomogenization}, x, t₀) where {H<:Homotopies.AbstractHomotopy}
+    nothing
+end
 function patchswitcher(prob::Problems.ProjectiveStartTargetProblem, x, t₀)
     p₁ = AffinePatches.state(AffinePatches.FixedPatch(), x)
     p₀ = AffinePatches.state(AffinePatches.EmbeddingPatch(), x)


### PR DESCRIPTION
Well, we designed everything to use `PVector{T, Nothing}` for homogenous systems. And then we messed up in the construction of the input and still used `PVector{T, Int}`