### PR TITLE
Fix double printing of final progress meter

### DIFF
--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -359,7 +359,7 @@ function track(tracker::CoreTracker, x::AbstractVector, stats::MonodromyStatisti
     retcode
 end
 
-"""x
+"""
     set_parameters!(tracker::CoreTracker, e::Edge, loop::Loop)
 
 Setup the parameters in the ParameterHomotopy in `tracker` to fit the edge `e`.

--- a/src/polyhedral.jl
+++ b/src/polyhedral.jl
@@ -409,7 +409,7 @@ function track_paths(PT::PolyhedralTracker, start_solutions::PolyhedralStartSolu
     end
 
     stats = SolveStats()
-    ntracked = 1
+    ntracked = 0
     try
         nthreads = Threads.nthreads()
         if threading && nthreads > 1
@@ -430,15 +430,13 @@ function track_paths(PT::PolyhedralTracker, start_solutions::PolyhedralStartSolu
                     end
                 end
                 ntracked += 1
-                if ntracked % 32 == 0
-                    if progress !== nothing
-                        update_progress!(progress, ntracked, stats)
-                    end
+                if progress !== nothing && ntracked % 32 == 0
+                    update_progress!(progress, ntracked, stats)
                 end
             end
         end
-        if progress !== nothing
-            update_progress!(progress, ntracked - 1, stats; finished=true)
+        if progress !== nothing && ntracked % 32 != 0
+            update_progress!(progress, ntracked, stats; finished=true)
         end
     catch e
         if isa(e, InterruptException)
@@ -447,7 +445,7 @@ function track_paths(PT::PolyhedralTracker, start_solutions::PolyhedralStartSolu
             rethrow(e)
         end
     end
-    results, ntracked - 1
+    results, ntracked
 end
 
 function tracker_startsolutions(prob::PolyhedralProblem, startsolutions::PolyhedralStartSolutionsIterator; kwargs...)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -300,7 +300,8 @@ function track_paths(tracker, start_solutions;
                 end
                 k % 32 == 0 && update_progress!(progress, k, stats)
             end
-            update_progress!(progress, n, stats)
+            # don't print if it already got printed above
+            n % 32 != 0 && update_progress!(progress, n, stats)
         end
     catch e
         if isa(e, InterruptException)
@@ -336,10 +337,6 @@ function update_progress!(progress, ntracked, stats::SolveStats; finished::Bool=
     )
 
     ProgressMeter.update!(progress, ntracked; showvalues=showvalues)
-    if finished
-        ProgressMeter.finish!(progress; showvalues=showvalues)
-    end
-
     nothing
 end
 


### PR DESCRIPTION
The progress meter got printed twice if the number of paths tracked was 
a multiple of 32.