### PR TITLE
Make it easier to setup a single path tracker

### DIFF
--- a/docs/src/pathtracking.md
+++ b/docs/src/pathtracking.md
@@ -3,7 +3,11 @@
 We also export a path tracking primitive to make the core path tracking routine
 available for other applications.
 At the heart is a [`PathTracking.PathTracker`](@ref) object which holds
-all the state.
+all the state. The easiest way to construct a `PathTracker` is to use the [`pathtracker_startsolutions`](@ref) routine.
+
+```@docs
+pathtracker_startsolutions
+```
 
 ## Types
 ```@docs

--- a/src/HomotopyContinuation.jl
+++ b/src/HomotopyContinuation.jl
@@ -43,6 +43,7 @@ module HomotopyContinuation
 
     include("solving.jl")
     include("solve.jl")
+    include("pathtracker.jl")
 
     include("interface_test.jl")
 

--- a/src/endgaming/types.jl
+++ b/src/endgaming/types.jl
@@ -1,6 +1,6 @@
-export Endgame, Result, allowed_kwargs
+export Endgame, Result, allowed_keywords
 
-const allowed_kwargs = [:sampling_factor, :tol, :minradius, :maxnorm, :minimal_maxnorm,
+const allowed_keywords = [:sampling_factor, :tol, :minradius, :maxnorm, :minimal_maxnorm,
     :maxwindingnumber, :max_extrapolation_samples, :cauchy_loop_closed_tolerance,
     :cauchy_samples_per_loop]
 

--- a/src/path_tracking/tracking.jl
+++ b/src/path_tracking/tracking.jl
@@ -50,7 +50,7 @@ end
 Setup `pathtracker` to track `x₁` from `t₁` to `t₀`. Use this if you want to use the
 pathtracker as an iterator.
 """
-function setup!(tracker::PathTracker, x₁, t₁, t₀; checkstartvalue=true, precondition=true)
+function setup!(tracker::PathTracker, x₁::ProjectiveVectors.AbstractProjectiveVector, t₁, t₀; checkstartvalue=true, precondition=true)
     S = tracker.state
 
     S.start = t₁
@@ -72,6 +72,12 @@ function setup!(tracker::PathTracker, x₁, t₁, t₀; checkstartvalue=true, pr
     end
     tracker
 end
+# If x₁ is not a AbstractProjectiveVector we need to embed it first. This is
+# just a convenience fallback.
+function setup!(tracker::PathTracker, x₁, t₁, t₀; kwargs...)
+    setup!(tracker, ProjectiveVectors.embed(tracker.x, x₁), t₁, t₀; kwargs...)
+end
+
 patch(cache::Cache) = cache.homotopy.homotopy.patch # this is a little bit hacky...
 
 currresidual(tracker) = residual(tracker, currx(tracker), currt(tracker))

--- a/src/path_tracking/types.jl
+++ b/src/path_tracking/types.jl
@@ -8,9 +8,9 @@ import ..StepLength
 
 using ..Utilities
 
-export PathTracker, allowed_kwargs
+export PathTracker, allowed_keywords
 
-const allowed_kwargs = [:corrector, :predictor, :steplength,
+const allowed_keywords = [:corrector, :predictor, :steplength,
     :tol, :refinement_tol, :corrector_maxiters,  :refinement_maxiters,
     :maxiters]
 

--- a/src/path_tracking/types.jl
+++ b/src/path_tracking/types.jl
@@ -7,6 +7,7 @@ import ..PredictionCorrection
 import ..Predictors
 import ..StepLength
 import ..Problems
+import ..ProjectiveVectors
 
 using ..Utilities
 
@@ -90,7 +91,7 @@ struct PathTracker{
     SL<:StepLength.AbstractStepLength,
     S<:State,
     C<:Cache,
-    V<:AbstractVector}
+    V<:ProjectiveVectors.AbstractProjectiveVector}
 
     # these are fixed
     homotopy::H
@@ -107,7 +108,7 @@ struct PathTracker{
     cache::C
 end
 
-function PathTracker(H::Homotopies.AbstractHomotopy, x₁::AbstractVector, t₁, t₀;
+function PathTracker(H::Homotopies.AbstractHomotopy, x₁::ProjectiveVectors.AbstractProjectiveVector, t₁, t₀;
     corrector::Correctors.AbstractCorrector=Correctors.Newton(),
     predictor::Predictors.AbstractPredictor=Predictors.RK4(),
     steplength::StepLength.AbstractStepLength=StepLength.HeuristicStepLength(),

--- a/src/path_tracking/types.jl
+++ b/src/path_tracking/types.jl
@@ -1,10 +1,12 @@
 import TreeViews
 
+import ..AffinePatches
 import ..Correctors
 import ..Homotopies
 import ..PredictionCorrection
 import ..Predictors
 import ..StepLength
+import ..Problems
 
 using ..Utilities
 
@@ -127,6 +129,19 @@ function PathTracker(H::Homotopies.AbstractHomotopy, x₁::AbstractVector, t₁,
 
     PathTracker(H, predictor_corrector, steplength, state, options, x, cache)
 end
+
+"""
+    PathTracker(problem::Problems.AbstractProblem, x₁, t₁, t₀; kwargs...)
+
+Construct a [`PathTracking.PathTracker`](@ref) from the given `problem`.
+"""
+function PathTracker(prob::Problems.Projective, x₁, t₁, t₀; patch=AffinePatches.OrthogonalPatch(), kwargs...)
+    y₁ = Problems.embed(prob, x₁)
+    H = Homotopies.PatchedHomotopy(prob.homotopy, AffinePatches.state(patch, y₁))
+    PathTracker(H, y₁, complex(t₁), complex(t₀); kwargs...)
+end
+
+Base.show(io::IO, ::PathTracker) = print(io, "PathTracker()")
 
 
 """

--- a/src/pathtracker.jl
+++ b/src/pathtracker.jl
@@ -1,0 +1,18 @@
+export pathtracker_startsolutions
+
+"""
+    pathtracker_startsolutions(args...; kwargs...)
+
+Construct a `PathTracking.PathTracker` and `startsolutions` in the same way [`solve`](@ref)
+does it. This als takes the same input arguments as `solve`. This is convient if you want
+to investigate single paths.
+"""
+function pathtracker_startsolutions(args...; kwargs...)
+    supported, rest = splitkwargs(kwargs, Problems.supported_kwargs)
+    prob, startsolutions = Problems.problem_startsolutions(args...; supported...)
+    t₁, t₀ = one(ComplexF64), zero(ComplexF64)
+    embeded_startsolutions = map(x -> Problems.embed(prob, x), startsolutions)
+    tracker = PathTracking.PathTracker(prob, embeded_startsolutions[1], t₁, t₀; rest...)
+
+    (tracker=tracker, startsolution=embeded_startsolutions)
+end

--- a/src/pathtracker.jl
+++ b/src/pathtracker.jl
@@ -3,16 +3,15 @@ export pathtracker_startsolutions
 """
     pathtracker_startsolutions(args...; kwargs...)
 
-Construct a `PathTracking.PathTracker` and `startsolutions` in the same way [`solve`](@ref)
-does it. This als takes the same input arguments as `solve`. This is convient if you want
+Construct a [`PathTracking.PathTracker`](@ref) and `startsolutions` in the same way [`solve`](@ref)
+does it. This als0 takes the same input arguments as `solve`. This is convenient if you want
 to investigate single paths.
 """
 function pathtracker_startsolutions(args...; kwargs...)
     supported, rest = splitkwargs(kwargs, Problems.supported_kwargs)
     prob, startsolutions = Problems.problem_startsolutions(args...; supported...)
     t₁, t₀ = one(ComplexF64), zero(ComplexF64)
-    embeded_startsolutions = map(x -> Problems.embed(prob, x), startsolutions)
-    tracker = PathTracking.PathTracker(prob, embeded_startsolutions[1], t₁, t₀; rest...)
+    tracker = PathTracking.PathTracker(prob, startsolutions[1], t₁, t₀; rest...)
 
-    (tracker=tracker, startsolution=embeded_startsolutions)
+    (tracker=tracker, startsolutions=startsolutions)
 end

--- a/src/pathtracker.jl
+++ b/src/pathtracker.jl
@@ -10,8 +10,7 @@ to investigate single paths.
 function pathtracker_startsolutions(args...; kwargs...)
     supported, rest = splitkwargs(kwargs, Problems.supported_kwargs)
     prob, startsolutions = Problems.problem_startsolutions(args...; supported...)
-    t₁, t₀ = one(ComplexF64), zero(ComplexF64)
-    tracker = PathTracking.PathTracker(prob, startsolutions[1], t₁, t₀; rest...)
+    tracker = PathTracking.PathTracker(prob, first(startsolutions), one(ComplexF64), zero(ComplexF64); rest...)
 
     (tracker=tracker, startsolutions=startsolutions)
 end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -4,6 +4,7 @@ import DynamicPolynomials
 import LinearAlgebra
 import MultivariatePolynomials
 const MP = MultivariatePolynomials
+import Random
 
 import ..Input
 import ..Input: AbstractInput, TotalDegree, StartTarget, ParameterSystem, MPPolys
@@ -63,34 +64,103 @@ function Homogenization(homvar::MP.AbstractVariable, variables::Vector{<:MP.Abst
 end
 
 """
-    Projective(prob::TotalDegreeProblem; options...)
-    Projective(prob::StartTargetProblem; options...)
-    Projective(start<:Vector{<:Polynomial}, target::Vector{<:MP.Polynomial}; options...)
-
-Construct a `Projective`. This steps constructs a homotopy and homogenizes
-the systems if necessary. The options are
-* `system=FPSystem`: A constructor to assemble a [`Systems.AbstractSystem`](@ref). The constructor
-is called with `system(polys, variables)` where `variables` determines the variable ordering.
-* `homotopy=StraightLineHomotopy`: A constructor to construct a [`Homotopies.AbstractHomotopy`](@ref) an `Systems.AbstractSystem`. The constructor
-is called with `homotopy(start, target)` where `start` and `target` are systems constructed
-with `system`.
-
-    Projective(H::AbstractHomotopy)
+    Projective(H::AbstractHomotopy, homogenization::AbstractHomogenization, seed::Int)
 
 Construct a `ProjectiveProblem`. The homotopy `H` needs to be homogenous.
 """
 struct Projective{H<:AbstractHomotopy, HS<:AbstractHomogenization} <: AbstractProblem
     homotopy::H
     homogenization::HS
+    seed::Int
 end
 function Projective(G::AbstractSystem, F::AbstractSystem,
-        homogenization::AbstractHomogenization; homotopy=DEFAULT_HOMOTOPY)
-    Projective(homotopy(G, F), homogenization)
+        homogenization::AbstractHomogenization, seed::Int; homotopy=DEFAULT_HOMOTOPY)
+    Projective(homotopy(G, F), homogenization, seed)
 end
 
+const supported_kwargs = [:seed, :homvar, :homotopy, :system]
 
+Base.broadcastable(P::AbstractProblem) = Ref(P)
 # We dispatch every input to the two argument case
-problem_startsolutions(prob::AbstractInput; homvar=nothing, kwargs...) = problem_startsolutions(prob, homvar; kwargs...)
+"""
+    problem_startsolutions(F; options...)
+    problem_startsolutions(G, F, startsolutions; options...)
+    problem_startsolutions(H::AbstractHomotopy, startsolutions; options...)
+    problem_startsolutions(prob::TotalDegreeProblem; options...)
+    problem_startsolutions(prob::StartTargetProblem; options...)
+
+    Construct the problem and if necessary the startsolutions. This steps
+    constructs a homotopy and homogenizes the systems if necessary.
+
+    The `options` are
+    * `seed::Int`: Random seed used in the construction.
+    * `system=FPSystem`: A constructor to assemble a [`Systems.AbstractSystem`](@ref). The constructor
+    is called with `system(polys, variables)` where `variables` determines the variable ordering.
+    * `homotopy=StraightLineHomotopy`: A constructor to construct a [`Homotopies.AbstractHomotopy`](@ref) an `Systems.AbstractSystem`. The constructor
+    is called with `homotopy(start, target)` where `start` and `target` are systems constructed
+    with `system`.
+"""
+function problem_startsolutions end
+
+function problem_startsolutions(F::Vector{<:MP.AbstractPolynomial}; seed=randseed(), homvar=nothing, kwargs...)
+    Random.seed!(seed)
+    F = filter(f -> !iszero(f), F)
+    check_zero_dimensional(F, homvar)
+    # square system and each polynomial is non-zero
+    if length(F) == MP.nvariables(F) && ishomogenous(F)
+        throw(AssertionError("The input system is a square homogenous system. This will result in an at least 1 dimensional solution space."))
+    end
+    problem_startsolutions(Input.TotalDegree(F), seed; homvar=homvar, kwargs...)
+end
+
+function problem_startsolutions(G::Vector{<:MP.AbstractPolynomial}, F::Vector{<:MP.AbstractPolynomial}, startsolutions; homvar=nothing, seed=randseed(), kwargs...)
+    Random.seed!(seed)
+    @assert length(G) == length(F) "Start and target system don't have the same length"
+    check_zero_dimensional(F, homvar)
+    problem_startsolutions(Input.StartTarget(G, F, promote_startsolutions(startsolutions)), seed; homvar=homvar, kwargs...)
+end
+
+function problem_startsolutions(F::Systems.AbstractSystem; seed=randseed(), kwargs...)
+    Random.seed!(seed)
+	problem_startsolutions(Input.TotalDegree(F), seed; kwargs...)
+end
+
+function problem_startsolutions(F::Vector{<:MP.AbstractPolynomial},
+    p::Vector{<:MP.AbstractVariable},
+    a_1::Vector{<:Number},
+    a_2::Vector{<:Number},
+    startsolutions; seed=randseed(), homotopy=nothing, kwargs...)
+    Random.seed!(seed)
+
+    @assert length(p) == length(a_1) "Number of parameters must match"
+    @assert length(a_1) == length(a_2) "Start and target parameters must have the same length"
+
+    problem_startsolutions(Input.ParameterSystem(F, p, a_1, a_2, promote_startsolutions(startsolutions)), seed; kwargs...)
+end
+
+function problem_startsolutions(H::AbstractHomotopy, startsolutions; seed=randseed(), kwargs...)
+    Random.seed!(seed)
+	problem_startsolutions(Input.Homotopy(H, promote_startsolutions(startsolutions)), seed; kwargs...)
+end
+
+function problem_startsolutions(input::Input.AbstractInput, seed;
+	homvar::Union{Nothing, Int, MP.AbstractVariable}=nothing,
+    system=Systems.FPSystem,
+    homotopy=StraightLineHomotopy)
+
+    problem_startsolutions(input, seed=seed, homvar=homvar, system=system, homotopy=homotopy)
+end
+
+promote_startsolutions(iter) = promote_startsolutions(collect(iter))
+promote_startsolutions(xs::Vector{Vector{ComplexF64}}) = xs
+function promote_startsolutions(xs::Vector{<:AbstractVector{<:Number}})
+    PT = promote_type(typeof(xs[1][1]), Complex{Float64})
+    map(s -> convert.(PT, s), xs)
+end
+
+function problem_startsolutions(prob::AbstractInput; seed=randseed(), homvar=nothing, kwargs...)
+    problem_startsolutions(prob, homvar, seed; kwargs...)
+end
 
 const overdetermined_error_msg = """
 The input system is overdetermined. Therefore it is necessary to provide an explicit start system.
@@ -99,7 +169,7 @@ See
 for details.
 """
 # TOTALDEGREE
-function problem_startsolutions(prob::TotalDegree{Vector{AP}}, _homvar::Nothing; system=DEFAULT_SYSTEM, kwargs...) where {AP<:MP.AbstractPolynomial}
+function problem_startsolutions(prob::TotalDegree{Vector{AP}}, _homvar::Nothing, seed; system=DEFAULT_SYSTEM, kwargs...) where {AP<:MP.AbstractPolynomial}
     F = prob.system
     n = length(F)
     variables = MP.variables(F)
@@ -113,7 +183,7 @@ function problem_startsolutions(prob::TotalDegree{Vector{AP}}, _homvar::Nothing;
 
         G = Systems.TotalDegreeSystem(F, variables, variables[1])
         start = totaldegree_solutions(F, NullHomogenization())
-        Projective(G, system(F), NullHomogenization(); kwargs...), start
+        Projective(G, system(F), NullHomogenization(), seed; kwargs...), start
     else
         # N = n is the only valid size configuration
         if n > N
@@ -125,13 +195,14 @@ function problem_startsolutions(prob::TotalDegree{Vector{AP}}, _homvar::Nothing;
         var_ordering = [homvar; variables]
         proj = Projective(
             Systems.TotalDegreeSystem(F, var_ordering, homvar),
-            system(homogenize(F, homvar), var_ordering), homogenization; kwargs...)
+            system(homogenize(F, homvar), var_ordering), homogenization, seed; kwargs...)
         start = totaldegree_solutions(F, homogenization)
         proj, start
     end
 end
 
-function problem_startsolutions(prob::TotalDegree{Vector{AP}}, homvar::MP.AbstractVariable; system=DEFAULT_SYSTEM, kwargs...) where {AP<:MP.AbstractPolynomialLike}
+function problem_startsolutions(prob::TotalDegree{Vector{AP}},
+    homvar::MP.AbstractVariable, seed; system=DEFAULT_SYSTEM, kwargs...) where {AP<:MP.AbstractPolynomialLike}
     @assert ishomogenous(prob.system) "Input system is not homogenous although `homvar=$(homvar)` was passed."
     n = length(prob.system)
     variables = MP.variables(prob.system)
@@ -144,11 +215,11 @@ function problem_startsolutions(prob::TotalDegree{Vector{AP}}, homvar::MP.Abstra
 
     proj = Projective(
         Systems.TotalDegreeSystem(prob.system, variables, homvar),
-        system(homogenize(prob.system, homvar), variables), homogenization; kwargs...)
+        system(homogenize(prob.system, homvar), variables), homogenization, seed; kwargs...)
     proj, start
 end
 
-function problem_startsolutions(prob::TotalDegree{<:AbstractSystem}, homvaridx::Nothing; system=DEFAULT_SYSTEM, kwargs...)
+function problem_startsolutions(prob::TotalDegree{<:AbstractSystem}, homvaridx::Nothing, seed; system=DEFAULT_SYSTEM, kwargs...)
     n, N = size(prob.system)
     degrees = check_homogenous_degrees(prob.system)
     # system needs to be homogenous
@@ -161,13 +232,13 @@ function problem_startsolutions(prob::TotalDegree{<:AbstractSystem}, homvaridx::
     G = Systems.TotalDegreeSystem(degrees, collect(2:N), 1)
     homogenization = NullHomogenization()
 
-    proj = Projective(G, prob.system, homogenization; kwargs...)
+    proj = Projective(G, prob.system, homogenization, seed; kwargs...)
     start = totaldegree_solutions(degrees, homogenization)
 
     proj, start
 end
 
-function problem_startsolutions(prob::TotalDegree{<:AbstractSystem}, homvaridx::Int; system=DEFAULT_SYSTEM, kwargs...)
+function problem_startsolutions(prob::TotalDegree{<:AbstractSystem}, homvaridx::Int, seed; system=DEFAULT_SYSTEM, kwargs...)
     n, N = size(prob.system)
     # system needs to be homogenous
     degrees = check_homogenous_degrees(prob.system)
@@ -178,7 +249,7 @@ function problem_startsolutions(prob::TotalDegree{<:AbstractSystem}, homvaridx::
 
     homogenization = Homogenization(homvaridx)
     G = Systems.TotalDegreeSystem(degrees, [1:homvaridx-1;homvaridx+1:N], homvaridx)
-    proj = Projective(G, prob.system, homogenization; kwargs...)
+    proj = Projective(G, prob.system, homogenization, seed; kwargs...)
     start = totaldegree_solutions(degrees, homogenization)
 
     proj, start
@@ -187,16 +258,16 @@ end
 
 
 # START TARGET
-function problem_startsolutions(prob::StartTarget{Vector{AP1}, Vector{AP2}, V}, homvar; system=DEFAULT_SYSTEM, kwargs...) where
+function problem_startsolutions(prob::StartTarget{Vector{AP1}, Vector{AP2}, V}, homvar, seed; system=DEFAULT_SYSTEM, kwargs...) where
     {AP1<:MP.AbstractPolynomialLike, AP2<:MP.AbstractPolynomialLike, V}
 
     F, G = prob.target, prob.start
     F_ishom, G_ishom = ishomogenous.((F, G))
     if F_ishom && G_ishom && homvar !== nothing
-        Projective(system(G), system(F), Homogenization(homvar, MP.variables(F)); kwargs...),
+        Projective(system(G), system(F), Homogenization(homvar, MP.variables(F)), seed; kwargs...),
         prob.startsolutions
     elseif F_ishom && G_ishom && homvar === nothing
-        Projective(system(G), system(F), NullHomogenization(); kwargs...), prob.startsolutions
+        Projective(system(G), system(F), NullHomogenization(), seed; kwargs...), prob.startsolutions
     elseif F_ishom || G_ishom
         throw(error("One of the input polynomials is homogenous and the other not!"))
     else
@@ -208,21 +279,21 @@ function problem_startsolutions(prob::StartTarget{Vector{AP1}, Vector{AP2}, V}, 
         var_ordering = [homvar; MP.variables(F)]
         Projective(
             system(homogenize(G, homvar), var_ordering),
-            system(homogenize(F, homvar), var_ordering), homogenization; kwargs...), prob.startsolutions
+            system(homogenize(F, homvar), var_ordering), homogenization, seed; kwargs...), prob.startsolutions
     end
 end
 
-function problem_startsolutions(input::Input.Homotopy, homvar::Int; kwargs...)
+function problem_startsolutions(input::Input.Homotopy, homvar::Int, seed; kwargs...)
     check_homogenous_degrees(Systems.FixedHomotopy(input.H, rand()))
-    Projective(input.H, Homogenization(homvar)), input.startsolutions
+    Projective(input.H, Homogenization(homvar), seed), input.startsolutions
 end
 
-function problem_startsolutions(input::Input.Homotopy, homvar::Nothing; kwargs...)
+function problem_startsolutions(input::Input.Homotopy, homvar::Nothing, seed; kwargs...)
     check_homogenous_degrees(Systems.FixedHomotopy(input.H, rand()))
-    Projective(input.H, NullHomogenization()), input.startsolutions
+    Projective(input.H, NullHomogenization(), seed), input.startsolutions
 end
 
-function problem_startsolutions(prob::ParameterSystem, homvar; system=FPSystem, kwargs...)
+function problem_startsolutions(prob::ParameterSystem, homvar, seed; system=FPSystem, kwargs...)
     variables = setdiff(allvariables(prob.system), prob.parameters)
     if ishomogenous(prob.system, variables)
         if homvar === nothing
@@ -251,7 +322,7 @@ function problem_startsolutions(prob::ParameterSystem, homvar; system=FPSystem, 
 
     H = ParameterHomotopy(f, collect(var_indices), collect(param_indices), prob.start, prob.target)
 
-    Projective(H, homogenization), prob.startsolutions
+    Projective(H, homogenization, seed), prob.startsolutions
 end
 
 
@@ -325,10 +396,10 @@ function totaldegree_solutions(F::Vector{AP}, homogenization) where {AP<:MP.Abst
     totaldegree_solutions(MP.maxdegree.(F), homogenization)
 end
 function totaldegree_solutions(degrees::Vector{Int}, ::NullHomogenization)
-    TotalDegreeSolutionIterator(degrees, true) |> collect
+    TotalDegreeSolutionIterator(degrees, true)
 end
 function totaldegree_solutions(degrees::Vector{Int}, ::Homogenization)
-    TotalDegreeSolutionIterator(degrees, false) |> collect
+    TotalDegreeSolutionIterator(degrees, false)
 end
 
 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -373,7 +373,7 @@ Embed the solution `x` into projective space if necessary.
 """
 function embed(prob::Projective{<:AbstractHomotopy, NullHomogenization}, x)
     M, N = size(homotopy(prob))
-    length(x) != N && throw(error("The length of the intial solution is $(length(x)) but expected length $N."))
+    length(x) != N && throw(error("The length of the initial solution is $(length(x)) but expected length $N."))
     return ProjectiveVectors.PVector(x, nothing)
 end
 function embed(prob::Projective{<:AbstractHomotopy, Homogenization}, x)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -10,6 +10,7 @@ import ..Input
 import ..Input: AbstractInput, TotalDegree, StartTarget, ParameterSystem, MPPolys
 import ..Homotopies: AbstractHomotopy, StraightLineHomotopy, ParameterHomotopy
 import ..ProjectiveVectors
+import ..ProjectiveVectors: PVector
 import ..Systems: AbstractSystem, SPSystem, FPSystem
 import ..Systems
 
@@ -368,17 +369,19 @@ Embed the solution `x` into projective space if necessary.
 function embed(prob::Projective{<:AbstractHomotopy, NullHomogenization}, x)
     M, N = size(homotopy(prob))
     length(x) != N && throw(error("The length of the initial solution is $(length(x)) but expected length $N."))
-    return ProjectiveVectors.PVector(x, nothing)
+    return PVector(x, nothing)
 end
 function embed(prob::Projective{<:AbstractHomotopy, Homogenization}, x)
     M, N = size(homotopy(prob))
     if length(x) == N
-        return ProjectiveVectors.PVector(x, homogenization(prob).homvaridx)
+        return PVector(x, homogenization(prob).homvaridx)
     elseif length(x) == N - 1
         return ProjectiveVectors.embed(x, homogenization(prob).homvaridx)
     end
     throw(error("The length of the initial solution is $(length(x)) but expected length $N or $(N-1)."))
 end
+embed(prob::Projective{<:AbstractHomotopy, Homogenization}, x::PVector) = x
+embed(prob::Projective{<:AbstractHomotopy, NullHomogenization}, x::PVector) = x
 
 
 """

--- a/src/projective_vectors.jl
+++ b/src/projective_vectors.jl
@@ -74,7 +74,13 @@ homvar(z::PVector) = z.homvar
 Base.similar(v::PVector, ::Type{T}) where T = PVector(convert.(T, v.data), v.homvar)
 
 """
-    embed(x::Vector, homvar)::PVector
+    embed(x::Vector, homvar::Union{Nothing, Int})::PVector
+
+Embed a vector `x` into projective space with homogenization variable `homvar`.
+
+    embed(z::PVector, x::Vector)
+
+Embed a vector `x` into projective space the same way `x` was embedded.
 """
 function embed(x::Vector{T}, homvar) where T
     k = 1
@@ -89,6 +95,8 @@ function embed(x::Vector{T}, homvar) where T
     end
     PVector(data, homvar)
 end
+embed(z::PVector, x::Vector) = embed(x, z.homvar)
+
 
 """
     affine_normalizer(z::PVector)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,6 +1,5 @@
 import MultivariatePolynomials
 const MP = MultivariatePolynomials
-import Random
 
 import .Input
 import .Problems
@@ -135,80 +134,15 @@ Endgame specific options
 """
 function solve end
 
-# External
-function solve(F::Vector{<:MP.AbstractPolynomial}; seed=randseed(), homvar=nothing, kwargs...)
-    Random.seed!(seed)
-    F = filter(f -> !iszero(f), F)
-    checkfinite_dimensional(F, homvar)
-    # square system and each polynomial is non-zero
-    if length(F) == MP.nvariables(F) && ishomogenous(F)
-        throw(AssertionError("The input system is a square homogenous system. This will result in an at least 1 dimensional solution space."))
-    end
-    solve(Input.TotalDegree(F), seed; homvar=homvar, kwargs...)
+function solve(args...; seed=randseed(), kwargs...)
+    supported, rest = splitkwargs(kwargs, Problems.supported_kwargs)
+    p, startsolutions = Problems.problem_startsolutions(args...; seed=seed, supported...)
+    solve(p, startsolutions; rest...)
 end
-
-function solve(G::Vector{<:MP.AbstractPolynomial}, F::Vector{<:MP.AbstractPolynomial}, startsolutions; homvar=nothing, seed=randseed(), kwargs...)
-    Random.seed!(seed)
-    @assert length(G) == length(F)
-    checkfinite_dimensional(F, homvar)
-    solve(Input.StartTarget(G, F, promote_startsolutions(startsolutions)), seed; homvar=homvar, kwargs...)
-end
-
-function solve(F::Systems.AbstractSystem; seed=randseed(), kwargs...)
-    Random.seed!(seed)
-	solve(Input.TotalDegree(F), seed; kwargs...)
-end
-
-function checkfinite_dimensional(F::Vector{<:MP.AbstractPolynomial}, homvar)
-    N = homvar === nothing ? MP.nvariables(F) : MP.nvariables(F) - 1
-    n = length(F)
-
-    if n ≥ N ||
-       n == N - 1 && ishomogenous(F)
-        return
-    end
-    throw(AssertionError("The input system will not result in a finite number of solutions."))
-end
-
-function solve(F::Vector{<:MP.AbstractPolynomial},
-    p::Vector{<:MP.AbstractVariable},
-    a_1::Vector{<:Number},
-    a_2::Vector{<:Number},
-    startsolutions; seed=randseed(), homotopy=nothing, kwargs...)
-    Random.seed!(seed)
-
-    @assert length(p) == length(a_1) "Number of parameters must match"
-    @assert length(a_1) == length(a_2) "Start and target parameters must have the same length"
-
-    solve(Input.ParameterSystem(F, p, a_1, a_2, promote_startsolutions(startsolutions)), seed; kwargs...)
-end
-
-function solve(H::Homotopies.AbstractHomotopy, startsolutions; seed=randseed(), kwargs...)
-    Random.seed!(seed)
-	solve(Input.Homotopy(H, promote_startsolutions(startsolutions)), seed; kwargs...)
-end
-
-promote_startsolutions(xs::Vector{Vector{ComplexF64}}) = xs
-function promote_startsolutions(xs::Vector{<:AbstractVector{<:Number}})
-    PT = promote_type(typeof(xs[1][1]), Complex{Float64})
-    map(s -> convert.(PT, s), xs)
-end
-
-randseed() = rand(1_000:1_000_000)
 
 # Internal
-function solve(input::Input.AbstractInput, seed;
-	homvar::Union{Nothing, Int, MP.AbstractVariable}=nothing,
-    system=Systems.FPSystem,
-    homotopy=Homotopies.StraightLineHomotopy,
-    kwargs...)
-
-    p, startsolutions = Problems.problem_startsolutions(input, homvar=homvar, system=system, homotopy=homotopy)
-    solve(p, startsolutions, seed; kwargs...)
-end
-
-function solve(prob::Problems.AbstractProblem, start_solutions, seed; threading=true, kwargs...)
-    solver = Solving.Solver(prob, start_solutions, 1.0, 0.0, seed; kwargs...)
+function solve(prob::Problems.AbstractProblem, start_solutions; threading=true, kwargs...)
+    solver = Solving.Solver(prob, start_solutions, 1.0, 0.0, prob.seed; kwargs...)
     if threading && Threads.nthreads() > 1
         solvers = append!([solver], [deepcopy(solver) for _=2:Threads.nthreads()])
         Solving.solve(solvers, start_solutions)

--- a/src/solving.jl
+++ b/src/solving.jl
@@ -19,6 +19,8 @@ import ..PatchSwitching
 import ..StepLength
 import ..Systems
 
+using ..Utilities
+
 export Solver,
     solve,
     multiplicities,
@@ -27,7 +29,7 @@ export Solver,
 include("solving/multiplicities.jl")
 include("solving/path_result.jl")
 include("solving/result.jl")
-include("solving/types.jl")
+include("solving/solver.jl")
 include("solving/solve.jl")
 
 

--- a/src/step_length.jl
+++ b/src/step_length.jl
@@ -64,6 +64,12 @@ The argument `success` indicates whether the step was successfull.
 """
 function update! end
 
+const allowed_keywords = [
+    :initial_steplength, :steplength_decrease_factor, :steplength_increase_factor,
+    :steplength_consecutive_successes_necessary,
+    :maximal_steplength, :minimal_steplength
+]
+
 
 # Implementation
 """
@@ -88,9 +94,13 @@ struct HeuristicStepLength <: AbstractStepLength
     minimal_steplength::Float64
 end
 function HeuristicStepLength(;initial=0.1,
+    initial_steplength=initial,
     increase_factor=2.0,
+    steplength_increase_factor=increase_factor,
     decrease_factor=inv(increase_factor),
+    steplength_decrease_factor=decrease_factor,
     consecutive_successes_necessary=5,
+    steplength_consecutive_successes_necessary=consecutive_successes_necessary,
     maximal_steplength=max(0.1, initial),
     minimal_steplength=1e-14)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -22,7 +22,34 @@ export allvariables,
     set_num_BLAS_threads,
     get_num_BLAS_threads,
     check_zero_dimensional,
-    randseed
+    randseed,
+    check_kwargs_empty
+
+
+"""
+    check_kwargs_empty(kwargs, [allowed_kwargs])
+
+Chack that the list of `kwargs` is empty. If not, print all unsupported keywords
+with their arguments.
+"""
+function check_kwargs_empty(kwargs, allowed_kwargs=[])
+    if !isempty(kwargs)
+        msg = "Unexpected keyword argument(s): "
+        first_el = true
+        for kwarg in kwargs
+            if !first_el
+                msg *= ", "
+            end
+            msg *= "$(first(kwarg))=$(last(kwarg))"
+            first_el = false
+        end
+        if !isempty(allowed_kwargs)
+            msg *= "\nAllowed keywords are\n"
+            msg *= join(allowed_kwargs, ", ")
+        end
+        throw(ErrorException(msg))
+    end
+end
 
 """
     check_zero_dimensional(F::Vector{<:MP.AbstractPolynomial}, homvar)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -17,10 +17,35 @@ export allvariables,
     batches,
     randomish_gamma,
     filterkwargs,
+    splitkwargs,
     solve!,
     set_num_BLAS_threads,
-    get_num_BLAS_threads
+    get_num_BLAS_threads,
+    check_zero_dimensional,
+    randseed
 
+"""
+    check_zero_dimensional(F::Vector{<:MP.AbstractPolynomial}, homvar)
+
+Check that the given polynomial system can have zero dimensional components.
+"""
+function check_zero_dimensional(F::Vector{<:MP.AbstractPolynomial}, homvar)
+    N = homvar === nothing ? MP.nvariables(F) : MP.nvariables(F) - 1
+    n = length(F)
+
+    if n ≥ N ||
+       n == N - 1 && ishomogenous(F)
+        return
+    end
+    throw(AssertionError("The input system will not result in a finite number of solutions."))
+end
+
+"""
+    randseed(range=1_000:1_000_000)
+
+Return a random seed in the range `range`.
+"""
+randseed(range=1_000:1_000_000) = rand(range)
 
 """
     solve!(A, b)
@@ -185,6 +210,25 @@ in `allowed_kwargs`.
 """
 function filterkwargs(kwargs, allowed_kwargs)
     [kwarg for kwarg in kwargs if any(kw -> kw == first(kwarg), allowed_kwargs)]
+end
+
+"""
+    splitkwargs(kwargs, supported_keywords)
+
+Split the vector of `kwargs` in two vectors, the first contains all `kwargs`
+whose keywords appear in `supported_keywords` and the rest the other one.
+"""
+function splitkwargs(kwargs, supported_keywords)
+    supported = []
+    rest = []
+    for kwarg in kwargs
+        if any(kw -> kw == first(kwarg), supported_keywords)
+            push!(supported, kwarg)
+        else
+            push!(rest, kwarg)
+        end
+    end
+    supported, rest
 end
 
 # Parallelization

--- a/test/path_tracking_test.jl
+++ b/test/path_tracking_test.jl
@@ -1,4 +1,4 @@
-@testset "Path Tracking" begin
+@testset "PathTracking" begin
     @testset "General" begin
         F = equations(katsura(5))
 
@@ -31,11 +31,11 @@
         @test t3.predictor_corrector.predictor isa Predictors.Euler
 
 
-        PathTracking.setup!(t1, Problems.embed(P, start_sols[2]), 1.0, 0.4)
+        PathTracking.setup!(t1, Problems.embed(P, first(start_sols)), 1.0, 0.4)
         @test PathTracking.currstatus(t1) == :ok
         @test PathTracking.currt(t1) == 1.0
 
-        PathTracking.setup!(t1, Problems.embed(P, start_sols[2]), 0.5, 0.4)
+        PathTracking.setup!(t1, Problems.embed(P, first(start_sols)), 0.5, 0.4)
         @test PathTracking.currstatus(t1) == :invalid_startvalue
         @test PathTracking.currt(t1) == 0.5
 
@@ -61,7 +61,7 @@
 
         P, sols = Problems.problem_startsolutions(Input.TotalDegree(F))
 
-        start_sols = Problems.embed.(Ref(P), sols)
+        start_sols = map(s -> Problems.embed(P,s), sols)
 
         s = start_sols[1]
         H = Homotopies.PatchedHomotopy(P.homotopy, AffinePatches.RandomPatch(), s)
@@ -86,10 +86,10 @@
         @test norm(x[2:end] / x[1] - A \ b) < 1e-6
     end
 
-    @testset "Fixed Patch" begin
+    @testset "fixedpatch" begin
         F = equations(katsura(5))
         P, start_sols = Problems.problem_startsolutions(Input.TotalDegree(F))
-        x1 = Problems.embed(P, start_sols[1])
+        x1 = Problems.embed(P, first(start_sols))
         patch = AffinePatches.state(AffinePatches.OrthogonalPatch(), x1)
         fixedpatch = AffinePatches.state(AffinePatches.FixedPatch(), x1)
         H = Homotopies.PatchedHomotopy(P.homotopy, patch)

--- a/test/pathtracker_test.jl
+++ b/test/pathtracker_test.jl
@@ -1,0 +1,7 @@
+@testset "pathtracker_startsolutions" begin
+    @polyvar  x y
+
+    tracker, S = pathtracker_startsolutions([x^2-y^2+4, x + y - 3])
+    result = PathTracking.track(tracker, first(S), 1.0, 0.0)
+    @test result.returncode == :success
+end

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -116,7 +116,7 @@
         Random.seed!(2337)
         F = equations(cyclic(6))
         P, start_sols = Problems.problem_startsolutions(Input.TotalDegree(F))
-        x₁ = Problems.embed(P, start_sols[1])
+        x₁ = Problems.embed(P, first(start_sols))
         H = Homotopies.PatchedHomotopy(P.homotopy, AffinePatches.OrthogonalPatch(), x₁)
         tracker = PathTracking.PathTracker(H, x₁, 1.0, 0.1, tol=1e-3)
         tracked_paths = map(start_sols) do x
@@ -128,7 +128,7 @@
 
         tracker = PathTracking.PathTracker(H, x₁, 1.0, 0.1, tol=1e-8)
         tracked_paths = map(start_sols) do x
-            PathTracking.track(tracker, Problems.embed(P, x), 1.0, 0.1)
+            PathTracking.track(tracker, x, 1.0, 0.1)
         end
         crossed_path_indices = Solving.check_crossed_paths(tracked_paths, 1e-7)
         @test isempty(crossed_path_indices)


### PR DESCRIPTION
Currently to setup a path tracker you have to stick together quite a lot things. To make this more easy we should apply all the transforms `solve` applies. As a first step, I refactored the solve logic such that
all assembly now takes place in `Problems.problem_startsolutions`.

To do:

- [x] Provide function `pathtracker` to easily assemble a path tracker