### PR TITLE
Fix typo in real check during monodromy

### DIFF
--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -323,7 +323,9 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
         return :incomplete
     end
 
-    if job.edge.target == 1
+    node = loop.nodes[job.edge.target]
+
+    if node.main_node
         y = verified_affine_vector(C, currx(C.tracker), job.x, options)
         #is the solution at infinity?
         if y === nothing
@@ -333,12 +335,12 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
         y = ProjectiveVectors.affine_chart!(job.x, currx(C.tracker))
     end
 
-    if job.edge.target == 1
+    if node.main_node
         #is the solution real?
         checkreal!(stats, y)
     end
 
-    node = loop.nodes[job.edge.target]
+
     if !iscontained(node, y, tol=options.accuracy)
         unsafe_add!(node, y)
 
@@ -356,8 +358,8 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
             for yᵢ in options.group_actions(y)
                 if !iscontained(node, yᵢ, tol=options.accuracy)
                     unsafe_add!(node, yᵢ)
-                    if job.edge.target == 1
                         checkreal!(stats, y)
+                    if node.main_node
                     end
                     # Check if we are done
                     if isdone(node, yᵢ, options)

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -358,8 +358,8 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
             for yᵢ in options.group_actions(y)
                 if !iscontained(node, yᵢ, tol=options.accuracy)
                     unsafe_add!(node, yᵢ)
-                        checkreal!(stats, y)
                     if node.main_node
+                        checkreal!(stats, yᵢ)
                     end
                     # Check if we are done
                     if isdone(node, yᵢ, options)

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -335,19 +335,16 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
         y = ProjectiveVectors.affine_chart!(job.x, currx(C.tracker))
     end
 
-    if node.main_node
-        #is the solution real?
-        checkreal!(stats, y)
-    end
-
 
     if !iscontained(node, y, tol=options.accuracy)
         unsafe_add!(node, y)
 
+        # If we are on the main node check whether we have a real root.
+        node.main_node && checkreal!(stats, y)
+
         # Check if we are done
-        if isdone(node, y, options)
-            return :done
-        end
+        isdone(node, y, options) && return :done
+
         next_edge = nextedge(loop, job.edge)
         push!(queue, Job(y, next_edge))
 
@@ -358,13 +355,12 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
             for yᵢ in options.group_actions(y)
                 if !iscontained(node, yᵢ, tol=options.accuracy)
                     unsafe_add!(node, yᵢ)
-                    if node.main_node
-                        checkreal!(stats, yᵢ)
-                    end
+
+                    node.main_node && checkreal!(stats, yᵢ)
+
                     # Check if we are done
-                    if isdone(node, yᵢ, options)
-                        return :done
-                    end
+                    isdone(node, yᵢ, options) && :done
+
                     push!(queue, Job(yᵢ, next_edge))
                 end
             end


### PR DESCRIPTION
After applying the group action we checked always for the same vector `y` and not for the results of the group actions (`y_i`) whether they are real.

cc: @PBrdng 