### PR TITLE
Allow AbstractSystems in monodromy

### DIFF
--- a/src/input.jl
+++ b/src/input.jl
@@ -7,7 +7,7 @@ export AbstractInput,
 const Inputs = Union{<:AbstractSystem, <:MPPolys, <:Composition}
 const MPPolyInputs = Union{<:MPPolys, <:Composition}
 
-const input_supported_keywords = [:parameters, :startparameters, :targetparameters,
+const input_supported_keywords = [:parameters, :generic_parameters, :startparameters, :targetparameters,
                             :targetgamma, :startgamma, :p₁, :p₀, :γ₁, :γ₀]
 
 
@@ -87,7 +87,7 @@ end
 Construct an `AbstractInput`.
 """
 function input(F::MPPolyInputs; parameters=nothing, kwargs...)
-    # if parameters === nothing this is actually the
+    # if parameters !== nothing this is actually the
     # input constructor for a parameter homotopy, but no startsolutions
     # are provided
     if parameters !== nothing
@@ -121,17 +121,23 @@ function input(G::MPPolyInputs, F::MPPolyInputs, startsolutions=nothing)
     StartTargetInput(G, F, startsolutions)
 end
 
-function input(F::Inputs, startsolutions;
+
+# need
+input(F::MPPolyInputs, starts; kwargs...) = parameter_homotopy(F, starts; kwargs...)
+input(F::AbstractSystem, starts; kwargs...) = parameter_homotopy(F, starts; kwargs...)
+
+function parameter_homotopy(F::Inputs, startsolutions;
     parameters=(isa(F, AbstractSystem) ? nothing : error(ArgumentError("You need to pass `parameters=...` as a keyword argument."))),
-    startparameters=nothing, p₁ = startparameters,
-    targetparameters=nothing, p₀ = targetparameters,
+    generic_parameters=nothing,
+    startparameters=generic_parameters, p₁ = startparameters,
+    targetparameters=generic_parameters, p₀ = targetparameters,
     startgamma=nothing, γ₁ = startgamma,
     targetgamma=nothing, γ₀ = targetgamma)
 
     if p₁ === nothing
-        error("!`startparameters=` or `p₁=` need to be passed as argument")
+        error("You need to pass `generic_parameters=`, `startparameters=` or `p₁=` as a keyword argument")
     elseif p₀ === nothing
-        error("!`targetparameters=` or `p₀=` need to be passed as argument")
+        error("`targetparameters=` or `p₀=` need to be passed as a keyword argument.")
     end
 
     if length(p₁) != length(p₀) || (parameters !== nothing && length(parameters) != length(p₀))

--- a/src/input.jl
+++ b/src/input.jl
@@ -67,12 +67,12 @@ end
 
 Construct a `ParameterSystemInput`.
 """
-struct ParameterSystemInput{P<:MPPolyInputs, V<:MP.AbstractVariable} <: AbstractInput
-    system::P
-    parameters::Vector{V}
+struct ParameterSystemInput{S<:Inputs} <: AbstractInput
+    system::S
+    parameters::Union{Nothing, Vector{<:MP.AbstractVariable}}
     p₁::AbstractVector
     p₀::AbstractVector
-    startsolutions::AbstractVector
+    startsolutions
     γ₁::Union{Nothing, ComplexF64}
     γ₀::Union{Nothing, ComplexF64}
 end
@@ -121,8 +121,8 @@ function input(G::MPPolyInputs, F::MPPolyInputs, startsolutions=nothing)
     StartTargetInput(G, F, startsolutions)
 end
 
-function input(F::MPPolyInputs, startsolutions;
-    parameters::Vector{<:MP.AbstractVariable}=error("parameters not defined"),
+function input(F::Inputs, startsolutions;
+    parameters=(isa(F, AbstractSystem) ? nothing : error(ArgumentError("You need to pass `parameters=...` as a keyword argument."))),
     startparameters=nothing, p₁ = startparameters,
     targetparameters=nothing, p₀ = targetparameters,
     startgamma=nothing, γ₁ = startgamma,
@@ -134,10 +134,10 @@ function input(F::MPPolyInputs, startsolutions;
         error("!`targetparameters=` or `p₀=` need to be passed as argument")
     end
 
-    if !(length(parameters) == length(p₁) == length(p₀))
+    if length(p₁) != length(p₀) || (parameters !== nothing && length(parameters) != length(p₀))
         error("Number of parameters doesn't match!")
     end
-    if startsolutions === nothing
+    if startsolutions === nothing && parameters !== nothing
         startsolutions = [randn(ComplexF64, nvariables(F, parameters=parameters))]
     elseif isa(startsolutions, AbstractVector{<:Number})
         startsolutions = [startsolutions]

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -305,7 +305,7 @@ end
 # Parameter homotopy
 #####################
 
-function problem_startsolutions(prob::ParameterSystemInput, hominfo, seed; affine_tracking=false, system=SPSystem, kwargs...)
+function problem_startsolutions(prob::ParameterSystemInput{<:MPPolyInputs}, hominfo, seed; affine_tracking=false, system=SPSystem, kwargs...)
 	Prob = affine_tracking ? AffineProblem : ProjectiveProblem
 	if affine_tracking
 		variable_groups = VariableGroups(variables(prob.system; parameters=prob.parameters))
@@ -318,4 +318,15 @@ function problem_startsolutions(prob::ParameterSystemInput, hominfo, seed; affin
 	F̂ = construct_system(F, system; homvars=homvars, variables=vars, parameters=prob.parameters)
 	H = ParameterHomotopy(F̂, p₁=prob.p₁, p₀=prob.p₀, γ₁=prob.γ₁, γ₀=prob.γ₀)
 	Prob(H, variable_groups, seed; startsolutions_need_reordering=!affine_tracking), prob.startsolutions
+end
+
+function problem_startsolutions(prob::ParameterSystemInput{<:AbstractSystem}, hominfo, seed; affine_tracking=false, system=SPSystem, kwargs...)
+	n, N = size(prob.system)
+	H = ParameterHomotopy(prob.system, p₁=prob.p₁, p₀=prob.p₀, γ₁=prob.γ₁, γ₀=prob.γ₀)
+	variable_groups = VariableGroups(N, hominfo)
+	if affine_tracking
+		AffineProblem(H, variable_groups, seed; startsolutions_need_reordering=false), prob.startsolutions
+	else
+    	ProjectiveProblem(H, variable_groups, seed; startsolutions_need_reordering=false), prob.startsolutions
+	end
 end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -320,10 +320,17 @@ function problem_startsolutions(prob::ParameterSystemInput{<:MPPolyInputs}, homi
 	Prob(H, variable_groups, seed; startsolutions_need_reordering=!affine_tracking), prob.startsolutions
 end
 
-function problem_startsolutions(prob::ParameterSystemInput{<:AbstractSystem}, hominfo, seed; affine_tracking=false, system=SPSystem, kwargs...)
+function problem_startsolutions(prob::ParameterSystemInput{<:AbstractSystem}, hominfo, seed; affine_tracking=nothing, system=SPSystem, kwargs...)
 	n, N = size(prob.system)
 	H = ParameterHomotopy(prob.system, p₁=prob.p₁, p₀=prob.p₀, γ₁=prob.γ₁, γ₀=prob.γ₀)
 	variable_groups = VariableGroups(N, hominfo)
+
+	# We do not set affine tracking here, to handle the case that the input system
+	# is not homogenous.
+	if affine_tracking === nothing
+	   affine_tracking = compute_numerically_degrees(FixedHomotopy(H, rand())) === nothing
+   end
+
 	if affine_tracking
 		AffineProblem(H, variable_groups, seed; startsolutions_need_reordering=false), prob.startsolutions
 	else

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -128,6 +128,14 @@ end
                         target_solutions_count=7,
                         maximal_number_of_iterations_without_progress=200)
         @test length(result.solutions) == 7
+
+        # AbstractSystem as input
+        F_p = SPSystem(F; parameters=p)
+        result = monodromy_solve(F_p, x₀, p₀, affine_tracking=true,
+                        group_action=roots_of_unity,
+                        target_solutions_count=7,
+                        maximal_number_of_iterations_without_progress=200)
+        @test length(result.solutions) == 7
     end
 
     @testset "Method of Moments" begin

--- a/test/path_tracker_test.jl
+++ b/test/path_tracker_test.jl
@@ -79,4 +79,23 @@
 
         @test isnonsingular(res)
     end
+
+    @testset "Parameter homotopy with AbstractSystem" begin
+        # affine
+        @polyvar x a y b
+        F = SPSystem([x^2-a, x*y-a+b]; parameters=[a, b])
+
+        tracker, starts = pathtracker_startsolutions(F, [1.0, 1.0 + 0.0*im],
+                        p₁=[1, 0], p₀=[2, 4], affine_tracking=true)
+        res = track(tracker, starts[1])
+        @test res.return_code == :success
+
+        # projective
+        @polyvar x y z a b
+        F = SPSystem([x^2-a*z^2, x*y-a*z^2+b*z^2]; parameters=[a, b])
+
+        tracker, starts = pathtracker_startsolutions(F, [1.0, 1.0 + 0.0*im], p₁=[1, 0], p₀=[2, 4], affine_tracking=false)
+        res = track(tracker, starts[1])
+        @test res.return_code == :success
+    end
 end

--- a/test/path_tracker_test.jl
+++ b/test/path_tracker_test.jl
@@ -90,6 +90,11 @@
         res = track(tracker, starts[1])
         @test res.return_code == :success
 
+        # affine without explicit flag (numerical degree check fails)
+        tracker, starts = pathtracker_startsolutions(F, [1.0, 1.0 + 0.0*im], p₁=[1, 0], p₀=[2, 4])
+        res = track(tracker, starts[1])
+        @test res.return_code == :success
+
         # projective
         @polyvar x y z a b
         F = SPSystem([x^2-a*z^2, x*y-a*z^2+b*z^2]; parameters=[a, b])


### PR DESCRIPTION
This generalises our monodromy routine to also accept `AbstractSystem`s as input.