### PR TITLE
Affine path tracking

### DIFF
--- a/docs/src/pathtracking.md
+++ b/docs/src/pathtracking.md
@@ -46,14 +46,14 @@ currstatus
 ## Changing options
 To change settings
 ```@docs
-corrector_maxiters
-set_corrector_maxiters!
-maximal_step_size
-set_maximal_step_size!
-refinement_maxiters
-set_refinement_maxiters!
-refinement_tol
-set_refinement_tol!
-tol
-set_tol!
+accuracy
+set_accuracy!
+max_corrector_iters
+set_max_corrector_iters!
+max_step_size
+set_max_step_size!
+refinement_max_iters
+set_refinement_max_iters!
+refinement_accuracy
+set_refinement_accuracy!
 ```

--- a/src/endgaming/types.jl
+++ b/src/endgaming/types.jl
@@ -166,7 +166,7 @@ function Endgame(H::AbstractHomotopy, x::ProjectiveVectors.PVector;
         maxwindingnumber, max_extrapolation_samples,
         cauchy_loop_closed_tolerance, cauchy_samples_per_loop, check_at_infinity)
     tracker = PathTracker(H, x, complex(0.1,0.0), 0.0im;
-        patch=FixedPatch(), maxiters=maxiters_per_step, pathtrackerkwargs...)
+        patch=FixedPatch(), max_steps=maxiters_per_step, pathtrackerkwargs...)
     state = EndgameState(x, complex(1.0,0.0), options)
 
     Endgame(tracker, state, Cache(state, options), options)

--- a/src/input.jl
+++ b/src/input.jl
@@ -122,6 +122,8 @@ function input(G::MPPolyInputs, F::MPPolyInputs, startsolutions=nothing)
     check_zero_dimensional(F)
     if startsolutions === nothing
         startsolutions = [randn(ComplexF64, nvariables(F))]
+    elseif isa(startsolutions, AbstractVector{<:Number})
+        startsolutions = [startsolutions]
     end
     StartTargetInput(G, F, startsolutions)
 end
@@ -144,11 +146,16 @@ function input(F::MPPolyInputs, startsolutions;
     end
     if startsolutions === nothing
         startsolutions = [randn(ComplexF64, nvariables(F, parameters=parameters))]
+    elseif isa(startsolutions, AbstractVector{<:Number})
+        startsolutions = [startsolutions]
     end
     ParameterSystemInput(F, parameters, p₁, p₀, startsolutions, γ₁, γ₀)
 end
 
 function input(H::AbstractHomotopy, startsolutions)
     check_homogenous_degrees(FixedHomotopy(H, rand()))
+    if isa(startsolutions, AbstractVector{<:Number})
+        startsolutions = [startsolutions]
+    end
     HomotopyInput(H, startsolutions)
 end

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -62,13 +62,13 @@ flatten(a::Tuple, b::Tuple) = (a..., b...)
 #####################
 # Monodromy Options #
 #####################
-const monodromy_options_allowed_keywords = [:accuracy, :done_callback,
+const monodromy_options_allowed_keywords = [:identical_tol, :done_callback,
     :group_action,:group_actions, :group_action_on_all_nodes,
     :parameter_sampler, :equivalence_classes, :complex_conjugation, :target_solutions_count, :timeout,
     :minimal_number_of_solutions, :maximal_number_of_iterations_without_progress]
 
 struct MonodromyOptions{F1<:Function, F2<:Tuple, F3<:Function}
-    accuracy::Float64
+    identical_tol::Float64
     done_callback::F1
     group_actions::GroupActions{F2}
     group_action_on_all_nodes::Bool
@@ -83,7 +83,7 @@ struct MonodromyOptions{F1<:Function, F2<:Tuple, F3<:Function}
 end
 
 function MonodromyOptions(isrealsystem;
-    accuracy::Float64=1e-6,
+    identical_tol::Float64=1e-6,
     done_callback=always_false,
     group_action=nothing,
     group_actions= group_action === nothing ? nothing : GroupActions(group_action),
@@ -103,7 +103,7 @@ function MonodromyOptions(isrealsystem;
        actions = GroupActions(group_actions)
     end
 
-    MonodromyOptions(accuracy, done_callback, actions,
+    MonodromyOptions(identical_tol, done_callback, actions,
         group_action_on_all_nodes, parameter_sampler, equivalence_classes, complex_conjugation,
         target_solutions_count == nothing ? typemax(Int) : target_solutions_count,
         float(timeout),
@@ -337,7 +337,7 @@ end
 function Loop(p₁::SVector, x::AbstractVector, nnodes::Int, options::MonodromyOptions; kwargs...)
     loop = Loop(p₁, first(x), nnodes, options; kwargs...)
     for xᵢ ∈ x
-        add!(loop.nodes[1], xᵢ; tol=options.accuracy)
+        add!(loop.nodes[1], xᵢ; tol=options.identical_tol)
     end
     loop
 end
@@ -590,7 +590,7 @@ by monodromy techniques. This makes loops in the parameter space of `F` to find 
 * `group_action=nothing`: A function taking one solution and returning other solutions if there is a constructive way to obtain them, e.g. by symmetry.
 * `strategy`: The strategy used to create loops. If `F` only depends linearly on `p` this will be [`Petal`](@ref). Otherwise this will be [`Triangle`](@ref) with weights if `F` is a real system.
 * `showprogress=true`: Enable a progress meter.
-* `accuracy::Float64=1e-6`: The tolerance with which it is decided whether two solutions are identical.
+* `identical_tol::Float64=1e-6`: The tolerance with which it is decided whether two solutions are identical.
 * `group_actions=nothing`: If there is more than one group action you can use this to chain the application of them. For example if you have two group actions `foo` and `bar` you can set `group_actions=[foo, bar]`. See [`GroupActions`](@ref) for details regarding the application rules.
 * `group_action_on_all_nodes=false`: By default the group_action(s) are only applied on the solutions with the main parameter `p`. If this is enabled then it is applied for every parameter `q`.
 * `parameter_sampler=independent_normal`: A function taking the parameter `p` and returning a new random parameter `q`. By default each entry of the parameter vector is drawn independently from the univariate normal distribution.
@@ -756,7 +756,7 @@ function empty_queue!(queue, loop::Loop, C::MonodromyCache, options::MonodromyOp
 end
 
 function verified_affine_vector(C::MonodromyCache, ŷ, x, options)
-    result = newton!(C.out, C.F, ŷ, options.accuracy, 3, true, C.newton_cache)
+    result = newton!(C.out, C.F, ŷ, options.identical_tol, 3, true, C.newton_cache)
 
     if result.retcode == converged
         return affine_chart(x, C.out)
@@ -787,14 +787,14 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
     end
 
 
-    if !iscontained(node, y; tol=options.accuracy)
+    if !iscontained(node, y; tol=options.identical_tol)
         if options.equivalence_classes
             if equivalence_class_contained(node, y, options)
                 return :incomplete
             end
         end
 
-        add!(node, y; tol=options.accuracy)
+        add!(node, y; tol=options.identical_tol)
         # If we are on the main node check whether we have a real root.
         node.main_node && checkreal!(stats, y)
         # Check if we are done
@@ -807,7 +807,7 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
         if options.complex_conjugation && node.main_node
             ȳ = conj.(y)
             if !equivalence_class_contained(node, ȳ, options)
-                add!(node, ȳ; tol=options.accuracy)
+                add!(node, ȳ; tol=options.identical_tol)
                 # Check if we are done
                 isdone(node, ȳ, options) && return :done
                 # Schedule new job
@@ -821,7 +821,7 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
         #    group actions `node.points !== nothing`
         if !options.equivalence_classes && node.points !== nothing
             for yᵢ in options.group_actions(y)
-                if add!(node, yᵢ; tol=options.accuracy)
+                if add!(node, yᵢ; tol=options.identical_tol)
                     node.main_node && checkreal!(stats, yᵢ)
                     # Check if we are done
                     node.main_node && isdone(node, yᵢ, options) && return :done
@@ -836,7 +836,7 @@ end
 
 function equivalence_class_contained(node, y, options)
     for yᵢ in options.group_actions(y)
-        if iscontained(node, yᵢ, tol=options.accuracy)
+        if iscontained(node, yᵢ, tol=options.identical_tol)
             # equivalence class already existing
             return true
         end

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -569,11 +569,11 @@ MonodromyCache{FT<:FixedHomotopy, Tracker<:PathTracker, NC<:NewtonCache}
 
 Cache for monodromy loops.
 """
-struct MonodromyCache{FT<:FixedHomotopy, Tracker<:PathTracker, NC<:NewtonCache, T<:Number, N}
+struct MonodromyCache{FT<:FixedHomotopy, Tracker<:PathTracker, NC<:NewtonCache, AV<:AbstractVector}
     F::FT
     tracker::Tracker
     newton_cache::NC
-    out::ProjectiveVectors.PVector{T,N}
+    out::AV
 end
 
 

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -776,7 +776,10 @@ function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop,
 
     node = loop.nodes[job.edge.target]
 
-    if node.main_node && !affine_tracking(C.tracker)
+    if node.main_node && (
+        !affine_tracking(C.tracker) ||
+        (affine_tracking(C.tracker) && accuracy(C.tracker) > options.identical_tol)
+       )
         y = verified_affine_vector(C, currx(C.tracker), job.x, options)
         #is the solution at infinity?
         if y === nothing

--- a/src/path_tracking.jl
+++ b/src/path_tracking.jl
@@ -156,7 +156,11 @@ end
 
 function PathTrackerState(x₁::AbstractVector, t₁, t₀, options::PathTrackerOptions, patch::Union{Nothing, AbstractAffinePatchState}=nothing)
     x, x̂, x̄ = copy(x₁), copy(x₁), copy(x₁)
-    ẋ = copy(x₁.data)
+    if x₁ isa PVector
+        ẋ = copy(x₁.data)
+    else
+        ẋ = copy(x₁)
+    end
     η = ω = NaN
     segment = ComplexSegment(promote(complex(t₁), complex(t₀))...)
     s = 0.0
@@ -261,9 +265,8 @@ end
 
 Construct a [`PathTracker`](@ref) from the given `problem`.
 """
-function PathTracker(prob::ProjectiveProblem, x₁, t₁, t₀; kwargs...)
-    y₁ = embed(prob, x₁)
-    PathTracker(prob.homotopy, y₁, t₁, t₀; kwargs...)
+function PathTracker(prob::AbstractProblem, x₁, t₁, t₀; kwargs...)
+    PathTracker(prob.homotopy, embed(prob, x₁), t₁, t₀; kwargs...)
 end
 
 # Tracking in Projective Space

--- a/src/path_tracking.jl
+++ b/src/path_tracking.jl
@@ -659,7 +659,7 @@ end
 Returns `true` if the path tracker tracks in affine space. If `false` then then the path tracker
 tracks in some affine chart of the projective space.
 """
-affine_tracking(tracker::PathTracker) = tracker.affine_patch === nothing
+affine_tracking(tracker::PathTracker) = !isa(tracker.state.x, ProjectiveVectors.PVector)
 
 #################
 ## Query State ##

--- a/src/path_tracking.jl
+++ b/src/path_tracking.jl
@@ -1,5 +1,5 @@
 export PathTracker, PathTrackerResult, PathTrackerStatus,
-        pathtracker, pathtracker_startsolutions,
+        pathtracker, pathtracker_startsolutions, affine_tracking,
         track, track!, setup!, iterator,
         currx, currt, currΔt, curriters, currstatus, accuracy, max_corrector_iters,
         max_step_size , refinement_accuracy, refinement_max_iters,
@@ -652,6 +652,14 @@ function Base.iterate(tracker::PathTracker, state=nothing)
         nothing
     end
 end
+
+"""
+    affine_tracking(tracker)
+
+Returns `true` if the path tracker tracks in affine space. If `false` then then the path tracker
+tracks in some affine chart of the projective space.
+"""
+affine_tracking(tracker::PathTracker) = tracker.affine_patch === nothing
 
 #################
 ## Query State ##

--- a/src/predictors/pade21.jl
+++ b/src/predictors/pade21.jl
@@ -6,10 +6,10 @@ export Pade21
 This uses a Padé-approximation of type (2,1) for prediction.
 """
 struct Pade21 <: AbstractPredictor end
-struct Pade21Cache{T,N} <: AbstractPredictorCache
+struct Pade21Cache{T, AV<:AbstractVector{T}} <: AbstractPredictorCache
     x²::Vector{T}
     x³::Vector{T}
-    x_h::PVector{T,N}
+    x_h::AV
 
     u::Vector{T}
     u₁::Vector{T}

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -114,14 +114,14 @@ General options:
 
 Pathtracking specific:
 * `corrector::AbstractCorrector`: The corrector used during in the predictor-corrector scheme. The default is [`NewtonCorrector`](@ref).
-* `corrector_maxiters=2`: The maximal number of correction steps in a single step.
+* `max_corrector_iters=2`: The maximal number of correction steps in a single step.
+* `accuracy=1e-7`: The accuracy used to track a value.
 * `predictor::AbstractPredictor`: The predictor used during in the predictor-corrector scheme. The default is [`Heun`](@ref).
-* `refinement_maxiters=corrector_maxiters`: The maximal number of correction steps used to refine the final value.
-* `refinement_tol=1e-8`: The precision used to refine the final value.
-* `tol=1e-7`: The precision used to track a value.
-* `initial_steplength=0.1`: The initial step size for the predictor.
-* `minimal_steplength=1e-14`: The minimal step size. If the size of step is below this the path is considered failed.
-* `maxiters=1000`: The maximal number of steps per path.
+* `refinement_max_iters=max_corrector_iters`: The maximal number of correction steps used to refine the final value.
+* `refinement_accuracy=1e-8`: The precision used to refine the final value.
+* `initial_step_size=0.1`: The initial step size for the predictor.
+* `min_step_size=1e-14`: The minimal step size. If the size of step is below this the path is considered failed.
+* `max_steps=1000`: The maximal number of steps per path.
 
 Endgame specific options
 * `cauchy_loop_closed_tolerance=1e-3`: The tolerance for which is used to determine whether a loop is closed. The distance between endpoints is normalized by the maximal difference between any point in the loop and the starting point.

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -244,10 +244,10 @@ function splitkwargs(kwargs, supported_keywords)
 end
 
 
-start_solution_sample(xs) = first(xs) |> promote_start_solution
-start_solution_sample(x::AbstractVector{<:Number}) = promote_start_solution(x )
-
+start_solution_sample(xs) = promote_start_solution(first(xs))
+start_solution_sample(x::AbstractVector{<:Number}) = promote_start_solution(x)
 promote_start_solution(x::AbstractVector{ComplexF64}) = x
+promote_start_solution(x::SVector) = map(xᵢ -> first(promote(xᵢ, 0.0im)), x)
 function promote_start_solution(x)
     x_new =similar(x, promote_type(eltype(x), ComplexF64), length(x))
     copyto!(x_new, x)

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -55,7 +55,7 @@ end
         @test monodromy_solve(F, result.solutions, p₀, parameters=p,
                     target_solutions_count=21).returncode == :success
 
-        # Test stop heuristic using too hight target_solutions_count
+        # Test stop heuristic using too high target_solutions_count
         result = monodromy_solve(F, x₀, p₀, parameters=p, target_solutions_count=25)
         @test result.returncode == :heuristic_stop
         # Test stop heuristic with no target solutions count
@@ -109,10 +109,15 @@ end
         # equivalence classes
         result = monodromy_solve(F, x₀, p₀, parameters=p,
             equivalence_classes=true,
+            maximal_number_of_iterations_without_progress=100,
             group_action=roots_of_unity)
         @test length(result.solutions) == 7
         # Test that equivalence classes are on by default if we supply a group action
-        result = monodromy_solve(F, x₀, p₀, parameters=p, group_action=roots_of_unity)
+        result = monodromy_solve(F, x₀, p₀, parameters=p, group_action=roots_of_unity, maximal_number_of_iterations_without_progress=100)
+        @test length(result.solutions) == 7
+
+        # Test affine tracking
+        result = monodromy_solve(F, x₀, p₀, parameters=p, affine=true, group_action=roots_of_unity, maximal_number_of_iterations_without_progress=100)
         @test length(result.solutions) == 7
     end
 end

--- a/test/path_tracking_test.jl
+++ b/test/path_tracking_test.jl
@@ -49,6 +49,7 @@
 
         tracker, starts = pathtracker_startsolutions(F, [1.0, 1.0 + 0.0*im], parameters=p, p₁=[1, 0], p₀=[2, 4],
                     affine=true)
+        @test affine_tracking(tracker) == true
         res = track(tracker, starts[1], 1.0, 0.0)
         @test res.returncode == PathTrackerStatus.success
         @test isa(res.x, Vector{ComplexF64})

--- a/test/path_tracking_test.jl
+++ b/test/path_tracking_test.jl
@@ -6,15 +6,15 @@
 
         @test_nowarn currΔt(t1)
 
-        rtol = refinement_tol(t1)
-        @test_nowarn set_refinement_tol!(t1, 5e-5)
-        @test refinement_tol(t1) == 5e-5
-        set_refinement_tol!(t1, rtol)
+        raccuracy = refinement_accuracy(t1)
+        @test_nowarn set_refinement_accuracy!(t1, 5e-5)
+        @test refinement_accuracy(t1) == 5e-5
+        set_refinement_accuracy!(t1, raccuracy)
 
-        rmaxiter = refinement_maxiters(t1)
-        @test_nowarn set_refinement_maxiters!(t1, 11)
-        @test refinement_maxiters(t1) == 11
-        set_refinement_maxiters!(t1, rmaxiter)
+        rmaxiter = refinement_max_iters(t1)
+        @test_nowarn set_refinement_max_iters!(t1, 11)
+        @test refinement_max_iters(t1) == 11
+        set_refinement_max_iters!(t1, rmaxiter)
 
         @test t1 isa PathTracker
         @test length(currx(t1)) == 7
@@ -71,7 +71,7 @@
         @polyvar x[1:3]
         F = A * x - b
 
-        tracker, start_sols = pathtracker_startsolutions(F, patch=RandomPatch(), maxiters=10)
+        tracker, start_sols = pathtracker_startsolutions(F, patch=RandomPatch(), max_steps=10)
         s = first(start_sols)
         result = track(tracker, s, 1.0, 0.0)
         @test result.returncode == PathTrackerStatus.success
@@ -138,9 +138,9 @@
         typeof(first(iterator(tracker, s, 1.0, 0.0; affine=false))) ==
             Tuple{ProjectiveVectors.PVector{ComplexF64, 1}, Float64}
 
-        @test maximal_step_size(tracker) == Inf
-        set_maximal_step_size!(tracker, 0.01)
-        @test maximal_step_size(tracker) == 0.01
+        @test max_step_size(tracker) == Inf
+        set_max_step_size!(tracker, 0.01)
+        @test max_step_size(tracker) == 0.01
 
         length(collect(iterator(tracker, s, 1.0, 0.0))) == 101
     end

--- a/test/path_tracking_test.jl
+++ b/test/path_tracking_test.jl
@@ -47,11 +47,17 @@
         F = [x^2-a, x*y-a+b]
         p = [a, b]
 
-        tracker, starts = pathtracker_startsolutions(F, [[1.0, 1.0 + 0.0*im]], parameters=p, p₁=[1, 0], p₀=[2, 4],
+        tracker, starts = pathtracker_startsolutions(F, [1.0, 1.0 + 0.0*im], parameters=p, p₁=[1, 0], p₀=[2, 4],
                     affine=true)
-
         res = track(tracker, starts[1], 1.0, 0.0)
         @test res.returncode == PathTrackerStatus.success
+        @test isa(res.x, Vector{ComplexF64})
+        @test length(res.x) == 2
+
+        x = @SVector [1.0, 1.0 + 0.0*im]
+        tracker, starts = pathtracker_startsolutions(F, x, parameters=p, p₁=[1, 0], p₀=[2, 4], affine=true)
+        @test length(starts) == 1
+        res = track(tracker, starts[1], 1.0, 0.0)
         @test isa(res.x, Vector{ComplexF64})
         @test length(res.x) == 2
     end

--- a/test/path_tracking_test.jl
+++ b/test/path_tracking_test.jl
@@ -42,6 +42,20 @@
         @test out == R.x
     end
 
+    @testset "Affine tracking" begin
+        @polyvar x a y b
+        F = [x^2-a, x*y-a+b]
+        p = [a, b]
+
+        tracker, starts = pathtracker_startsolutions(F, [[1.0, 1.0 + 0.0*im]], parameters=p, p₁=[1, 0], p₀=[2, 4],
+                    affine=true)
+
+        res = track(tracker, starts[1], 1.0, 0.0)
+        @test res.returncode == PathTrackerStatus.success
+        @test isa(res.x, Vector{ComplexF64})
+        @test length(res.x) == 2
+    end
+
     @testset "Allocations" begin
         F = equations(katsura(5))
         tracker, start_sols = pathtracker_startsolutions(F)

--- a/test/problem_test.jl
+++ b/test/problem_test.jl
@@ -30,6 +30,10 @@
         [x^2+y^2+z^2, x^4+y^4+z^4], [x^3+z^3,y^3-z^3], [rand(ComplexF64, 3)]))
     @test homvars(P) == nothing
 
+    _, starts = problem_startsolutions(HC.input(
+        [x^2+y^2+z^2, x^4+y^4+z^4], [x^3+z^3,y^3-z^3], rand(ComplexF64, 3)))
+    @test length(starts) == 1
+
     P, _ = problem_startsolutions(StartTargetInput(
         [x^2+y^2+z^2, x^4+y^4+z^4], [x^3+z^3,y^3-z^3], [rand(ComplexF64, 3)]), homvar=z)
     @test homvars(P) == (3,)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, LinearAlgebra, Random
-using DynamicPolynomials, HomotopyContinuation
+using DynamicPolynomials, HomotopyContinuation, StaticArrays
 import TreeViews, ProjectiveVectors, PolynomialTestSystems
 
 import PolynomialTestSystems: cyclic, katsura, equations, ipp2, heart

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -36,7 +36,7 @@
 
         # Simple step size
         F = equations(katsura(5))
-        @test nfinite(solve(F, simple_step_size=true, threading=false)) == 32
+        @test nfinite(solve(F, simple_step_size_alg=true, threading=false)) == 32
 
         # scaling
         F = equations(katsura(5))
@@ -45,7 +45,7 @@
         @test nfinite(solve(F, homotopy=StraightLineHomotopy)) == 32
         result = solve(F, predictor=Euler(), homotopy=StraightLineHomotopy)
         @test nresults(result) == 32
-        @test nfinite(solve(F, tol=1e-5)) == 32
+        @test nfinite(solve(F, accuracy=1e-5)) == 32
 
         result = solve(F)
         @test nfinite(result) == 32
@@ -134,7 +134,7 @@
     @testset "Path Crossing" begin
         # This tests that we indeed detect path crossings
         F = equations(cyclic(6))
-        tracker, start_sols = pathtracker_startsolutions(F, tol=1e-3, corrector_maxiters=5, seed=123512)
+        tracker, start_sols = pathtracker_startsolutions(F, accuracy=1e-3, max_corrector_iters=5, seed=123512)
         tracked_paths = map(start_sols) do x
             track(tracker, x, 1.0, 0.1)
         end


### PR DESCRIPTION
With these changes, our PathTracker doesn't care anymore where it tracks paths. Both, projective space and affine space, are supported.
For now this can be enabled with an `affine=true` flag in the `problem_startsolutions` pipeline and in monodromy.
I also used this to revamp the names of the different options to the path tracker. So this is quite breaking, but I now feels these reflect things better:

Old options:
```julia
refinement_tol=1e-8,
corrector_maxiters::Int=2,
refinement_maxiters=corrector_maxiters,
maxiters=10_000,
initial_steplength=0.1,
initial_step_size=initial_steplength,
minimal_steplength=1e-14,
minimal_step_size=minimal_steplength,
maximal_steplength=Inf,
maximal_step_size=maximal_steplength,
simple_step_size=false,
update_patch=true
```

New options:
```julia
accuracy=1e-7,
refinement_accuracy=1e-8,
max_corrector_iters::Int=2,
refinement_max_iters=max_corrector_iters,
max_steps=1_000,
initial_step_size=0.1,
min_step_size=1e-14,
max_step_size=Inf,
simple_step_size_alg=false,
update_patch=true,
```