### PR TITLE
Make it easier to use monodromy

### DIFF
--- a/docs/src/solving.md
+++ b/docs/src/solving.md
@@ -100,3 +100,9 @@ of group actions. These will be internally transformed into `GroupActions`.
 ```@docs
 GroupActions
 ```
+
+To help with the more common group actions we provide some helper functions:
+
+```@docs
+SymmetricGroup
+```

--- a/docs/src/solving.md
+++ b/docs/src/solving.md
@@ -106,3 +106,9 @@ To help with the more common group actions we provide some helper functions:
 ```@docs
 SymmetricGroup
 ```
+
+
+### Helper functions
+```@docs
+parameters
+```

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -203,7 +203,7 @@ export Triangle, Petal
 #####################
 
 """
-    Node(p::SVector, x::AbstractVector; store_points=true, is_main_node=false)
+    Node(p, x::AbstractVector; store_points=true, is_main_node=false)
 
 Create a node with a parameter from the same type as `p` and expecting
 points with tthe same type as `x`. If `stores_points` is `true` a `UniquePoints`
@@ -299,17 +299,17 @@ end
 # Loop data structure
 #######################
 """
-    Loop(p::SVector, x::AbstractVector{<:Number}, nnodes::Int, options::MonodromyOptions; usegamma=true)
+    Loop(p, x::AbstractVector{<:Number}, nnodes::Int, options::MonodromyOptions; usegamma=true)
 
 Construct a loop using `nnodes` nodes with parameters of the type of `p` and solutions
 of the type of `x`. `usegamma` refers to the use weights on the edges. See also
 [`Edge`](@ref).
 
-    Loop(p::SVector, x::AbstractVector, nnodes::Int, options::MonodromyOptions; usegamma=true)
+    Loop(p, x::AbstractVector, nnodes::Int, options::MonodromyOptions; usegamma=true)
 
 Construct the loop and add all points in `x` to it.
 
-    Loop(style::LoopStyle, p::SVector, x::AbstractVector, options::MonodromyOptions)
+    Loop(style::LoopStyle, p, x::AbstractVector, options::MonodromyOptions)
 
 Construct a loop using the defined style `style` with parameters of the type of `p` and solutions
 of the type of `x`.
@@ -319,7 +319,7 @@ struct Loop{N<:Node}
     edges::Vector{Edge}
 end
 
-function Loop(p₁::SVector, x₁::AbstractVector{<:Number}, nnodes::Int, options::MonodromyOptions; usegamma=true)
+function Loop(p₁, x₁::AbstractVector{<:Number}, nnodes::Int, options::MonodromyOptions; usegamma=true)
     n₁ = Node(p₁, x₁, is_main_node = true)
     nodes = [n₁]
     store_points = options.group_action_on_all_nodes && has_group_actions(options)
@@ -333,7 +333,7 @@ function Loop(p₁::SVector, x₁::AbstractVector{<:Number}, nnodes::Int, option
 
     Loop(nodes, loop)
 end
-function Loop(p₁::SVector, x::AbstractVector, nnodes::Int, options::MonodromyOptions; kwargs...)
+function Loop(p₁, x::AbstractVector, nnodes::Int, options::MonodromyOptions; kwargs...)
     loop = Loop(p₁, first(x), nnodes, options; kwargs...)
     for xᵢ ∈ x
         add!(loop.nodes[1], xᵢ; tol=options.identical_tol)
@@ -387,7 +387,7 @@ struct Triangle <: LoopStyle
 end
 Triangle(;useweights=true) = Triangle(useweights)
 
-function Loop(strategy::Triangle, p::SVector, x::AbstractVector, options::MonodromyOptions)
+function Loop(strategy::Triangle, p, x::AbstractVector, options::MonodromyOptions)
     Loop(p, x, 3, options, usegamma=strategy.useweights)
 end
 
@@ -398,7 +398,7 @@ A petal is a loop consisting of the main node and one other node connected
 by two edges with different random weights.
 """
 struct Petal <: LoopStyle end
-function Loop(strategy::Petal, p::SVector, x::AbstractVector, options::MonodromyOptions)
+function Loop(strategy::Petal, p, x::AbstractVector, options::MonodromyOptions)
     Loop(p, x, 2, options, usegamma=true)
 end
 
@@ -608,10 +608,10 @@ by monodromy techniques. This makes loops in the parameter space of `F` to find 
 * `timeout=float(typemax(Int))`: The maximal number of *seconds* the computation is allowed to run.
 * `minimal_number_of_solutions`: The minimal number of solutions before a stopping heuristic is applied. By default this is half of `target_solutions_count` if applicable otherwise 2.
 """
-function monodromy_solve(F::Vector{<:MP.AbstractPolynomialLike}, solution::Vector{<:Number}, p₀::AbstractVector{<:Number}; kwargs...)
+function monodromy_solve(F::Vector{<:MP.AbstractPolynomialLike}, solution::Vector{<:Number}, p₀::AbstractVector{TP}; kwargs...) where {TP}
     monodromy_solve(F, [solution], p₀; kwargs...)
 end
-function monodromy_solve(F::Vector{<:MP.AbstractPolynomialLike}, solutions::Vector{<:AbstractVector{<:Number}}, p₀::AbstractVector{<:Number}; kwargs...)
+function monodromy_solve(F::Vector{<:MP.AbstractPolynomialLike}, solutions::Vector{<:AbstractVector{<:Number}}, p₀::AbstractVector{TP}; kwargs...) where {TP}
     monodromy_solve(F, static_solutions(solutions), p₀; kwargs...)
 end
 function monodromy_solve(F::Vector{<:MP.AbstractPolynomialLike{TC}},
@@ -622,7 +622,7 @@ function monodromy_solve(F::Vector{<:MP.AbstractPolynomialLike{TC}},
         showprogress=true,
         kwargs...) where {TC, TP, NVars}
 
-    if length(p₀) ≠ length(parameters)
+    if length(p) ≠ length(parameters)
         throw(ArgumentError("Number of provided parameters doesn't match the length of initially provided parameter `p₀`."))
     end
 

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -122,13 +122,12 @@ has_group_actions(options::MonodromyOptions) = !(options.group_actions isa Group
 
 
 """
-    independent_normal(p::SVector{N, T}) where {N, T}
+    independent_normal(p::AbstractVector{T}) where {T}
 
-Sample a `SVector{N, T}` where each entries is drawn independently from the univariate normal distribution.
+Sample a vector where each entries is drawn independently from the univariate normal distribution.
 """
-function independent_normal(p::SVector{N, T}) where {N, T}
-    @SVector randn(T, N)
-end
+independent_normal(p::SVector{N, T}) where {N, T} = @SVector randn(T, N)
+independent_normal(p::AbstractVector{T}) where {T} = randn(T, length(p))
 
 ##########################
 ## Monodromy Statistics ##
@@ -210,26 +209,26 @@ Create a node with a parameter from the same type as `p` and expecting
 points with tthe same type as `x`. If `stores_points` is `true` a `UniquePoints`
 data structure is allocated to keep track of all known solutions of this node.
 """
-struct Node{N, T, UP<:UniquePoints}
-    p::SVector{N, T} # maybe just a Vector?
+struct Node{T, UP<:UniquePoints}
+    p::Vector{T}
     points::Union{Nothing, UP}
     # Metadata / configuration
     main_node::Bool
 end
 
-function Node(p::SVector{N, T}, x::AbstractVector; store_points=true, is_main_node=false) where {N, T}
+function Node(p::AbstractVector{T}, x::AbstractVector; store_points=true, is_main_node=false) where {T}
     uniquepoints = UniquePoints(typeof(x))
     if store_points == false
-        Node{N, T, typeof(uniquepoints)}(p, nothing, is_main_node)
+        Node{T, typeof(uniquepoints)}(Vector(p), nothing, is_main_node)
     else
-        Node(p, uniquepoints, is_main_node)
+        Node(Vector(p), uniquepoints, is_main_node)
     end
 end
-function Node(p::SVector{N, T}, node::Node{N,T,UP}; store_points=true, is_main_node=false) where {N, T, UP}
+function Node(p::AbstractVector{T}, node::Node{T,UP}; store_points=true, is_main_node=false) where {T, UP}
     if store_points == false
-        Node{N, T, UP}(p, nothing, is_main_node)
+        Node{T, UP}(Vector(p), nothing, is_main_node)
     else
-        Node{N, T, UP}(p, UniquePoints(UP), is_main_node)
+        Node{T, UP}(Vector(p), UniquePoints(UP), is_main_node)
     end
 end
 

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -489,7 +489,7 @@ function TreeViews.nodelabel(io::IO, x::MonodromyResult, i::Int, ::MIME"applicat
     elseif i == 4
         print(io, "Tracked Paths")
     elseif i == 5
-        print(io, "Paramters")
+        print(io, "Parameters")
     end
 end
 function TreeViews.treenode(r::MonodromyResult, i::Integer)

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -1,4 +1,43 @@
-export infinity_norm, infinity_distance, fubini_study
+export SymmetricGroup, infinity_norm, infinity_distance, fubini_study
+
+"""
+    SymmetricGroup(n)
+
+Group action of the symmetric group S(n). This does not contain the identity element.
+"""
+struct SymmetricGroup{N,M}
+    permutations::NTuple{M, SVector{N,Int}} # We should get rid of the necessary of a tuple
+end
+SymmetricGroup(N::Int) = SymmetricGroup(permutations(Val(N)))
+function permutations(::Val{N}) where {N}
+    s = StaticArrays.MVector{N}(1:N)
+    perms = Vector{SVector{N, Int}}()
+    while true
+        i = N - 1
+        while i>=1 && s[i] >= s[i+1]
+            i -= 1
+        end
+        if i > 0
+            j = N
+            while j > i && s[i] >= s[j]
+                j -= 1
+            end
+            s[i], s[j] = s[j], s[i]
+            reverse!(s, i+1)
+        else
+            s[1] = N+1
+        end
+
+        s[1] > N && break
+        push!(perms, SVector(s))
+    end
+    tuple(perms...)
+end
+
+Base.eltype(::Type{SymmetricGroup{N}}) where {N} = SVector{N, Int}
+Base.length(p::SymmetricGroup{N}) where {N} = length(p.permutations)
+Base.iterate(p::SymmetricGroup) = iterate(p.permutations)
+Base.iterate(p::SymmetricGroup, s) = iterate(p.permutations, s)
 
 """
     deprecatekwarg(oldkw, newkw)

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -67,7 +67,9 @@ end
 
 
         # By group_actions=nothing we force that complex conjugation is not used.
-        result2 = monodromy_solve(F, x₀, p₀, parameters=p, target_solutions_count=21, complex_conjugation=false, maximal_number_of_iterations_without_progress=100)
+        result2 = monodromy_solve(F, x₀, p₀, parameters=p,
+                        target_solutions_count=21, complex_conjugation=false,
+                        maximal_number_of_iterations_without_progress=100)
         @test result2.returncode == :success
 
         result = monodromy_solve(F, x₀, p₀, parameters=p, target_solutions_count=21,
@@ -113,11 +115,15 @@ end
             group_action=roots_of_unity)
         @test length(result.solutions) == 7
         # Test that equivalence classes are on by default if we supply a group action
-        result = monodromy_solve(F, x₀, p₀, parameters=p, group_action=roots_of_unity, maximal_number_of_iterations_without_progress=100)
+        result = monodromy_solve(F, x₀, p₀, parameters=p,
+                            group_action=roots_of_unity,
+                            maximal_number_of_iterations_without_progress=200)
         @test length(result.solutions) == 7
 
         # Test affine tracking
-        result = monodromy_solve(F, x₀, p₀, parameters=p, affine=true, group_action=roots_of_unity, maximal_number_of_iterations_without_progress=100)
+        result = monodromy_solve(F, x₀, p₀, parameters=p, affine=true,
+                        group_action=roots_of_unity,
+                        maximal_number_of_iterations_without_progress=200)
         @test length(result.solutions) == 7
     end
 

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -170,9 +170,10 @@ end
 
         R = monodromy_solve(f - p, y₀, p₀;
         			parameters=p, group_action=relabeling,
-        			maximal_number_of_iterations_without_progress=100,
+        			maximal_number_of_iterations_without_progress=150,
         			target_solutions_count=225,
-        			parameter_sampler=last ∘ sample_moments)
+        			parameter_sampler=last ∘ sample_moments,
+                    showprogress=false)
 
         @test length(solutions(R)) == 225
     end


### PR DESCRIPTION
This makes thing a little bit easier to use with monodromy. 

* Parameter sampler don't need to return a `SVector` anymore.
* Store the start parameters also in the `MonodromyResult`.
* I defined `SymmetricGroup` to make it easier to work with permutations / relabelings.