### PR TITLE
Prettier tables

### DIFF
--- a/docs/src/path_tracker.md
+++ b/docs/src/path_tracker.md
@@ -44,6 +44,7 @@ The following helper functions are provided
 ```@docs
 solution
 accuracy(::PathResult)
+multiplicity
 residual
 start_solution
 Base.isreal(::PathResult)

--- a/docs/src/solving.md
+++ b/docs/src/solving.md
@@ -31,7 +31,6 @@ results
 mapresults
 solutions
 realsolutions
-uniquesolutions
 finite
 Base.real(::HomotopyContinuation.Results)
 atinfinity

--- a/docs/src/solving.md
+++ b/docs/src/solving.md
@@ -36,6 +36,7 @@ finite
 Base.real(::HomotopyContinuation.Results)
 atinfinity
 failed
+multiplicities!(::HomotopyContinuation.Result)
 multiplicities(::HomotopyContinuation.Results)
 ```
 

--- a/docs/src/solving.md
+++ b/docs/src/solving.md
@@ -15,7 +15,17 @@ Result
 seed
 ```
 
-In order to analyse a `Result` we provide the following helper functions
+The nonsingular solutions are obtained as follows.
+```@docs
+nonsingular
+```
+
+The singular solutions are returned by using the following.
+```@docs
+singular
+```
+
+In order to analyse a `Result` we provide the following additional helper functions
 ```@docs
 results
 mapresults
@@ -25,8 +35,6 @@ uniquesolutions
 finite
 Base.real(::HomotopyContinuation.Results)
 atinfinity
-singular
-nonsingular
 failed
 multiplicities(::HomotopyContinuation.Results)
 ```

--- a/src/affine_patches.jl
+++ b/src/affine_patches.jl
@@ -55,6 +55,8 @@ The same as [`setup!`](@ref) but only called during the path tracking.
 """
 changepatch!(::AbstractAffinePatchState, x::AbstractVector) = nothing
 
+is_global_patch(::AbstractAffinePatch) = false
+
 include("affine_patches/common.jl")
 include("affine_patches/orthogonal_patch.jl")
 include("affine_patches/embedding_patch.jl")

--- a/src/affine_patches/embedding_patch.jl
+++ b/src/affine_patches/embedding_patch.jl
@@ -8,6 +8,8 @@ is basically the same as tracking in affine space.
 """
 struct EmbeddingPatch <: AbstractAffinePatch end
 
+is_global_patch(::EmbeddingPatch) = true
+
 struct EmbeddingPatchState{N} <: AbstractAffinePatchState{N} end
 
 function state(::EmbeddingPatch, x::PVector{T,N}) where {T,N}

--- a/src/affine_patches/random_patch.jl
+++ b/src/affine_patches/random_patch.jl
@@ -11,6 +11,8 @@ struct RandomPatchState{T, N} <: AbstractAffinePatchState{N}
     v̄::PVector{T, N}
 end
 
+is_global_patch(::RandomPatch) = true
+
 function state(::RandomPatch, x::PVector)
     v = copy(x)
     Random.randn!(v)

--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -378,7 +378,7 @@ function CoreTracker(homotopy::AbstractHomotopy, x₁::ProjectiveVectors.PVector
     # We close over the patch state, the homotopy and its cache
     # to be able to pass things around more easily
     HC = HomotopyWithCache(PatchedHomotopy(H, patch_state), x₁, t₁)
-    if patch isa EmbeddingPatch
+    if is_global_patch(patch)
         inner_product = WeightedIP(x₁)
     else
         inner_product = EuclideanIP()

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -222,7 +222,7 @@ mutable struct PathTrackerOptions
     accuracy_eg::Float64
 end
 
-function PathTrackerOptions(;
+function PathTrackerOptions(prob::Problem;
             at_infinity_check=true,
             samples_per_loop::Int=12,
             max_winding_number::Int=12,
@@ -383,7 +383,7 @@ function PathTracker(prob::AbstractProblem, x::AbstractVector{<:Number};
                         accuracy=accuracy,
                         core_tracker_supported...)
     state = PathTrackerState(core_tracker.state.x; at_infinity_check=at_infinity_check)
-    options = PathTrackerOptions(;at_infinity_check=at_infinity_check,
+    options = PathTrackerOptions(prob; at_infinity_check=at_infinity_check,
                                   accuracy=accuracy, optionskwargs...)
     cache = PathTrackerCache(prob, core_tracker)
     PathTracker(prob, core_tracker, state, options, cache)

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -5,9 +5,7 @@ export PathResult, PathTrackerStatus, PathTracker,
 
 
 const pathtracker_supported_keywords = [
-    :at_infinity_check, :min_step_size_endgame_start,
-    :min_val_accuracy, :samples_per_loop,
-    :max_winding_number, :max_affine_norm,
+    :at_infinity_check, :samples_per_loop, :max_winding_number,
     :overdetermined_min_accuracy, :overdetermined_min_residual,
     :cond_eg_start, :min_cond_at_infinity,
     :t_eg_start, :tol_val_inf_accurate, :tol_val_finite_accurate, :accuracy, :accuracy_eg]

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -836,7 +836,7 @@ function Base.show(io::IO, x::Result)
     println(io, "• $(ntracked(x)) paths tracked")
     println(io, "• random seed: $(seed(x))")
     if s.singular > 0
-        println(io, "• multiplicity table singular solutions:")
+        println(io, "• multiplicity table of singular solutions:")
         singular_multiplicities_table(io, x, s)
     end
 end
@@ -923,7 +923,7 @@ function TreeViews.nodelabel(io::IO, x::ProjectiveResult, i::Int, ::MIME"applica
     elseif i == 6
         print(io, "Random seed used")
     elseif i == 7 && s.singular > 0
-        print(io, "  multiplicity table singular solutions: \n")
+        print(io, "  multiplicity table of singular solutions: \n")
         singular_multiplicities_table(io, x, s)
     end
 end
@@ -949,6 +949,8 @@ function TreeViews.treenode(r::ProjectiveResult, i::Integer)
 end
 
 plural(singularstr, n) = n == 1 ? singularstr : singularstr * "s"
+
+
 
 function singular_multiplicities_table(io, result::Result, stats = statistics(result))
     multiplicities_dict = Dict{Int, Vector{Vector{Int}}}()
@@ -989,8 +991,11 @@ function singular_multiplicities_table(io, result::Result, stats = statistics(re
     	data[1,4] = stats.singular - curr_n_sols
     end
 
-    headers = ["multiplicity", "# real", "# non-real", "# total"]
-    PrettyTables.pretty_table(io, data, headers;
+
+    headers = ["mult.", "#real", "#nonreal", "total"]
+    PrettyTables.pretty_table(io, data, headers,
+            PrettyTables.unicode_rounded;
             alignment=:c,
-            header_crayon=PrettyTables.Crayon(bold=false))
+            header_crayon=PrettyTables.Crayon(bold=false),
+            border_crayon=PrettyTables.Crayon(faint=true))
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -573,7 +573,6 @@ Base.iterate(r::Result, state) = iterate(r.pathresults, state)
 Base.lastindex(r::Result) = lastindex(r.pathresults)
 Base.eltype(r::Type{Result{V}}) where {V} = PathResult{V}
 
-
 is_multiple_result(r::PathResult, R::Result) = is_multiple_result(r, R.multiplicity_info)
 is_multiple_result(r::PathResult, R::Vector{<:PathResult}) = false
 
@@ -677,7 +676,7 @@ nfinite(R::Results) = count(isfinite, R)
 
 The number of solutions.
 """
-nsolutions(R::Results) = count(issuccess, R)
+nsolutions(R::Results) = nresults(R)
 
 """
     nsingular(result; singulartol=1e10, multiplicitytol=1e-5, counting_multiplicities=false, kwargs...)
@@ -833,7 +832,7 @@ If `multiple_results=false` only one point from each cluster of multiple solutio
 If If `multiple_results=true` all singular solutions in `R` are returned.
 For the possible `kwargs` see [`results`](@ref).
 """
-function singular(R::Result; tol=1e10, kwargs...)
+function singular(R::Results; tol=1e10, kwargs...)
     results(R; onlysingular = true, singulartol=tol, kwargs...)
 end
 
@@ -877,54 +876,6 @@ Two solutions are regarded as equal, when their pairwise distance is less than '
 function multiplicities(results::Results; tol=1e-6)
     map(i -> results[i], multiplicities(solution, results; tol = tol))
 end
-
-"""
-    uniquesolutions(R::Result; tol=1e-6, multiplicities=false, conditions...)
-
-Return all *unique* solutions. If `multiplicities` is `true`, then
-all *unique* solutions with their correspnding multiplicities as pairs `(s, m)`
-where `s` is the solution and `m` the multiplicity are returned.
-For the possible `conditions` see [`results`](@ref).
-
-## Example
-```julia-repl
-julia> @polyvar x;
-julia> uniquesolutions([(x-3)^3*(x+2)], multiplicities=true)
-[([3.0+0.0im], 3), ([-2.0+0.0im], 1)]
-julia> uniquesolutions([(x-3)^3*(x+2)])
-[[3.0+0.0im], [-2.0+0.0im]]
-```
-"""
-function uniquesolutions(R::Results; tol=1e-6, multiplicities=false, conditions...)
-    uniquesolutions(R, Val(multiplicities); tol=tol, conditions...)
-end
-
-function uniquesolutions(R::Results, ::Val{Multiplicities}; tol=1e-6, conditions...)  where {Multiplicities}
-    sols = solutions(R; conditions...)
-    M = multiplicities(sols; tol=tol)
-    indicator = trues(length(sols))
-    uniques = map(M) do m
-        for k in m
-            indicator[k] = false
-        end
-        if Multiplicities
-            (sols[m[1]], length(m))
-        else
-            sols[m[1]]
-        end
-    end
-    for (k, s) in enumerate(sols)
-        if indicator[k]
-            if Multiplicities
-                push!(uniques, (s, 1))
-            else
-                push!(uniques, s)
-            end
-        end
-    end
-    uniques
-end
-
 
 ####Show function
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -852,7 +852,7 @@ function Base.show(io::IO, x::ProjectiveResult)
     println(io, "• $(ntracked(x)) paths tracked")
     println(io, "• random seed: $(seed(x))")
     if s.singular > 0
-        println(io, "• multiplicity table singular solutions:")
+        println(io, "• multiplicity table of singular solutions:")
         singular_multiplicities_table(io, x, s)
     end
 end
@@ -881,7 +881,7 @@ function TreeViews.nodelabel(io::IO, x::Result, i::Int, ::MIME"application/prs.j
     elseif i == 7
         print(io, "Random seed used")
     elseif i == 8 && s.singular > 0
-        print(io, "  multiplicity table singular solutions: \n")
+        print(io, "  multiplicity table of singular solutions: \n")
         singular_multiplicities_table(io, x, s)
     end
 end
@@ -976,9 +976,10 @@ function singular_multiplicities_table(io, result::Result, stats = statistics(re
     	data[i+off, 1] = k
     	n_real_solsᵢ = count(M -> isreal(result.pathresults[first(M)]), multiplicities_dict[k])
     	n_solsᵢ = length(multiplicities_dict[k])
-    	data[i+off, 2] = n_real_solsᵢ
-    	data[i+off, 3] = n_solsᵢ - n_real_solsᵢ
-    	data[i+off, 4] = n_solsᵢ
+        data[i+off, 2] = n_solsᵢ
+    	data[i+off, 3] = n_real_solsᵢ
+    	data[i+off, 4] = n_solsᵢ - n_real_solsᵢ
+
 
     	curr_n_real_sols += k * n_real_solsᵢ
     	curr_n_sols += k * n_solsᵢ
@@ -986,13 +987,13 @@ function singular_multiplicities_table(io, result::Result, stats = statistics(re
 
     if off
     	data[1,1] = 1
-    	data[1,2] = stats.real_singular - curr_n_real_sols
-    	data[1,3] = (stats.singular - curr_n_sols) - (stats.real_singular - curr_n_real_sols)
-    	data[1,4] = stats.singular - curr_n_sols
+        data[1,2] = stats.singular - curr_n_sols
+    	data[1,3] = stats.real_singular - curr_n_real_sols
+    	data[1,4] = (stats.singular - curr_n_sols) - (stats.real_singular - curr_n_real_sols)
     end
 
 
-    headers = ["mult.", "#real", "#nonreal", "total"]
+    headers = ["mult.", "total", "#real", "#nonreal"]
     PrettyTables.pretty_table(io, data, headers,
             PrettyTables.unicode_rounded;
             alignment=:c,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -995,7 +995,7 @@ function singular_multiplicities_table(io, result::Result, stats = statistics(re
 
     headers = ["mult.", "total", "#real", "#nonreal"]
     PrettyTables.pretty_table(io, data, headers,
-            PrettyTables.unicode_rounded;
+            PrettyTables.unicode;
             alignment=:c,
             header_crayon=PrettyTables.Crayon(bold=false),
             border_crayon=PrettyTables.Crayon(faint=true))

--- a/test/result_test.jl
+++ b/test/result_test.jl
@@ -82,6 +82,20 @@
         @test_nowarn sprint(show, R)
     end
 
+    @testset "singular result" begin
+        @polyvar x
+        f = (x-3)^3*(x-2)
+        R = solve([f])
+        @test length(solutions(R)) == 2
+        @test sort(results(multiplicity, R)) == [1,3]
+
+        @polyvar x y
+        f = (x-3y)^3*(x-2y)
+        R = solve([f])
+        @test nsolutions(R) == 2
+        @test sort(results(multiplicity, R)) == [1,3]
+    end
+
     @testset "multiplicities" begin
         @polyvar x y z
         f = (x-1*y)*(x-1.01*y)
@@ -101,25 +115,5 @@
         @test length(multiplicities(S.pathresults, tol=1e-1)) == 1
         @test length(multiplicities(S.pathresults, tol=1e-5)) == 0
         @test norm(solution(S[1]) - solution(S[2])) < 1e-1
-    end
-
-    @testset "uniquesolutions" begin
-        @polyvar x
-        f = (x-3)^3*(x-2)
-        R = solve([f])
-        @test length(uniquesolutions(R)) == 2
-        @test uniquesolutions(R) isa Vector{Vector{Complex{Float64}}}
-        @test length(uniquesolutions(R, multiplicities=true)) == 2
-        a, b = uniquesolutions(R, multiplicities=true)
-        @test (a[2] == 3 && b[2] == 1) || (b[2] == 3 && a[2] == 1)
-
-        @polyvar x y
-        f = (x-3y)^3*(x-2y)
-        R = solve([f])
-        @test length(uniquesolutions(R)) == 2
-        @test uniquesolutions(R) isa Vector{ProjectiveVectors.PVector{Complex{Float64}, 1}}
-        @test length(uniquesolutions(R, multiplicities=true)) == 2
-        a, b = uniquesolutions(R, multiplicities=true)
-        @test (a[2] == 3 && b[2] == 1) || (b[2] == 3 && a[2] == 1)
     end
 end

--- a/test/result_test.jl
+++ b/test/result_test.jl
@@ -50,12 +50,14 @@
         @test R isa Result
         test_treeviews(R)
         @test nnonsingular(R) == 0
-        @test nsingular(R) == 3
+        @test nsingular(R) == 1
+        @test nsingular(R, counting_multiplicities=true) == 3
         @test_nowarn sprint(show, R)
 
         R = solve([(x-3)^3,(y-2)], affine_tracking=true, system_scaling=nothing)
         @test nnonsingular(R) == 0
-        @test nsingular(R) == 3
+        @test nsingular(R) == 1
+        @test nsingular(R, counting_multiplicities=true) == 3
         @test_nowarn sprint(show, R)
 
         @polyvar x y z
@@ -70,7 +72,8 @@
         @test R isa Result{<:ProjectiveVectors.PVector}
         test_treeviews(R)
         @test nnonsingular(R) == 0
-        @test nsingular(R) == 3
+        @test nsingular(R) == 1
+        @test nsingular(R, counting_multiplicities=true) == 3
 
         @polyvar x y z
         V = x^2 + y^2 - z^2

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -121,8 +121,10 @@
         z = 1
         F = [x^2 + 2*y^2 + 2*im*y*z, (18 + 3*im)*x*y + 7*im*y^2 - (3 - 18*im)*x*z - 14*y*z - 7*im*z^2]
         result = solve(F)
-        @test nsingular(result) == 3
-        @test all(r -> r.winding_number == 3, singular(result))
+        @test nsingular(result) == 1
+        @test nsingular(result; counting_multiplicities=true) == 3
+        @test length(singular(result)) == 1
+        @test all(r -> r.winding_number == 3, singular(result; multiple_results = true))
     end
 
     @testset "Path jumping" begin
@@ -316,17 +318,20 @@
         # This has two roots of multiplicity 6 at the hyperplane z=0
         F = [0.75x^4 + 1.5x^2*y^2-2.5x^2*z^2+0.75*y^4 - 2.5y^2*z^2 + 0.75z^4; 10x^2*z + 10*y^2*z-6z^3]
         res = solve(F; threading=false)
-        @test nsingular(res) == 12
+        @test nsingular(res) == 2
+        @test nsingular(res; counting_multiplicities=true) == 12
         @test length.(multiplicities(solutions(res))) == [6,6]
 
         F_affine = subs.(F, Ref(y => 1))
         res_affine = solve(F_affine; threading=false)
-        @test nsingular(res_affine) == 12
+        @test nsingular(res_affine) == 2
+        @test nsingular(res_affine; counting_multiplicities=true) == 12
         @test length.(multiplicities(solutions(res_affine))) == [6,6]
         @test_nowarn sprint(show, res_affine)
 
         res_affine2 = solve(F_affine; affine_tracking=false, threading=false)
-        @test nsingular(res_affine2) == 12
+        @test nsingular(res_affine2) == 2
+        @test nsingular(res_affine2; counting_multiplicities=true) == 12
         @test length.(multiplicities(solutions(res_affine2))) == [6,6]
     end
 end

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -121,6 +121,8 @@
         z = 1
         F = [x^2 + 2*y^2 + 2*im*y*z, (18 + 3*im)*x*y + 7*im*y^2 - (3 - 18*im)*x*z - 14*y*z - 7*im*z^2]
         result = solve(F)
+        @test multiplicity(first(nonsingular(result))) == 1
+        @test multiplicity(first(singular(result))) == 3
         @test nsingular(result) == 1
         @test nsingular(result; counting_multiplicities=true) == 3
         @test length(singular(result)) == 1

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -126,7 +126,7 @@
         @test nsingular(result) == 1
         @test nsingular(result; counting_multiplicities=true) == 3
         @test length(singular(result)) == 1
-        @test all(r -> r.winding_number == 3, singular(result; multiple_results = true))
+        @test all(r -> multiplicity(r) == 3, singular(result; multiple_results = true))
     end
 
     @testset "Path jumping" begin
@@ -316,24 +316,36 @@
     end
 
     @testset "Singular1" begin
-        @polyvar x y z
+        @polyvar x z y
         # This has two roots of multiplicity 6 at the hyperplane z=0
         F = [0.75x^4 + 1.5x^2*y^2-2.5x^2*z^2+0.75*y^4 - 2.5y^2*z^2 + 0.75z^4; 10x^2*z + 10*y^2*z-6z^3]
         res = solve(F; threading=false)
         @test nsingular(res) == 2
         @test nsingular(res; counting_multiplicities=true) == 12
-        @test length.(multiplicities(solutions(res))) == [6,6]
+        @test multiplicity.(results(res)) == [6,6]
 
         F_affine = subs.(F, Ref(y => 1))
         res_affine = solve(F_affine; threading=false)
         @test nsingular(res_affine) == 2
         @test nsingular(res_affine; counting_multiplicities=true) == 12
-        @test length.(multiplicities(solutions(res_affine))) == [6,6]
+        @test multiplicity.(results(res_affine)) == [6,6]
+        @test_nowarn sprint(show, res_affine)
+
+        res_affine = solve(F_affine; threading=true)
+        @test nsingular(res_affine) == 2
+        @test nsingular(res_affine; counting_multiplicities=true) == 12
+        @test multiplicity.(results(res_affine)) == [6,6]
         @test_nowarn sprint(show, res_affine)
 
         res_affine2 = solve(F_affine; affine_tracking=false, threading=false)
         @test nsingular(res_affine2) == 2
         @test nsingular(res_affine2; counting_multiplicities=true) == 12
-        @test length.(multiplicities(solutions(res_affine2))) == [6,6]
+        @test multiplicity.(results(res_affine2)) == [6,6]
+        @test_nowarn sprint(show, res_affine2)
+
+        # change multiplicity tolerance to only have one
+        multiplicities!(res_affine2; tol=10)
+        @test nsingular(res_affine2) == 1
+        @test multiplicity.(results(res_affine2)) == [12]
     end
 end


### PR DESCRIPTION
The tables look more quiet now.

There is another issue: as number of singular solutions we print the number counting multiplicities. Should it be without counting multiplicities? And singular(result) should return the singular solutions *without* multiplicities imo.

