### PR TITLE
Improve endgame

### DIFF
--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -518,7 +518,8 @@ end
 
     correct!(x̄, tracker.corrector, tracker.cache.corrector,
              tracker.cache.homotopy, x, t, norm, tracker.state.jacobian,
-             accuracy, max_iters; update_jacobian_infos=update_jacobian_infos, use_qr=use_qr)
+             accuracy, max_iters, tracker.state.step_size;
+             update_jacobian_infos=update_jacobian_infos, use_qr=use_qr)
 end
 
 function step!(tracker::CoreTracker)

--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -441,7 +441,7 @@ Additionally also stores the result in `x₀` if the tracking was successfull.
 """
 function track!(x₀, tracker::CoreTracker, x₁, t₁=1.0, t₀=0.0; setup_patch::Bool=tracker.options.update_patch,
             loop::Bool=false, checkstartvalue::Bool=!loop)
-     track!(tracker, x₁, t₁, t₀, setup_patch, checkstartvalue, loop)
+     _track!(tracker, x₁, t₁, t₀, setup_patch, checkstartvalue, loop)
      retcode = currstatus(tracker)
      if retcode == CoreTrackerStatus.success
          x₀ .= currx(tracker)

--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -143,7 +143,7 @@ function CoreTrackerOptions(::Type{Precision}; accuracy=1e-7,
     max_step_size=Inf,
     simple_step_size_alg=false,
     update_patch=true,
-    maximal_lost_digits=default_maximal_lost_digits(Precision, accuracy),
+    maximal_lost_digits=default_maximal_lost_digits(Precision),
     auto_scaling=true,
     auto_scaling_options=AutoScalingOptions(),
     terminate_ill_conditioned::Bool=true) where {Precision<:Real}
@@ -154,7 +154,7 @@ function CoreTrackerOptions(::Type{Precision}; accuracy=1e-7,
             auto_scaling, auto_scaling_options, terminate_ill_conditioned)
 end
 
-default_maximal_lost_digits(::Type{T}, accuracy) where T = -log10(eps(T)) + log10(accuracy) + 3
+default_maximal_lost_digits(::Type{T}) where T = -log10(eps(T)) - 4
 
 Base.show(io::IO, opts::CoreTrackerOptions) = print_fieldnames(io, opts)
 Base.show(io::IO, ::MIME"application/prs.juno.inline", opts::CoreTrackerOptions) = opts

--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -250,11 +250,11 @@ function init_auto_scaling!(ip::WeightedIP, x::AbstractVector, opts::AutoScaling
     for i in 1:length(w)
         wᵢ = abs(x[i])
         if wᵢ < opts.scale_min * point_norm
-            wᵢ = max(opts.scale_min * point_norm, opts.scale_abs_min)
+            wᵢ = opts.scale_min * point_norm
         elseif wᵢ > opts.scale_max * point_norm
             wᵢ = opts.scale_max * point_norm
         end
-        w[i] = wᵢ
+        w[i] = max(wᵢ, opts.scale_abs_min)
     end
     nothing
 end
@@ -702,11 +702,11 @@ function auto_scaling!(ip::WeightedIP, x::AbstractVector, opts::AutoScalingOptio
     for i in 1:length(x)
         wᵢ = (abs(x[i]) + ip.weight[i]) / 2
         if wᵢ < opts.scale_min * norm_x
-            wᵢ = max(opts.scale_min * norm_x, opts.scale_abs_min)
+            wᵢ = opts.scale_min * norm_x
         elseif wᵢ > opts.scale_max * norm_x
             wᵢ = opts.scale_max * norm_x
         end
-        ip.weight[i] = wᵢ
+        ip.weight[i] = max(wᵢ, opts.scale_abs_min)
     end
     nothing
 end

--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -133,11 +133,12 @@ mutable struct CoreTrackerOptions
     terminate_ill_conditioned::Bool
 end
 
-function CoreTrackerOptions(::Type{Precision}; accuracy=1e-7,
+function CoreTrackerOptions(::Type{Precision}; parameter_homotopy=false,
+    accuracy=1e-7,
     refinement_accuracy=1e-8,
     max_corrector_iters::Int=2,
-    max_refinement_iters=10,
-    max_steps=1_000,
+    max_refinement_iters=5,
+    max_steps=parameter_homotopy ? 10_000 : 1_000,
     initial_step_size=0.1,
     min_step_size=1e-14,
     max_step_size=Inf,
@@ -337,7 +338,9 @@ function CoreTracker(homotopy::AbstractHomotopy, x₁::ProjectiveVectors.PVector
     predictor::AbstractPredictor=default_predictor(x₁),
     log_transform=false, kwargs...)
 
-    options = CoreTrackerOptions(real(eltype(x₁)); kwargs...)
+    options = CoreTrackerOptions(real(eltype(x₁));
+                    parameter_homotopy=isa(homotopy, ParameterHomotopy),
+                    kwargs...)
     # disable auto scaling always in projective space
     options.auto_scaling = false
 
@@ -365,7 +368,9 @@ function CoreTracker(homotopy::AbstractHomotopy, x₁::AbstractVector, t₁, t�
     predictor::AbstractPredictor=default_predictor(x₁),
     log_transform=false, kwargs...)
 
-    options = CoreTrackerOptions(real(eltype(x₁)); kwargs...)
+    options = CoreTrackerOptions(real(eltype(x₁));
+                parameter_homotopy=isa(homotopy, ParameterHomotopy),
+                kwargs...)
 
     H = log_transform ? LogHomotopy(homotopy) : homotopy
     # We close over the patch state, the homotopy and its cache

--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -575,9 +575,9 @@ function step!(tracker::CoreTracker)
             # Check termination criterion: we became too ill-conditioned
             if options.terminate_ill_conditioned && (
                 unpack(state.jacobian.digits_lost, 0.0) > options.maximal_lost_digits ||
-                state.jacobian.corank > 0
-                )
+                state.jacobian.corank > 0)
                 state.status = CoreTrackerStatus.terminated_ill_conditioned
+                return nothing
             end
 
             # Step failed, so we have to try with a new (smaller) step size

--- a/src/core_tracker.jl
+++ b/src/core_tracker.jl
@@ -457,6 +457,11 @@ end
 
 function _track!(tracker::CoreTracker, x₁, t₁, t₀,
                     setup_patch::Bool, checkstartvalue::Bool, loop::Bool)
+    if t₁ == t₀
+        tracker.state.status = CoreTrackerStatus.success
+        return tracker.state.status
+    end
+
     setup!(tracker, x₁, t₁, t₀, setup_patch, checkstartvalue, loop)
 
     while tracker.state.status == CoreTrackerStatus.tracking

--- a/src/correctors.jl
+++ b/src/correctors.jl
@@ -115,10 +115,11 @@ end
 
 @inline function correct!(out, alg::NewtonCorrector, cache::NewtonCorrectorCache,
                   H::HomotopyWithCache, x, t, norm, jacobian::Jacobian, tol::Float64,
-                  maxiters::Int; update_jacobian_infos::Bool=false, use_qr::Bool=false)
+                  maxiters::Int, step_size_model; update_jacobian_infos::Bool=false, use_qr::Bool=false,
+                  ω::Float64=0.0)
     cache.F.t = t
     result = newton!(out, cache.F, x, norm, cache.C, jacobian, tol, 1, maxiters,
-        alg.simplified_last_step, update_jacobian_infos, use_qr)
+        alg.simplified_last_step, update_jacobian_infos, use_qr, step_size_model.ω, step_size_model.expected_Δx₀)
     CorrectorResult(result)
 end
 

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -446,6 +446,16 @@ function _track!(tracker::PathTracker, x₁, s₁::Real, s₀::Real)
     setup!(core_tracker, core_tracker.state.x, s₁, s₀)
     reset!(state)
 
+    # Handle the case that the start value is already a solution
+    if residual(tracker, core_tracker.state.x) < 1e-14
+        state.status = PathTrackerStatus.success
+        state.prediction .= core_tracker.state.x
+        state.s = Inf
+        # Set winding_number to 1 to get into the possible singular solution case in
+        # `check_and_refine_solution!`
+        state.winding_number = 1
+    end
+
     while state.status == PathTrackerStatus.tracking
         step!(core_tracker)
         state.s = real(currt(core_tracker))

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -68,7 +68,7 @@ function reset!(val::Valuation)
     val
 end
 
-function update!(val::Valuation, z::Vector, ż, Δs::Float64, ::Val{true})
+function update!(val::Valuation, z::Vector, ż, Δs::Float64, ::Val)
     _update!(val, z, ż, Δs)
 end
 function update!(val::Valuation, z::PVector, ż, Δs::Float64, ::Val{false})

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -464,6 +464,10 @@ function _track!(tracker::PathTracker, x₁, s₁::Real, s₀::Real)
         # We only care if we moved forward
         core_tracker.state.last_step_failed && continue
 
+        # If we are too early, we also don't check the valuation
+        if state.s < 2 # ≈ 0.1353352832366127
+            continue
+        end
         # Our endgame strategy is split in different stages
         # 1) During the path tracking we update an approximation
         #    of the valuation of x(t) since this has for t ≈ 0

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -818,17 +818,16 @@ Construct a [`PathTracker`](@ref) and start solutions in the same way [`solve`](
 This also takes the same input arguments as `solve`. This is convenient if you want
 to investigate single paths.
 """
-function pathtracker_startsolutions(args...; system_scaling=true, kwargs...)
+function pathtracker_startsolutions(args...; kwargs...)
     invalid = invalid_kwargs(kwargs, pathtracker_startsolutions_supported_keywords)
     check_kwargs_empty(invalid, pathtracker_startsolutions_supported_keywords)
     supported, rest = splitkwargs(kwargs, problem_startsolutions_supported_keywords)
-    prob, startsolutions = problem_startsolutions(args...; system_scaling=system_scaling, supported...)
+    prob, startsolutions = problem_startsolutions(args...; supported...)
     tracker_startsolutions(prob, startsolutions; rest...)
 end
 
 function tracker_startsolutions(prob::Problem, startsolutions; kwargs...)
-    core_tracker_supported, pathtracker_kwargs = splitkwargs(kwargs, coretracker_supported_keywords)
-    tracker = PathTracker(prob, start_solution_sample(startsolutions); pathtracker_kwargs...)
+    tracker = PathTracker(prob, start_solution_sample(startsolutions); kwargs...)
     (tracker=tracker, startsolutions=startsolutions)
 end
 

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -742,6 +742,7 @@ function check_and_refine_solution!(tracker::PathTracker)
             state.status = PathTrackerStatus.at_infinity
             return nothing
         else
+            state.solution .= currx(core_tracker)
             state.status = PathTrackerStatus.post_check_failed
             return nothing
         end

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -390,7 +390,7 @@ struct PathTracker{V<:AbstractVector, Prob<:AbstractProblem, PTC<:PathTrackerCac
     cache::PTC
 end
 
-function PathTracker(prob::AbstractProblem, x::AbstractVector{<:Number}; at_infinity_check=default_at_infinity_check(prob), min_step_size=eps(), kwargs...)
+function PathTracker(prob::AbstractProblem, x::AbstractVector{<:Number}; at_infinity_check=default_at_infinity_check(prob), min_step_size=1e-30, kwargs...)
     core_tracker_supported, optionskwargs = splitkwargs(kwargs, coretracker_supported_keywords)
     core_tracker = CoreTracker(prob, x, complex(0.0), 36.0;
                         log_transform=true, predictor=Pade21(),
@@ -422,7 +422,7 @@ Possible values for the options are
 * `start_parameters::AbstractVector`
 * `target_parameters::AbstractVector`
 """
-function track!(tracker::PathTracker, x₁, s₁=0.0, s₀=36.0;
+function track!(tracker::PathTracker, x₁, s₁=0.0, s₀=-log(tracker.core_tracker.options.min_step_size);
         start_parameters::Union{Nothing,<:AbstractVector}=nothing,
         target_parameters::Union{Nothing,<:AbstractVector}=nothing,
         kwargs...)
@@ -538,7 +538,7 @@ Possible values for the options are
 * `start_parameters::AbstractVector`
 * `target_parameters::AbstractVector`
 """
-function track(tracker::PathTracker, x₁, t₁=0.0, t₀=36.0; path_number::Int=1, details::Symbol=:default, kwargs...)
+function track(tracker::PathTracker, x₁, t₁=0.0, t₀=-log(tracker.core_tracker.options.min_step_size); path_number::Int=1, details::Symbol=:default, kwargs...)
     track!(tracker, x₁, t₁, t₀; kwargs...)
     PathResult(tracker, x₁, path_number; details=details)
 end

--- a/src/path_tracker.jl
+++ b/src/path_tracker.jl
@@ -718,6 +718,8 @@ function check_and_refine_solution!(tracker::PathTracker)
                 state.winding_number = 0
                 @goto non_singular_case
             end
+        elseif state.winding_number > 1 && state.solution_cond < 1e10 && residual(tracker) > 100
+            state.status = PathTrackerStatus.post_check_failed
         end
 
         # In the case of a squared up system we now have to get rid of the

--- a/src/polyhedral.jl
+++ b/src/polyhedral.jl
@@ -448,8 +448,18 @@ function tracker_startsolutions(prob::PolyhedralProblem, startsolutions::Polyhed
     x = randn(ComplexF64, size(prob.toric_homotopy)[2])
     toric_tracker =
         coretracker(prob.toric_homotopy, [x]; seed=prob.seed, affine_tracking=true, predictor=Pade21())
-    generic_tracker =
-        pathtracker(prob.generic_homotopy, x; seed=prob.seed, affine_tracking=isa(prob.tracking_type, AffineTracking), kwargs...)
+    generic_prob = target_problem(prob)
+    generic_tracker, _ =
+        tracker_startsolutions(generic_prob, startsolutions; kwargs...)
     tracker = PolyhedralTracker(prob.toric_homotopy, toric_tracker, generic_tracker, Ref(NaN))
     (tracker=tracker, startsolutions=startsolutions)
+end
+
+function target_problem(P::PolyhedralProblem)
+	Problem(P.tracking_type, P.generic_homotopy, P.vargroups,
+				P.seed, P.startsolutions_need_reordering, P.regauging_factors)
+end
+
+function start_solution_sample(iter::PolyhedralStartSolutionsIterator)
+    randn(ComplexF64, size(iter.X, 1))
 end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -10,6 +10,7 @@ const problem_startsolutions_supported_keywords = [
 
 const DEFAULT_SYSTEM = @static VERSION < v"1.1" ? FPSystem : SPSystem
 const DEFAULT_HOMOTOPY = StraightLineHomotopy
+const DEFAULT_SYSTEM_SCALING = true
 
 """
 	TrackingType
@@ -253,7 +254,7 @@ end
 ##############
 
 function problem_startsolutions(input::TargetSystemInput{<:MPPolyInputs}, ::Nothing, homvar_info, seed;
-				start_system=:total_degree, affine_tracking=false, system_scaling=true, system=DEFAULT_SYSTEM,
+				start_system=:total_degree, affine_tracking=false, system_scaling=DEFAULT_SYSTEM_SCALING, system=DEFAULT_SYSTEM,
 			 	kwargs...)
 	if affine_tracking
 		vargroups = VariableGroups(variables(input.system))
@@ -379,7 +380,7 @@ end
 # START TARGET
 ###############
 
-function problem_startsolutions(input::StartTargetInput, startsolutions, homvar, seed; affine_tracking=false, system_scaling=true, system=DEFAULT_SYSTEM, kwargs...)
+function problem_startsolutions(input::StartTargetInput, startsolutions, homvar, seed; affine_tracking=false, system_scaling=DEFAULT_SYSTEM_SCALING, system=DEFAULT_SYSTEM, kwargs...)
     F, G = input.target, input.start
     F_ishom, G_ishom = ishomogeneous.((F, G))
 	vars = variables(F)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -952,7 +952,11 @@ function singular_multiplicities_table(io, result::Result, stats = statistics(re
     		multiplicities_dict[length(m)] = [m]
     	end
     end
-    n_mults_total = sum(M -> sum(length, M), values(multiplicities_dict))
+    if isempty(multiplicities_dict)
+        n_mults_total = 0
+    else
+        n_mults_total = sum(M -> sum(length, M), values(multiplicities_dict))
+    end
 
     curr_n_real_sols = 0
     curr_n_sols = 0

--- a/src/utilities/linear_algebra.jl
+++ b/src/utilities/linear_algebra.jl
@@ -105,16 +105,16 @@ function Jacobian(A::AbstractMatrix, corank::Int=0)
 end
 
 function update_rank!(Jac::Jacobian)
-    # if Jac.corank_proposal < Jac.corank
-    #     Jac.corank = Jac.corank_proposal
-    # elseif Jac.corank_proposal > Jac.corank == 0 && issquare(Jac.J)
-    #     if unpack(Jac.digits_lost, 0.0) > maximal_lost_digits
-    #         Jac.corank = Jac.corank_proposal
-    #     end
-    # else
     Jac.corank = Jac.corank_proposal
-    # end
     Jac
+end
+
+function reset!(jacobian::Jacobian)
+    jacobian.cond = 1.0
+    jacobian.corank = 0
+    jacobian.corank_proposal = 0
+    jacobian.digits_lost = nothing
+    jacobian
 end
 
 """
@@ -185,7 +185,6 @@ Solve `Jac.J * x = b` inplace. Assumes `Jac` contains already the correct factor
 This stores the result in `x`.
 """
 function solve!(x, Jac::Jacobian, b::AbstractVector; update_digits_lost::Bool=false, refinement_step::Bool=false)
-    # @show Jac.active_factorization
     if Jac.active_factorization == LU_FACTORIZATION
         lu = Jac.lu
         if lu !== nothing
@@ -568,7 +567,6 @@ function hnf!(A, U)
             if !iszero(A[j, j]) || !iszero(A[j, ii])
                 # 4.1
                 r, p, q = gcdx(A[j, j], A[j, ii])
-                # @show r, p, q, A[j, j], A[j, ii]
                 # 4.2
                 d_j = -A[j, ii] ÷ r
                 d_ii = A[j, j] ÷ r

--- a/test/correctors_test.jl
+++ b/test/correctors_test.jl
@@ -31,11 +31,12 @@ end
         @test corrector_cache isa HomotopyContinuation.NewtonCorrectorCache
 
         # check that this doesn't throw
-        out = correct!(xnext, corrector, corrector_cache, H, x, t, euclidean_norm, Jac, 1e-7, 3)
+        out = correct!(xnext, corrector, corrector_cache, H, x, t, euclidean_norm, Jac, 1e-7, 3,
+        HC.StepSizeModel())
         @test out isa CorrectorResult
 
         out = correct!(xnext, corrector, corrector_cache, H, x, t,
-                    euclidean_norm, Jac, 1e-7, 3; update_jacobian_infos=true)
+                    euclidean_norm, Jac, 1e-7, 3, HC.StepSizeModel(); update_jacobian_infos=true)
         @test out isa CorrectorResult
     end
 
@@ -48,11 +49,11 @@ end
         @test corrector_cache isa HomotopyContinuation.NewtonCorrectorCache
 
         # check that this doesn't throw
-        out = correct!(xnext, corrector, corrector_cache, H, x, t, euclidean_norm, Jac, 1e-7, 3)
+        out = correct!(xnext, corrector, corrector_cache, H, x, t, euclidean_norm, Jac, 1e-7, 3, HC.StepSizeModel())
         @test out isa CorrectorResult
 
         out = correct!(xnext, corrector, corrector_cache, H, x, t,
-                    euclidean_norm, Jac, 1e-7, 3; update_jacobian_infos=true)
+                    euclidean_norm, Jac, 1e-7, 3, HC.StepSizeModel(); update_jacobian_infos=true)
         @test out isa CorrectorResult
     end
 end

--- a/test/path_tracker_test.jl
+++ b/test/path_tracker_test.jl
@@ -142,7 +142,7 @@
         # Let's store the generic solutions
         S_p₀ = solutions(result_p₀)
         # Construct the PathTracker
-        tracker = pathtracker(F; parameters=p, generic_parameters=p₀)
+        tracker = pathtracker(F; parameters=p, affine_tracking=true, generic_parameters=p₀)
 
         q = randn(3)
         result = track(tracker, first(S_p₀); target_parameters=q)

--- a/test/polyhedral_test.jl
+++ b/test/polyhedral_test.jl
@@ -23,6 +23,6 @@
     @testset "Polyhedral solve" begin
         f = equations(cyclic(5))
         result = solve(f; start_system=:polyhedral)
-        nfinite(result) == 70
+        @test nfinite(result) == 70
     end
 end

--- a/test/polyhedral_test.jl
+++ b/test/polyhedral_test.jl
@@ -24,5 +24,11 @@
         f = equations(cyclic(5))
         result = solve(f; start_system=:polyhedral)
         @test nfinite(result) == 70
+
+        @polyvar x y
+        result1 = solve([(x-3),(y-2)], start_system=:polyhedral, system_scaling=false)
+        @test [3,2] ≈ solutions(result1)[1] atol=1e-8
+        result1 = solve([(x-3),(y-2)], start_system=:polyhedral, system_scaling=true)
+        @test [3,2] ≈ solutions(result1)[1] atol=1e-8
     end
 end

--- a/test/real_world_test.jl
+++ b/test/real_world_test.jl
@@ -69,10 +69,14 @@
             results4_template[length(sol4_again)+1] +=1
         end
 
-        @test results1_direct == results1_template
-        @test results2_direct == results2_template
-        @test results3_direct == results3_template
-        @test results4_direct == results4_template
+        @test results1_template[4] == 100
+        @test 98 <= results1_direct[4] <= 100
+        @test 95 <= results2_direct[7] <= 100
+        @test results2_direct[8] <= 1
+        @test 98 ≤ results2_template[7] ≤ 100
+        @test 98 ≤ results3_direct[7] ≤ 100
+        @test 98 ≤ results3_template[7] ≤ 100
+        @test 98 ≤ results4_direct[4] ≤ 100
+        @test 98 ≤ results4_template[4] ≤ 100
     end
-
 end

--- a/test/real_world_test.jl
+++ b/test/real_world_test.jl
@@ -1,0 +1,78 @@
+@testset "Real world" begin
+
+    # These test got prepared by Torkel Loman to test the BioDiffEq integration
+    @testset "Bio-chemical reaction networks 1" begin
+        @polyvar x[1:3] p[1:10]
+        results1_direct = fill(0,10)
+        results1_template = fill(0,10)
+        results2_direct = fill(0,10)
+        results2_template = fill(0,10)
+        results3_direct = fill(0,10)
+        results3_template = fill(0,10)
+        results4_direct = fill(0,10)
+        results4_template = fill(0,10)
+
+        for i = 1:100
+            pol = [ -x[1]*x[3]*p[3] - x[1]*p[2] + p[1],
+                    # x[1]*x[2]*x[3]*p[8]*p[9] + x[1]*x[3]*p[7]*p[8]*p[9] - x[2]*x[3]*p[5]*p[6] - x[2]*p[5]*p[6]*p[10] - x[2]*x[3]*p[4] - x[2]*p[4]*p[10],
+                    -x[1]*x[2]*x[3]*p[8]*p[9] - x[1]*x[3]*p[7]*p[8]*p[9] + x[2]*x[3]*p[5]*p[6] + x[2]*p[5]*p[6]*p[10] + x[2]*x[3]*p[4] + x[2]*p[4]*p[10],
+                    x[2] + x[3] - 1.0 ]
+            p_vals = [0.04,0.04,1.,1.,10.0,0.,0.04,35.,.1,.04]
+            pol_pars = DynamicPolynomials.subs.(pol, Ref(p => p_vals))
+            sol = solutions(HomotopyContinuation.solve(pol_pars, affine_tracking=true, show_progress=false))
+            results1_direct[length(sol)+1] +=1
+
+            p_template = randn(ComplexF64, 10)
+            f_template = DynamicPolynomials.subs.(pol, Ref(p => p_template))
+            result_template = solutions(HomotopyContinuation.solve(f_template, affine_tracking=true, show_progress=false))
+            (length(result_template)>0) && (sol_again = solutions(HomotopyContinuation.solve(pol, result_template, affine_tracking=true, parameters=p, p₁=p_template, p₀=ComplexF64.(p_vals), show_progress=false)))
+            (length(result_template)>0) ? (results1_template[length(sol_again)+1] += 1) : (results1_template[1] += 1)
+
+            pol2 = [ -x[1]^5*x[2]*p[5] + x[1]^4*x[3]*p[6]*p[8] - x[1]*x[2]*p[3]^4*p[5] + x[3]*p[3]^4*p[6]*p[8] - x[1]^5*p[7] + x[1]^4*x[3]*p[4] - x[1]*p[3]^4*p[7] + x[3]*p[3]^4*p[4] + x[1]^4*p[1] + x[1]^4*p[2] + p[1]*p[3]^4,
+                     -x[1]^5*x[2]*p[5] - x[1]*x[2]*p[3]^4*p[5] - x[1]^4*x[2]*p[7] + x[1]^4*x[3]*p[4] - x[2]*p[3]^4*p[7] + x[3]*p[3]^4*p[4] + x[1]^4*p[1] + x[1]^4*p[2] + p[1]*p[3]^4,
+                     x[1]*x[2]*p[5] - x[3]*p[6]*p[8] - x[3]*p[4] - x[3]*p[7] ]
+            p2_vals = [0.005, 0.1, 2.8,  10, 100, 0.1, 0.01, 0.]
+            pol2_pars = DynamicPolynomials.subs.(pol2, Ref(p => p2_vals))
+            sol2 = solutions(HomotopyContinuation.solve(pol2_pars, affine_tracking=true, show_progress=false))
+            results2_direct[length(sol2)+1] +=1
+
+            p2_template = randn(ComplexF64, 8)
+            f2_template = DynamicPolynomials.subs.(pol2, Ref(p => p2_template))
+            solve_templ2 = HomotopyContinuation.solve(f2_template, affine_tracking=true, show_progress=false)
+            result2_template = solutions(solve_templ2)
+            sol2_again = solutions(HomotopyContinuation.solve(pol2, result2_template, max_steps=10_000, parameters=p[1:8], p₁=p2_template, p₀=ComplexF64.(p2_vals), affine_tracking=true, show_progress=false))
+            results2_template[length(sol2_again)+1] +=1
+
+            pol3 = pol2
+            p3_vals = [0.005, 0.1, 2.8,  10, 100, 0.1, 0.01, 1.] #Last parameter is 1 and not 0. Here there should be 3 real solutions instead of 1.
+            pol3_pars = DynamicPolynomials.subs.(pol3, Ref(p => p3_vals))
+            sol3 = solutions(HomotopyContinuation.solve(pol3_pars, affine_tracking=true, show_progress=false))
+            results3_direct[length(sol3)+1] +=1
+
+            p3_template = randn(ComplexF64, 8)
+            f3_template = DynamicPolynomials.subs.(pol3, Ref(p => p3_template))
+            result3_template = solutions(HomotopyContinuation.solve(f3_template, affine_tracking=true, show_progress=false))
+            sol3_again = solutions(HomotopyContinuation.solve(pol3, result3_template, affine_tracking=true, parameters=p[1:8], p₁=p3_template, p₀=ComplexF64.(p3_vals), show_progress=false))
+            results3_template[length(sol3_again)+1] +=1
+
+
+            pol4 = [-x[1]^3*p[3] - x[1]*p[2]^2*p[3] + x[1]^2*p[1]]
+            p4_vals = [1., 0.2, 1.];
+            pol4_pars = DynamicPolynomials.subs.(pol4, Ref(p => p4_vals))
+            sol4 = solutions(HomotopyContinuation.solve(pol4_pars, affine_tracking=true, show_progress=false))
+            results4_direct[length(sol4)+1] +=1
+
+            p4_template = randn(ComplexF64, 3)
+            f4_template = DynamicPolynomials.subs.(pol4, Ref(p => p4_template))
+            result4_template = solutions(HomotopyContinuation.solve(f4_template, affine_tracking=true, show_progress=false))
+            sol4_again = solutions(HomotopyContinuation.solve(pol4, result4_template, affine_tracking=true, parameters=p[1:3], p₁=p4_template, p₀=ComplexF64.(p4_vals), show_progress=false))
+            results4_template[length(sol4_again)+1] +=1
+        end
+
+        @test results1_direct == results1_template
+        @test results2_direct == results2_template
+        @test results3_direct == results3_template
+        @test results4_direct == results4_template
+    end
+
+end

--- a/test/result_test.jl
+++ b/test/result_test.jl
@@ -46,9 +46,14 @@
         test_treeviews(R)
 
         @polyvar x y z
-        R = solve([(x-3)^3,(y-2)])
+        R = solve([(x-3)^3,(y-2)], affine_tracking=true, system_scaling=true)
         @test R isa Result
         test_treeviews(R)
+        @test nnonsingular(R) == 0
+        @test nsingular(R) == 3
+        @test_nowarn sprint(show, R)
+
+        R = solve([(x-3)^3,(y-2)], affine_tracking=true, system_scaling=false)
         @test nnonsingular(R) == 0
         @test nsingular(R) == 3
         @test_nowarn sprint(show, R)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,4 +34,5 @@ end
     include("result_test.jl")
     include("integration_tests.jl")
     include("monodromy_test.jl")
+    include("real_world_test.jl")
 end

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -334,7 +334,8 @@
         @test length.(multiplicities(solutions(res))) == [6,6]
 
         F_affine = subs.(F, Ref(y => 1))
-        res_affine = solve(F_affine; affine_tracking=true, threading=false)
+        res_affine = solve(F_affine; affine_tracking=true, threading=false,
+                    save_all_paths=true)
         @test nsingular(res_affine) == 12
         @test length.(multiplicities(solutions(res_affine))) == [6,6]
 


### PR DESCRIPTION
These are many small improvements to all the heuristics involved in the endgame.

This was motived by some test examples provided by @TorkelE which compared a direct solve approach against the first solve a generic instance and then solve for the specific parameters approach.

The script is now also included as a [test](https://github.com/JuliaHomotopyContinuation/HomotopyContinuation.jl/blob/8dccbc4926427a006c5aa749f94e5beb39be3a8f/test/real_world_test.jl):

Here are the results if using v0.8.0 (the i-th entries indicate how many of the 1000 runs resulted in i solutions):

```julia
# Results for the first system
[0, 0, 0, 1000, 0, 0, 0, 0, 0, 0]
[0, 0, 0, 1000, 0, 0, 0, 0, 0, 0]

# Results for the second system
[0, 42, 958, 0, 0, 0, 0, 0, 0, 0] <- ouch
[0, 0, 0, 0, 0, 43, 957, 0, 0, 0]

# Results for the third system
[0, 0, 0, 0, 0, 1000, 0, 0, 0, 0] <- one consistent lost
[0, 0, 0, 0, 0, 0, 1000, 0, 0, 0]

# Results for the fourth system
[0, 0, 0, 1000, 0, 0, 0, 0, 0, 0]
[0, 0, 978, 22, 0, 0, 0, 0, 0, 0] <- urgh
```

The results on master don't look really better.

Using this pull request we get:
```
Results for the first system
[0, 0, 0, 1000, 0, 0, 0, 0, 0, 0]
[0, 0, 0, 1000, 0, 0, 0, 0, 0, 0]

Results for the second system
[0, 0, 0, 0, 0, 10, 990, 0, 0, 0]
[0, 0, 0, 0, 0, 0, 1000, 0, 0, 0]

Results for the third system
[0, 0, 0, 0, 0, 0, 1000, 0, 0, 0]
[0, 0, 0, 0, 0, 0, 1000, 0, 0, 0]

Results for the fourth system
[0, 0, 0, 1000, 0, 0, 0, 0, 0, 0]
[0, 0, 0, 1000, 0, 0, 0, 0, 0, 0]
```

If we would use polyhedral homotopy we would get 1000 consistently.

I did not measure the effect on the performance, since I think it is more important for now to get more consistent results.