### PR TITLE
Make ParameterHomotopy independent of StaticPolynomials

### DIFF
--- a/src/homotopies/parameter_homotopy.jl
+++ b/src/homotopies/parameter_homotopy.jl
@@ -1,4 +1,4 @@
-export ParameterHomotopy, nparameters
+export ParameterHomotopy, nparameters, set_parameters!
 
 import LinearAlgebra
 import MultivariatePolynomials
@@ -39,29 +39,21 @@ are stored as a tuple `γ` or as `γ=nothing`
 This is a non-unicode variant where `γ₁=startparameters`, `γ₀=targetparameters`,
 `γ₁=startgamma`, `γ₀=targetgamma`.
 """
-mutable struct ParameterHomotopy{Sys<:AbstractSystem, NParams, T<:Number} <: AbstractHomotopy
+mutable struct ParameterHomotopy{Sys<:AbstractSystem, T<:Number} <: AbstractHomotopy
     F::Sys
-    p::NTuple{2, SVector{NParams, T}}
+    p::NTuple{2, Vector{T}}
     γ::Union{Nothing, NTuple{2, ComplexF64}}
 end
 
 function ParameterHomotopy(F::AbstractSystem, p₁::AbstractVector, p₀::AbstractVector;
     startgamma=nothing, γ₀ = startgamma,
-    targetgamma=nothing, γ₁ = targetgamma
-    )
+    targetgamma=nothing, γ₁ = targetgamma)
 
+    length(p₁) == length(p₀) || error("Length of parameters provided doesn't match.")
 
-    if length(p₁) != length(p₀)
-        error("Length of parameters provided doesn't match.")
-    end
+    γ = (γ₁ === nothing || γ₀ === nothing) ? nothing : (γ₁, γ₀)
+    p = Vector.(promote(p₁, p₀))
 
-    if γ₁ === nothing || γ₀ === nothing
-        γ = nothing
-    else
-        γ = (γ₁, γ₀)
-    end
-
-    p = promote(SVector{length(p₁)}(p₁), SVector{length(p₁)}(p₀))
     ParameterHomotopy(F, p, γ)
 end
 
@@ -77,6 +69,7 @@ end
 
 struct ParameterHomotopyCache{C<:AbstractSystemCache, T1<:Number, T2<:Number} <: AbstractHomotopyCache
     F_cache::C
+    pt::Vector{T1}
     ∂p∂t::Vector{T1}
     J_p::Matrix{T2}
 end
@@ -84,12 +77,17 @@ end
 (H::ParameterHomotopy)(x, t, c=cache(H, x, t)) = evaluate(H, x, t, c)
 
 function cache(H::ParameterHomotopy, x, t)
-    pt = p(H, t)
+    if H.γ === nothing
+        pt = Vector{typeof(t * H.p[1][1])}(undef, length(H.p[1]))
+    else
+        pt = Vector{typeof(H.γ[1] * t * H.p[1][1])}(undef, length(H.p[1]))
+    end
+    p!(pt, H, t)
     F_cache = Systems.cache(H.F, x, pt)
     ∂p∂t = Vector{eltype(pt)}(undef, length(pt))
     J_p = Matrix(Systems.differentiate_parameters(H.F, x, pt, F_cache))
 
-    ParameterHomotopyCache(F_cache, ∂p∂t, J_p)
+    ParameterHomotopyCache(F_cache, pt, ∂p∂t, J_p)
 end
 
 Base.size(H::ParameterHomotopy) = size(H.F)
@@ -99,46 +97,49 @@ Base.size(H::ParameterHomotopy) = size(H.F)
 
 Returns the number of parameters of `H`.
 """
-function nparameters(::ParameterHomotopy{N, NVars, NParams}) where {N, NVars, NParams}
-    NParams
-end
+nparameters(H::ParameterHomotopy) = length(H.p[1])
 
 
 """
-    set_parameters!(H::ParameterHomotopy, p::NTuple{2, <:SVector}, γ)
+    set_parameters!(H::ParameterHomotopy, p::Tuple, γ)
 
 Update the parameters `p` and `γ` of `H`.
 """
-function set_parameters!(H::Homotopies.ParameterHomotopy{S, NParams, T},
-    p::NTuple{2, SVector{NParams, T}},
-    γ::Union{Nothing, NTuple{2, ComplexF64}}) where {S, NParams, T}
-    H.p = p
+function set_parameters!(H::Homotopies.ParameterHomotopy, p::Tuple, γ=nothing)
+    H.p[1] .= p[1]
+    H.p[2] .= p[2]
     H.γ = γ
     H
 end
 
 """
-    set_parameters!(H::ParameterHomotopy, p::NTuple{2, SVector})
+    set_parameters!(H::ParameterHomotopy, p₁, p₀, γ)
 
-Update the parameter `p` of `H`.
+Update the parameters `p` and `γ` of `H`.
 """
-function set_parameters!(H::Homotopies.ParameterHomotopy{S, NParams, T},
-    p::NTuple{2, SVector{NParams, T}}) where {S, NParams, T}
-    H.p = p
-    H
+function set_parameters!(H::Homotopies.ParameterHomotopy, p₁::AbstractVector, p₀::AbstractVector, γ=nothing)
+    set_parameters!(H, (p₁, p₀), γ)
 end
 
-@inline function p(H::ParameterHomotopy, t)
+
+@inline function p!(pt, H::ParameterHomotopy, t)
     p₁, p₀ = H.p
     if H.γ === nothing
-        return t * p₁ + (1 - t) * p₀
+        for i in eachindex(pt)
+            @inbounds pt[i] = t * p₁[i] + (1 - t) * p₀[i]
+        end
     else
         # compute (tγ₁p₁+(1-t)γ₀p₀) / (tγ₁+(1-t)γ₀)
         γ₁, γ₀ = H.γ
         tγ₁, γ₀_₁₋t = t * γ₁, (1 - t) * γ₀
         γ = (tγ₁ + γ₀_₁₋t)
-        return (@fastmath tγ₁ / γ) * p₁ + (@fastmath γ₀_₁₋t / γ) * p₀
+        a = (@fastmath tγ₁ / γ)
+        b = (@fastmath γ₀_₁₋t / γ)
+        for i in eachindex(pt)
+            @inbounds pt[i] = a * p₁[i] + b * p₀[i]
+        end
     end
+    pt
 end
 
 @inline function ∂p∂t!(u, H::ParameterHomotopy, t, c::ParameterHomotopyCache)
@@ -151,8 +152,6 @@ end
         γ₁, γ₀ = H.γ
         tγ₁, γ₀_₁₋t = t * γ₁, (1 - t) * γ₀
         γ = (tγ₁ + γ₀_₁₋t)
-        pt = (@fastmath tγ₁ / γ) * p₁ + (@fastmath γ₀_₁₋t / γ) * p₀
-        # quotient rule to get the derivative of p(t)
         λ = @fastmath γ₁ * γ₀ / (γ * γ)
         for i in eachindex(p₁)
             u[i] = λ * (p₁[i] - p₀[i])
@@ -162,17 +161,17 @@ end
 
 
 function evaluate!(u, H::ParameterHomotopy, x, t, c::ParameterHomotopyCache)
-    Systems.evaluate!(u, H.F, x, p(H, t), c.F_cache)
+    Systems.evaluate!(u, H.F, x, p!(c.pt, H, t), c.F_cache)
 end
 function evaluate(H::ParameterHomotopy, x, t, c::ParameterHomotopyCache)
-    Systems.evaluate(H.F, x, p(H, t), c.F_cache)
+    Systems.evaluate(H.F, x, p!(c.pt, H, t), c.F_cache)
 end
 
 function jacobian!(u, H::ParameterHomotopy, x, t, c::ParameterHomotopyCache)
-    Systems.jacobian!(u, H.F, x, p(H, t), c.F_cache)
+    Systems.jacobian!(u, H.F, x, p!(c.pt, H, t), c.F_cache)
 end
 function jacobian(H::ParameterHomotopy, x, t, c::ParameterHomotopyCache)
-    Systems.jacobian(H.F, x, p(H, t), c.F_cache)
+    Systems.jacobian(H.F, x, p!(c.pt, H, t), c.F_cache)
 end
 
 function evaluate_and_jacobian!(u, H::ParameterHomotopy, x, t, c::ParameterHomotopyCache)
@@ -181,8 +180,8 @@ end
 
 function dt!(u, H::ParameterHomotopy, x, t, c::ParameterHomotopyCache)
     # apply chain rule to H(x, p(t))
-    pt = p(H, t)
+    p!(c.pt, H, t)
     ∂p∂t!(c.∂p∂t, H, t, c)
-    Systems.differentiate_parameters!(c.J_p, H.F, x, pt, c.F_cache)
+    Systems.differentiate_parameters!(c.J_p, H.F, x, c.pt, c.F_cache)
     LinearAlgebra.mul!(u, c.J_p, c.∂p∂t)
 end

--- a/src/homotopies/parameter_homotopy.jl
+++ b/src/homotopies/parameter_homotopy.jl
@@ -109,9 +109,9 @@ end
 
 Update the parameters `p` and `γ` of `H`.
 """
-function set_parameters!(H::Homotopies.ParameterHomotopy{N, NVars, NParams},
+function set_parameters!(H::Homotopies.ParameterHomotopy{S, NParams, T},
     p::NTuple{2, SVector{NParams, T}},
-    γ::Union{Nothing, NTuple{2, ComplexF64}}) where {N, NVars, NParams, T}
+    γ::Union{Nothing, NTuple{2, ComplexF64}}) where {S, NParams, T}
     H.p = p
     H.γ = γ
     H
@@ -122,8 +122,8 @@ end
 
 Update the parameter `p` of `H`.
 """
-function set_parameters!(H::Homotopies.ParameterHomotopy{N, NVars, NParams},
-    p::NTuple{2, SVector{NParams, T}}) where {N, NVars, NParams, T}
+function set_parameters!(H::Homotopies.ParameterHomotopy{S, NParams, T},
+    p::NTuple{2, SVector{NParams, T}}) where {S, NParams, T}
     H.p = p
     H
 end

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -13,7 +13,9 @@ import ..SystemsBase: AbstractSystem,
     jacobian,
     jacobian!,
     evaluate_and_jacobian,
-    evaluate_and_jacobian!
+    evaluate_and_jacobian!,
+    differentiate_parameters!,
+    differentiate_parameters
 
 export NullCache
 

--- a/src/systems/sp_system.jl
+++ b/src/systems/sp_system.jl
@@ -27,14 +27,22 @@ struct SPSystem{S<:SP.PolynomialSystem} <: AbstractSystem
 end
 
 SPSystem(polys::Vector{<:MP.AbstractPolynomial}, vars) = SPSystem(SP.PolynomialSystem(polys, variables=vars))
-SPSystem(polys::Vector{<:MP.AbstractPolynomial}) = SPSystem(SP.PolynomialSystem(polys))
+SPSystem(polys::Vector{<:MP.AbstractPolynomial}; kwargs...) = SPSystem(SP.PolynomialSystem(polys; kwargs...))
 
 Base.size(F::SPSystem) = (SP.npolynomials(F.system), SP.nvariables(F.system))
 
-cache(F::SPSystem, x) = NullCache()
+cache(F::SPSystem, x, p=nothing) = NullCache()
 Base.@propagate_inbounds evaluate!(u, F::SPSystem, x, ::NullCache) = SP.evaluate!(u, F.system, x)
-Base.@propagate_inbounds evaluate(F::SPSystem, x, ::NullCache) = SP.evaluate(F.system, x)
+Base.@propagate_inbounds evaluate!(u, F::SPSystem, x, p, ::NullCache) = SP.evaluate!(u, F.system, x, p)
+evaluate(F::SPSystem, x, ::NullCache) = SP.evaluate(F.system, x)
+evaluate(F::SPSystem, x, p, ::NullCache) = SP.evaluate(F.system, x, p)
 Base.@propagate_inbounds jacobian!(U, F::SPSystem, x, ::NullCache) = SP.jacobian!(U, F.system, x)
-Base.@propagate_inbounds jacobian(F::SPSystem, x, ::NullCache) = SP.jacobian(F.system, x)
+Base.@propagate_inbounds jacobian!(U, F::SPSystem, x, p, ::NullCache) = SP.jacobian!(U, F.system, x, p)
+jacobian(F::SPSystem, x, ::NullCache) = SP.jacobian(F.system, x)
+jacobian(F::SPSystem, x, p, ::NullCache) = SP.jacobian(F.system, x, p)
 Base.@propagate_inbounds evaluate_and_jacobian!(u, U, F::SPSystem, x, ::NullCache) = SP.evaluate_and_jacobian!(u, U, F.system, x)
-Base.@propagate_inbounds evaluate_and_jacobian(F::SPSystem, x, ::NullCache) = SP.evaluate_and_jacobian(F.system, x)
+Base.@propagate_inbounds evaluate_and_jacobian!(u, U, F::SPSystem, x, p, ::NullCache) = SP.evaluate_and_jacobian!(u, U, F.system, x, p)
+evaluate_and_jacobian(F::SPSystem, x, ::NullCache) = SP.evaluate_and_jacobian(F.system, x)
+evaluate_and_jacobian(F::SPSystem, x, p, ::NullCache) = SP.evaluate_and_jacobian(F.system, x, p)
+Base.@propagate_inbounds differentiate_parameters!(U, F::SPSystem, x, p, ::NullCache) = SP.differentiate_parameters!(U, F.system, x, p)
+differentiate_parameters(F::SPSystem, x, p, ::NullCache) = SP.differentiate_parameters(F.system, x, p)

--- a/src/systems_base.jl
+++ b/src/systems_base.jl
@@ -7,6 +7,8 @@ export AbstractSystem,
     evaluate!,
     jacobian,
     jacobian!,
+    differentiate_parameters!,
+    differentiate_parameters,
     evaluate_and_jacobian,
     evaluate_and_jacobian!
 
@@ -37,14 +39,24 @@ struct NullCache <: AbstractSystemCache end
     cache(F::AbstractSystem, x)::AbstractSystemCache
 
 Create a cache for the evaluation (incl. Jacobian) of `F` with elements of the type
-of `x`. The default implementation returns a [`NullCache`](@ref).
+of `x`.
+
+    cache(F::AbstractSystem, x, p)::AbstractSystemCache
+
+Create a cache for the evaluation (incl. Jacobian) of `F` with elements of the type
+of `x` and parameters `p`.
 """
 function cache end
 
+
 """
-    evaluate!(u, F::AbstractSystem, x , cache::AbstractSystemCache)
+    evaluate!(u, F::AbstractSystem, x, cache::AbstractSystemCache)
 
 Evaluate the system `F` at `x` and store the result in `u`.
+
+    evaluate!(u, F::AbstractSystem, x, p, cache::AbstractSystemCache)
+
+Evaluate the system `F` at `x` and parameters `p` and store the result in `u`.
 """
 function evaluate! end
 
@@ -52,6 +64,10 @@ function evaluate! end
     evaluate(F::AbstractSystem, x::AbstractVector, cache=cache(F, x))
 
 Evaluate the system `F` at `x`.
+
+    evaluate(F::AbstractSystem, x::AbstractVector, p, cache=cache(F, x))
+
+Evaluate the system `F` at `x` and parameters `p`.
 """
 evaluate(F::AbstractSystem, x, c=cache(F, x)) = evaluate(F, x, c)
 
@@ -60,6 +76,10 @@ evaluate(F::AbstractSystem, x, c=cache(F, x)) = evaluate(F, x, c)
     jacobian!(u, F::AbstractSystem, x , cache::AbstractSystemCache)
 
 Evaluate the Jacobian of the system `F` at `x` and store the result in `u`.
+
+    jacobian!(u, F::AbstractSystem, x , p, cache::AbstractSystemCache)
+
+Evaluate the Jacobian of the system `F` at `x` and parameters `p` and store the result in `u`.
 """
 function jacobian! end
 
@@ -67,8 +87,28 @@ function jacobian! end
     jacobian(F::AbstractSystem, x, cache=cache(F, x))
 
 Evaluate the Jacobian of the system `F` at `x`.
+
+    jacobian(F::AbstractSystem, x , p, cache::AbstractSystemCache)
+
+Evaluate the Jacobian of the system `F` at `x` and parameters `p`.
 """
 jacobian(F::AbstractSystem, x, c=cache(F, x)) = jacobian(F, x, c)
+
+
+"""
+    differentiate_parameters!(u, F::AbstractSystem, x, p, cache::AbstractSystemCache)
+
+Evaluate the Jacobian of the system `F` at `x` and parameters `p` w.r.t. the parameters
+and store the result in `u`.
+"""
+function differentiate_parameters! end
+
+"""
+    differentiate_parameters(F::AbstractSystem, x, p, cache=cache(F, x))
+
+Evaluate the Jacobian of the system `F` at `x` and parameters `p` w.r.t. the parameters
+"""
+differentiate_parameters(F::AbstractSystem, x, c=cache(F, x)) = differentiate_parameters(F, x, c)
 
 # Optional
 """
@@ -84,13 +124,25 @@ function evaluate_and_jacobian!(u, U, F::AbstractSystem, x, cache::AbstractSyste
 end
 
 """
-    evaluate_and_jacobian(F::AbstractSystem, x , cache=cache(F, x))
+    evaluate_and_jacobian!(u, U, F, x, p, cache::AbstractSystemCache)
 
-Evaluate the system `F` and its Jacobian at `x`.
+Evaluate the system `F` and its Jacobian at `x` and parameters `p` and store the results in `u` (evalution)
+and `U` (Jacobian).
 """
-function evaluate_and_jacobian(F::AbstractSystem, x, c=cache(F, x))
-    u = evaluate(F, x, c)
-    U = jacobian(F, x, c)
+function evaluate_and_jacobian!(u, U, F::AbstractSystem, x, p, cache::AbstractSystemCache)
+    evaluate!(u, F, x, p, cache)
+    jacobian!(U, F, x, p, cache)
+    nothing
+end
+
+"""
+    evaluate_and_jacobian(F::AbstractSystem, x, p, cache=cache(F, x))
+
+Evaluate the system `F` and its Jacobian at `x` and parameters `p`.
+"""
+function evaluate_and_jacobian(F::AbstractSystem, x, p, c=cache(F, x))
+    u = evaluate(F, x, p, c)
+    U = jacobian(F, x, p, c)
     u, U
 end
 

--- a/src/systems_base.jl
+++ b/src/systems_base.jl
@@ -69,7 +69,7 @@ Evaluate the system `F` at `x`.
 
 Evaluate the system `F` at `x` and parameters `p`.
 """
-evaluate(F::AbstractSystem, x, c=cache(F, x)) = evaluate(F, x, c)
+evaluate(F::AbstractSystem, x, c::AbstractSystemCache=cache(F, x)) = evaluate(F, x, c)
 
 
 """
@@ -92,7 +92,7 @@ Evaluate the Jacobian of the system `F` at `x`.
 
 Evaluate the Jacobian of the system `F` at `x` and parameters `p`.
 """
-jacobian(F::AbstractSystem, x, c=cache(F, x)) = jacobian(F, x, c)
+jacobian(F::AbstractSystem, x, c::AbstractSystemCache=cache(F, x)) = jacobian(F, x, c)
 
 
 """
@@ -108,7 +108,7 @@ function differentiate_parameters! end
 
 Evaluate the Jacobian of the system `F` at `x` and parameters `p` w.r.t. the parameters
 """
-differentiate_parameters(F::AbstractSystem, x, c=cache(F, x)) = differentiate_parameters(F, x, c)
+differentiate_parameters(F::AbstractSystem, x, c::AbstractSystemCache=cache(F, x)) = differentiate_parameters(F, x, c)
 
 # Optional
 """
@@ -141,7 +141,7 @@ end
 
 Evaluate the system `F` and its Jacobian at `x`.
 """
-function evaluate_and_jacobian(F::AbstractSystem, x, c=cache(F, x))
+function evaluate_and_jacobian(F::AbstractSystem, x, c::AbstractSystemCache=cache(F, x))
     u = evaluate(F, x, c)
     U = jacobian(F, x, c)
     u, U
@@ -151,7 +151,7 @@ end
 
 Evaluate the system `F` and its Jacobian at `x` and parameters `p`.
 """
-function evaluate_and_jacobian(F::AbstractSystem, x, p, c=cache(F, x))
+function evaluate_and_jacobian(F::AbstractSystem, x, p, c::AbstractSystemCache=cache(F, x))
     u = evaluate(F, x, p, c)
     U = jacobian(F, x, p, c)
     u, U

--- a/src/systems_base.jl
+++ b/src/systems_base.jl
@@ -135,6 +135,17 @@ function evaluate_and_jacobian!(u, U, F::AbstractSystem, x, p, cache::AbstractSy
     nothing
 end
 
+
+"""
+    evaluate_and_jacobian(F::AbstractSystem, x, cache=cache(F, x))
+
+Evaluate the system `F` and its Jacobian at `x`.
+"""
+function evaluate_and_jacobian(F::AbstractSystem, x, c=cache(F, x))
+    u = evaluate(F, x, c)
+    U = jacobian(F, x, c)
+    u, U
+end
 """
     evaluate_and_jacobian(F::AbstractSystem, x, p, cache=cache(F, x))
 


### PR DESCRIPTION
Now ParameterHomotopy just requires an `AbstractSystem` which also supports parameters via the new `differentiate_parameters` interface.