### PR TITLE
Compute all affine solutions in polyhedral homotopy by default

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -35,13 +35,14 @@ Result with 2 solutions
 
 # Polyhedral Homotopy
 
-    solve(F; start_system = :polyhedral, options...)
+    solve(F; start_system = :polyhedral, only_torus=false, options...)
 
 Solve the system `F` using a start system computed from the Newton Polytopes of the entries `F`. The number of paths to track is equal to the mixed volume of the Newton Polytopes of the entries of `F`. The mixed volume is at most the total degree of `F`. `F` can be
 - `Vector{<:MultivariatePolynomials.AbstractPolynomial}` (e.g. constructed by `@polyvar`)
 - A composition of polynomial systems constructed by [`compose`](@ref).
 - [`AbstractSystem`](@ref) (the system has to represent a **homogeneous** polynomial system.)
-solve(f; start_system = :polyhedral, affine_tracking=true, seed = 141691, save_all_paths = true)
+
+If `only_torus == true` then only solutions in the algebraic torus ``(ℂ\\{0})^n`` will be computed.
 
 ### Example
 We can solve the system ``F(x,y) = (x^2+y^2+1, 2x+3y-1)`` in the following way:

--- a/test/polyhedral_test.jl
+++ b/test/polyhedral_test.jl
@@ -31,4 +31,20 @@
         result1 = solve([(x-3),(y-2)], start_system=:polyhedral, system_scaling=true)
         @test [3,2] ≈ solutions(result1)[1] atol=1e-8
     end
+
+    @testset "All affine solutions" begin
+        @polyvar x y
+        f = [2y + 3y^2 - x*y^3, x + 4*x^2 - 2*x^3*y]
+        res = solve(f, start_system=:polyhedral, only_torus=true)
+        @test nsolutions(res) == 3
+        @test ntracked(res) == 3
+
+        res = solve(f, start_system=:polyhedral, affine_tracking=false, only_torus=false)
+        @test nsolutions(res) == 6
+        @test ntracked(res) == 8
+
+        res = solve(f, start_system=:polyhedral, affine_tracking=true, only_torus=false)
+        @test nsolutions(res) == 6
+        @test ntracked(res) == 8
+    end
 end


### PR DESCRIPTION
This adds the easy version where we extend the support if necessary to include the constant term.