### PR TITLE
Add option to reuse loops and make it possible to set a seed.

### DIFF
--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -145,145 +145,40 @@ end
 
 export Triangle, Petal
 
-#####################
-# Nodes of the Loop
-#####################
+#######################
+# Loop data structure
+#######################
 
-"""
-    Node(p, x::UniquePoints; store_points=true, is_main_node=false)
-
-Create a node with a parameter from the same type as `p` and
-points from `x`. If `stores_points` is `true` a `UniquePoints`
-data structure is allocated to keep track of all known solutions of this node.
-"""
-struct Node{T, UP<:UniquePoints}
-    p::Vector{T}
-    points::Union{Nothing, UP}
-    # Metadata / configuration
-    main_node::Bool
+struct LoopEdge
+    p₁::Vector{ComplexF64}
+    p₀::Vector{ComplexF64}
+    weights::Union{Nothing, NTuple{2, ComplexF64}}
 end
 
-function Node(p::AbstractVector{T}, x::UP; store_points=true, is_main_node=false) where {T, UP<:UniquePoints}
-    if store_points == false
-        Node{T, typeof(x)}(Vector(p), nothing, is_main_node)
-    else
-        Node(Vector(p), x, is_main_node)
-    end
-end
-function Node(p::AbstractVector{T}, node::Node{T,UP}, options::MonodromyOptions; store_points=true, is_main_node=false) where {T, UP}
-    if store_points == false
-        Node{T, UP}(Vector(p), nothing, is_main_node)
-    else
-        Node{T, UP}(Vector(p), similar(UP), is_main_node)
-    end
-end
-
-
-"""
-    add!(node::Node, x; kwargs...)
-
-Calls [`add!`](@ref) on the points of the Node with option `Val(true)`.
-"""
-function add!(node::Node, x; kwargs...)
-    if node.points === nothing
-        nothing
-    else
-        add!(node.points, x, Val(true); kwargs...)
-    end
-end
-
-
-#####################
-# Edges of the Loop
-#####################
-"""
-    Edge(start::Int, target::Int; usegamma=false)
-
-Create an edge between two nodes references by the index. `usegamma` refers
-to an optional weight of two random complex numbers γ=(γ₁, γ₀). These are the same
-gammas as in [`ParameterHomotopy`](@ref).
-
-    Edge(edge::Edge)
-
-Construct an indentical `Edge` as `edge`, but with newly samples γ (if applicable).
-"""
-struct Edge
-    start::Int
-    target::Int
-    γ::Union{Nothing, NTuple{2, ComplexF64}}
-end
-function Edge(start::Int, target::Int; usegamma=false)
-    if usegamma
+function LoopEdge(p₁, p₀; weights=false)
+    if weights
         γ = (randn(ComplexF64), randn(ComplexF64))
     else
         γ = nothing
     end
-    Edge(start, target, γ)
-end
-function Edge(edge::Edge)
-    if edge.γ === nothing
-        edge
-    else
-        γ = (randn(ComplexF64), randn(ComplexF64))
-        Edge(edge.start, edge.target, γ)
-    end
+    LoopEdge(convert(Vector{ComplexF64}, p₁), convert(Vector{ComplexF64}, p₀), γ)
 end
 
-#######################
-# Loop data structure
-#######################
-"""
-    Loop(p, x::UniquePoints, nnodes::Int, options::MonodromyOptions; usegamma=true)
-
-Construct a loop using `nnodes` nodes with parameters of the type of `p` and solutions `x`. `usegamma` refers to the use weights on the edges. See also
-[`Edge`](@ref).
-
-    Loop(style::LoopStyle, p, x::UniquePoints, options::MonodromyOptions)
-
-Construct a loop using the defined style `style` with parameters of the type of `p` and solutions `x`.
-"""
-struct Loop{N<:Node}
-    nodes::Vector{N}
-    edges::Vector{Edge}
+struct MonodromyLoop
+    edges::Vector{LoopEdge}
 end
 
-function Loop(p₁, x₁::UP, nnodes::Int, options::MonodromyOptions; usegamma=true) where {UP<:UniquePoints}
-    n₁ = Node(p₁, x₁, is_main_node = true)
-    nodes = [n₁]
-    store_points = options.group_action_on_all_nodes && has_group_actions(options)
+function MonodromyLoop(base_p, nnodes::Int, options::MonodromyOptions; weights=true)
+    edges = LoopEdge[]
+    p₁ = base_p
     for i = 2:nnodes
-        p = options.parameter_sampler(p₁)
-        push!(nodes, Node(p, n₁, options; store_points=store_points, is_main_node=false))
+        p₀ = options.parameter_sampler(p₁)
+        push!(edges, LoopEdge(p₁, p₀; weights=weights))
+        p₁ = p₀
     end
-
-    loop = map(i -> Edge(i - 1, i; usegamma=usegamma), 2:nnodes)
-    push!(loop, Edge(nnodes, 1; usegamma=usegamma))
-
-    Loop(nodes, loop)
+    push!(edges, LoopEdge(p₁, base_p; weights=weights))
+    MonodromyLoop(edges)
 end
-
-"""
-    solutions(loop::Loop)
-
-Get the solutions of the loop.
-"""
-solutions(loop::Loop) = loop.nodes[1].points
-
-"""
-    nsolutions(loop::Loop)
-
-Get the number solutions of the loop.
-"""
-nsolutions(loop::Loop) = length(solutions(loop))
-
-"""
-    mainnode(loop::Loop)
-
-Get the main [`Node`](@ref) of the loop, i.e., the one with the original provided parameter.
-"""
-mainnode(loop::Loop) = loop.nodes[1]
-
-nextedge(loop::Loop, edge::Edge) = loop.edges[edge.target]
 
 ##############
 # Loop styles
@@ -308,8 +203,8 @@ struct Triangle <: LoopStyle
 end
 Triangle(;useweights=true) = Triangle(useweights)
 
-function Loop(strategy::Triangle, p, x::UP, options::MonodromyOptions) where {UP<:UniquePoints}
-    Loop(p, x, 3, options, usegamma=strategy.useweights)
+function MonodromyLoop(strategy::Triangle, p, options::MonodromyOptions)
+    MonodromyLoop(p, 3, options, weights=strategy.useweights)
 end
 
 """
@@ -319,17 +214,17 @@ A petal is a loop consisting of the main node and one other node connected
 by two edges with different random weights.
 """
 struct Petal <: LoopStyle end
-function Loop(strategy::Petal, p, x::UP, options::MonodromyOptions) where {UP<:UniquePoints}
-    Loop(p, x, 2, options, usegamma=true)
+function MonodromyLoop(strategy::Petal, p, options::MonodromyOptions)
+    MonodromyLoop(p, 2, options, weights=true)
 end
 
 
 """
-    regenerate!(loop::Loop, options::MonodromyOptions, stats::MonodromyStatistics)
+    regenerate!(loop::MonodromyLoop, options::MonodromyOptions, stats::MonodromyStatistics)
 
 Regenerate all random parameters in the loop in order to introduce a new monodromy action.
 """
-function regenerate!(loop::Loop, options::MonodromyOptions, stats::MonodromyStatistics)
+function regenerate!(loop::MonodromyLoop, options::MonodromyOptions, stats::MonodromyStatistics)
     main = mainnode(loop)
 
     # The first node is the main node and doesn't get touched
@@ -344,33 +239,23 @@ end
 
 
 """
-    track(tracker, x::AbstractVector, edge::Edge, loop::Loop, stats::MonodromyStatistics)
+    track(tracker, x::AbstractVector, edge::LoopEdge, loop::MonodromyLoop, stats::MonodromyStatistics)
 
 Track `x` along the edge `edge` in the loop `loop` using `tracker`. Record statistics
 in `stats`.
 """
-function track(tracker::CoreTracker, x::AbstractVector, edge::Edge, loop::Loop, stats::MonodromyStatistics)
-    set_parameters!(tracker, edge, loop)
-    track(tracker, x, stats)
-end
-function track(tracker::CoreTracker, x::AbstractVector, stats::MonodromyStatistics)
-    retcode = track!(tracker, x, 1.0, 0.0)
-    trackedpath!(stats, retcode)
-    retcode
-end
-
-"""
-    set_parameters!(tracker::CoreTracker, e::Edge, loop::Loop)
-
-Setup the parameters in the ParameterHomotopy in `tracker` to fit the edge `e`.
-"""
-function set_parameters!(tracker::CoreTracker, e::Edge, loop::Loop)
+function track(tracker::CoreTracker, x::AbstractVector, loop::MonodromyLoop, stats::MonodromyStatistics)
     H = basehomotopy(tracker.homotopy)
-    if !(H isa ParameterHomotopy)
-        error("Base homotopy is not a ParameterHomotopy")
+    local retcode::CoreTrackerStatus.states
+    y = x
+    for e in loop.edges
+        set_parameters!(H, (e.p₁, e.p₀), e.weights)
+        retcode = track!(tracker, y)
+        trackedpath!(stats, retcode)
+        retcode == CoreTrackerStatus.success || break
+        y = current_x(tracker)
     end
-    p = (loop.nodes[e.start].p, loop.nodes[e.target].p)
-    set_parameters!(H, p, e.γ)
+    retcode
 end
 
 
@@ -516,7 +401,7 @@ parameters(r::MonodromyResult) = r.parameters
 ## monodromy solve ##
 #####################
 """
-MonodromyCache{FT<:FixedHomotopy, Tracker<:CoreTracker, NC<:AbstractNewtonCache}
+    MonodromyCache{FT<:FixedHomotopy, Tracker<:CoreTracker, NC<:AbstractNewtonCache}
 
 Cache for monodromy loops.
 """
@@ -527,37 +412,23 @@ struct MonodromyCache{FT<:FixedHomotopy, Tracker<:CoreTracker, NC<:AbstractNewto
     out::AV
 end
 
-
-"""
-    monodromy_solve(F, sols, p; parameters=..., options..., pathtrackerkwargs...)
-
-Solve a polynomial system `F(x;p)` with specified parameters and initial solutions `sols`
-by monodromy techniques. This makes loops in the parameter space of `F` to find new solutions.
-
-## Options
-* `target_solutions_count=nothing`: The computations are stopped if this number of solutions is reached.
-* `done_callback=always_false`: A callback to end the computation early. This function takes 2 arguments. The first one is the new solution `x` and the second one are all current solutions (including `x`). Return `true` if the compuation is done.
-* `max_loops_no_progress::Int=10`: The maximal number of iterations (i.e. loops generated) without any progress.
-* `group_action=nothing`: A function taking one solution and returning other solutions if there is a constructive way to obtain them, e.g. by symmetry.
-* `strategy`: The strategy used to create loops. If `F` only depends linearly on `p` this will be [`Petal`](@ref). Otherwise this will be [`Triangle`](@ref) with weights if `F` is a real system.
-* `show_progress=true`: Enable a progress meter.
-* `distance_function=euclidean_distance`: The distance function used for [`UniquePoints`](@ref).
-* `identical_tol::Float64=1e-6`: The tolerance with which it is decided whether two solutions are identical.
-* `group_actions=nothing`: If there is more than one group action you can use this to chain the application of them. For example if you have two group actions `foo` and `bar` you can set `group_actions=[foo, bar]`. See [`GroupActions`](@ref) for details regarding the application rules.
-* `group_action_on_all_nodes=false`: By default the group_action(s) are only applied on the solutions with the main parameter `p`. If this is enabled then it is applied for every parameter `q`.
-* `parameter_sampler=independent_normal`: A function taking the parameter `p` and returning a new random parameter `q`. By default each entry of the parameter vector is drawn independently from the univariate normal distribution.
-* `equivalence_classes=true`: This only applies if there is at least one group action supplied. We then consider two solutions in the same equivalence class if we can transform one to the other by the supplied group actions. We only track one solution per equivalence class.
-* `check_startsolutions=true`: If `true`, we do a Newton step for each entry of `sols`for checking if it is a valid startsolutions. Solutions which are not valid are sorted out.
-* `timeout=float(typemax(Int))`: The maximal number of *seconds* the computation is allowed to run.
-* `min_solutions`: The minimal number of solutions before a stopping heuristic is applied. By default this is half of `target_solutions_count` if applicable otherwise 2.
-"""
-function monodromy_solve(F::Inputs, solution::Vector{<:Number}, p₀::AbstractVector{TP}; kwargs...) where {TP}
-    monodromy_solve(F, [solution], p₀; kwargs...)
+struct MonodromySolver{T<:Number, UP<:UniquePoints, MO<:MonodromyOptions, MC<:MonodromyCache}
+    parameters::Vector{T}
+    solutions::UP
+    loops::Vector{MonodromyLoop}
+    options::MO
+    statistics::MonodromyStatistics
+    cache::MC
 end
-function monodromy_solve(F::Inputs, solutions::Vector{<:AbstractVector{<:Number}}, p₀::AbstractVector{TP}; kwargs...) where {TP}
-    monodromy_solve(F, static_solutions(solutions), p₀; kwargs...)
+
+
+function MonodromySolver(F::Inputs, solution::Vector{<:Number}, p₀::AbstractVector{TP}; kwargs...) where {TP}
+    MonodromySolver(F, [solution], p₀; kwargs...)
 end
-function monodromy_solve(F::Inputs,
+function MonodromySolver(F::Inputs, solutions::Vector{<:AbstractVector{<:Number}}, p₀::AbstractVector{TP}; kwargs...) where {TP}
+    MonodromySolver(F, static_solutions(solutions), p₀; kwargs...)
+end
+function MonodromySolver(F::Inputs,
         startsolutions::Vector{<:SVector{NVars, <:Complex}},
         p::AbstractVector{TP};
         parameters=nothing,
@@ -615,47 +486,57 @@ function monodromy_solve(F::Inputs,
         add!(uniquepoints, startsolutions; tol=options.identical_tol)
     end
     statistics = MonodromyStatistics(uniquepoints)
-    if  length(points(uniquepoints)) == 0
-        @warn "None of the provided solutions is a valid start solution."
-        return MonodromyResult(:invalid_startvalue,
-                Vector{SVector{length(startsolutions[1]),ComplexF64}}(), p₀, statistics,
-                options.equivalence_classes)
-    end
 
     if strategy === nothing
         strategy = default_strategy(F, parameters, p; is_real_system=is_real_system)
     end
 
     # construct Loop
-    loop = Loop(strategy, p₀, uniquepoints, options)
+    loops = [MonodromyLoop(strategy, p₀, options)]
 
-    # solve
-    retcode = :not_assigned
-    if show_progress
-        if !options.equivalence_classes
-            desc = "Solutions found:"
-        else
-            desc = "Classes of solutions (modulo group action) found:"
-        end
-        progress = ProgressMeter.ProgressUnknown(desc; delay=0.5, clear_output_ijulia=true)
-    else
-        progress = nothing
-    end
+    MonodromySolver(p₀, uniquepoints, loops, options, statistics, C)
+end
 
-    n_blas_threads = single_thread_blas()
-    try
-        retcode = monodromy_solve!(loop, C, options, statistics, progress)
-    catch e
-        if (e isa InterruptException)
-            retcode = :interrupt
-        else
-            rethrow(e)
-        end
-    end
-    n_blas_threads > 1 && set_num_BLAS_threads(n_blas_threads)
+"""
+    solutions(MS::MonodromySolver)
 
-    finished!(statistics, nsolutions(loop))
-    MonodromyResult(retcode, points(solutions(loop)), p₀, statistics, options.equivalence_classes)
+Get the solutions of the loop.
+"""
+solutions(MS::MonodromySolver) = MS.solutions.points
+
+"""
+    nsolutions(loop::MonodromyLoop)
+
+Get the number solutions of the loop.
+"""
+nsolutions(MS::MonodromySolver) = length(solutions(MS))
+
+
+"""
+    monodromy_solve(F, sols, p; parameters=..., options..., pathtrackerkwargs...)
+
+Solve a polynomial system `F(x;p)` with specified parameters and initial solutions `sols`
+by monodromy techniques. This makes loops in the parameter space of `F` to find new solutions.
+
+## Options
+* `target_solutions_count=nothing`: The computations are stopped if this number of solutions is reached.
+* `done_callback=always_false`: A callback to end the computation early. This function takes 2 arguments. The first one is the new solution `x` and the second one are all current solutions (including `x`). Return `true` if the compuation is done.
+* `max_loops_no_progress::Int=10`: The maximal number of iterations (i.e. loops generated) without any progress.
+* `group_action=nothing`: A function taking one solution and returning other solutions if there is a constructive way to obtain them, e.g. by symmetry.
+* `strategy`: The strategy used to create loops. If `F` only depends linearly on `p` this will be [`Petal`](@ref). Otherwise this will be [`Triangle`](@ref) with weights if `F` is a real system.
+* `show_progress=true`: Enable a progress meter.
+* `distance_function=euclidean_distance`: The distance function used for [`UniquePoints`](@ref).
+* `identical_tol::Float64=1e-6`: The tolerance with which it is decided whether two solutions are identical.
+* `group_actions=nothing`: If there is more than one group action you can use this to chain the application of them. For example if you have two group actions `foo` and `bar` you can set `group_actions=[foo, bar]`. See [`GroupActions`](@ref) for details regarding the application rules.
+* `group_action_on_all_nodes=false`: By default the group_action(s) are only applied on the solutions with the main parameter `p`. If this is enabled then it is applied for every parameter `q`.
+* `parameter_sampler=independent_normal`: A function taking the parameter `p` and returning a new random parameter `q`. By default each entry of the parameter vector is drawn independently from the univariate normal distribution.
+* `equivalence_classes=true`: This only applies if there is at least one group action supplied. We then consider two solutions in the same equivalence class if we can transform one to the other by the supplied group actions. We only track one solution per equivalence class.
+* `check_startsolutions=true`: If `true`, we do a Newton step for each entry of `sols`for checking if it is a valid startsolutions. Solutions which are not valid are sorted out.
+* `timeout=float(typemax(Int))`: The maximal number of *seconds* the computation is allowed to run.
+* `min_solutions`: The minimal number of solutions before a stopping heuristic is applied. By default this is half of `target_solutions_count` if applicable otherwise 2.
+"""
+function monodromy_solve(args...; show_progress=true, kwargs...)
+    monodromy_solve!(MonodromySolver(args...; kwargs...); show_progress=show_progress)
 end
 
 function default_strategy(F::MPPolyInputs, parameters, p₀::AbstractVector{TP}; is_real_system=false) where {TC,TP}
@@ -705,29 +586,63 @@ end
 #################
 
 """
-    Job{N, T}
+    MonodromyJob
 
-A `Job` is consisting of an `Edge` and a solution to the start node of this edge.
+A `MonodromyJob` is consisting of a solution id and a loop id.
 """
-struct Job{N, T}
-    x::SVector{N, T}
-    edge::Edge
+struct MonodromyJob
+    id::Int
+    loop_id::Int
 end
 
-function monodromy_solve!(loop::Loop, C::MonodromyCache, options::MonodromyOptions,
-    stats::MonodromyStatistics, progress)
+function monodromy_solve!(MS::MonodromySolver; show_progress=true)
+    if nsolutions(MS) == 0
+        @warn "None of the provided solutions is a valid start solution."
+        return MonodromyResult(:invalid_startvalue,
+                similar(MS.solutions.points, 0), MS.parameters, MS.statistics,
+                MS.options.equivalence_classes)
+    end
+    # solve
+    retcode = :not_assigned
+    if show_progress
+        if !MS.options.equivalence_classes
+            desc = "Solutions found:"
+        else
+            desc = "Classes of solutions (modulo group action) found:"
+        end
+        progress = ProgressMeter.ProgressUnknown(desc; delay=0.5, clear_output_ijulia=true)
+    else
+        progress = nothing
+    end
 
+    n_blas_threads = single_thread_blas()
+    try
+        retcode = monodromy_solve!(MS, progress)
+    catch e
+        if (e isa InterruptException)
+            retcode = :interrupt
+        else
+            rethrow(e)
+        end
+    end
+    n_blas_threads > 1 && set_num_BLAS_threads(n_blas_threads)
+    finished!(MS.statistics, nsolutions(MS))
+    MonodromyResult(retcode, solutions(MS), MS.parameters, MS.statistics, MS.options.equivalence_classes)
+end
+
+
+function monodromy_solve!(MS::MonodromySolver, progress::Union{Nothing,ProgressMeter.ProgressUnknown})
     t₀ = time_ns()
     iterations_without_progress = 0 # stopping heuristic
     # intialize job queue
-    queue = map(x -> Job(x, loop.edges[1]), solutions(loop))
+    queue = MonodromyJob.(1:nsolutions(MS), 1)
 
-    n = nsolutions(loop)
-    while n < options.target_solutions_count
-        retcode = empty_queue!(queue, loop, C, options, t₀, stats, progress)
+    n = nsolutions(MS)
+    while n < MS.options.target_solutions_count
+        retcode = empty_queue!(queue, MS, t₀, progress)
 
         if retcode == :done
-            update_progress!(progress, loop, stats; finish=true)
+            update_progress!(progress, nsolutions(MS), MS.statistics; finish=true)
             break
         elseif retcode == :timeout
             return :timeout
@@ -736,37 +651,36 @@ function monodromy_solve!(loop::Loop, C::MonodromyCache, options::MonodromyOptio
         end
 
         # Iterations heuristic
-        n_new = nsolutions(loop)
+        n_new = nsolutions(MS)
         if n == n_new
             iterations_without_progress += 1
         else
             iterations_without_progress = 0
             n = n_new
         end
-        if iterations_without_progress == options.max_loops_no_progress &&
-            n_new ≥ options.min_solutions
+        if iterations_without_progress == MS.options.max_loops_no_progress &&
+            n_new ≥ MS.options.min_solutions
             return :heuristic_stop
         end
 
-        regenerate_loop_and_schedule_jobs!(queue, loop, options, stats)
+        regenerate_loop_and_schedule_jobs!(queue, MS)
     end
 
     :success
 end
 
-function empty_queue!(queue, loop::Loop, C::MonodromyCache, options::MonodromyOptions,
-        t₀::UInt, stats::MonodromyStatistics, progress)
+function empty_queue!(queue, MS::MonodromySolver, t₀::UInt, progress)
     while !isempty(queue)
         job = pop!(queue)
-        status = process!(queue, job, C, loop, options, stats, progress)
+        status = process!(queue, job, MS, progress)
         if status == :done
             return :done
         elseif status == :invalid_startvalue
             return :invalid_startvalue
         end
-        update_progress!(progress, loop, stats)
+        update_progress!(progress, nsolutions(MS), MS.statistics)
         # check timeout
-        if (time_ns() - t₀) > options.timeout * 1e9 # convert s to ns
+        if (time_ns() - t₀) > MS.options.timeout * 1e9 # convert s to ns
             return :timeout
         end
     end
@@ -792,72 +706,59 @@ end
 affine_chart(x::SVector, y::PVector) = ProjectiveVectors.affine_chart!(x, y)
 affine_chart(x::SVector{N, T}, y::AbstractVector) where {N, T} = SVector{N,T}(y)
 
-function process!(queue::Vector{<:Job}, job::Job, C::MonodromyCache, loop::Loop, options::MonodromyOptions, stats::MonodromyStatistics, progress)
-    retcode = track(C.tracker, job.x, job.edge, loop, stats)
+function process!(queue, job::MonodromyJob, MS::MonodromySolver, progress)
+    x = solutions(MS)[job.id]
+    loop = MS.loops[job.loop_id]
+    retcode = track(MS.cache.tracker, x, loop, MS.statistics)
     if retcode ≠ CoreTrackerStatus.success
-        if retcode == CoreTrackerStatus.terminated_invalid_startvalue && stats.ntrackedpaths == 0
+        if retcode == CoreTrackerStatus.terminated_invalid_startvalue &&
+           MS.statistics.ntrackedpaths == 0
             return :invalid_startvalue
         end
         return :incomplete
     end
 
-    node = loop.nodes[job.edge.target]
 
-    if node.main_node
-        y = verified_affine_vector(C, current_x(C.tracker), job.x, options)
-        # is the solution at infinity?
-        if y === nothing
-            return :incomplete
-        end
-    else
-        y = affine_chart(job.x, current_x(C.tracker))
-    end
-    next_edge = nextedge(loop, job.edge)
-    add_and_schedule!(node, queue, y, options, stats, next_edge) && return :done
+    y = verified_affine_vector(MS.cache, current_x(MS.cache.tracker), x, MS.options)
+    # is the solution at infinity?
+    y !== nothing || return :incomplete
 
-    if options.complex_conjugation
-        add_and_schedule!(node, queue, conj.(y), options, stats, next_edge) && return :done
+    add_and_schedule!(MS, queue, y, job) && return :done
+
+    if MS.options.complex_conjugation
+        add_and_schedule!(MS, queue, conj.(y), job) && return :done
     end
 
-    if !options.equivalence_classes && node.points !== nothing
-        apply_actions(options.group_actions, y) do yᵢ
-            add_and_schedule!(node, queue, yᵢ, options, stats, next_edge)
+    if !MS.options.equivalence_classes
+        apply_actions(MS.options.group_actions, y) do yᵢ
+            add_and_schedule!(MS, queue, yᵢ, job)
         end
     end
     return :incomplete
 end
 
 """
-    add_and_schedule!(node, queue::Vector{Job{N,T}}, y, options, stats, nextedge)
+    add_and_schedule!(MS, queue, y, job)
 
 Add `y` to the current `node` (if it not already exists) and schedule a new job to the `queue`.
 Returns `true` if we are done. Otherwise `false`.
 """
-function add_and_schedule!(node, queue::Vector{Job{N,T}}, y, options, stats, next_edge) where {N,T}
-    k = add!(node, y; tol=options.identical_tol)
-    if k == NOT_FOUND
+function add_and_schedule!(MS::MonodromySolver, queue, y, job::MonodromyJob) where {N,T}
+    k = add!(MS.solutions, y, Val(true); tol=MS.options.identical_tol)
+    if k == NOT_FOUND || k == NOT_FOUND_AND_REAL
         # Check if we are done
-        node.main_node && isdone(node, y, options) && return true
-        push!(queue, Job(SVector{N,T}(y), next_edge))
-    elseif k == NOT_FOUND_AND_REAL
-        # If we are on the main node check whether we have a real root.
-        if node.main_node
-            stats.nreal +=1
-        end
-        # Check if we are done
-        node.main_node && isdone(node, y, options) && return true
-        push!(queue, Job(SVector{N,T}(y), next_edge))
-    elseif k === nothing
-        push!(queue, Job(SVector{N,T}(y), next_edge))
+        isdone(MS.solutions, y, MS.options) && return true
+        push!(queue, MonodromyJob(nsolutions(MS), job.loop_id))
+        # TODO: Schedule on other loops
     end
+    MS.statistics.nreal += (k == NOT_FOUND_AND_REAL)
     false
 end
 
-function update_progress!(::Nothing, loop::Loop, statistics::MonodromyStatistics; finish=false)
+function update_progress!(::Nothing, nsolutions, statistics::MonodromyStatistics; finish=false)
     nothing
 end
-function update_progress!(progress, loop::Loop, statistics::MonodromyStatistics; finish=false)
-    nsolutions = length(solutions(loop))
+function update_progress!(progress, nsolutions, statistics::MonodromyStatistics; finish=false)
     ProgressMeter.update!(progress, nsolutions, showvalues=(
         ("# paths tracked", statistics.ntrackedpaths),
         ("# loops generated", statistics.nparametergenerations),
@@ -871,20 +772,18 @@ function update_progress!(progress, loop::Loop, statistics::MonodromyStatistics;
     nothing
 end
 
-function isdone(node::Node, x, options::MonodromyOptions)
-    !node.main_node && return false
-
-    options.done_callback(x, node.points) ||
-    length(node.points) ≥ options.target_solutions_count
+function isdone(solutions::UniquePoints, x, options::MonodromyOptions)
+    options.done_callback(x, solutions.points) ||
+    length(solutions) ≥ options.target_solutions_count
 end
 
-function regenerate_loop_and_schedule_jobs!(queue, loop::Loop, options::MonodromyOptions, stats::MonodromyStatistics)
-    sols = solutions(loop)
-    # create a new loop by regenerating the parameters (but don't touch our
-    # main node)
-    regenerate!(loop, options, stats)
-    for x in sols
-        push!(queue, Job(x, loop.edges[1]))
+function regenerate_loop_and_schedule_jobs!(queue, MS::MonodromySolver)
+    es = MS.loops[1].edges
+    loop = MonodromyLoop(MS.parameters, length(es), MS.options, weights=!isnothing(es[1].weights))
+    MS.loops[1] = loop
+    for id in 1:nsolutions(MS)
+        push!(queue, MonodromyJob(id, 1))
     end
+    generated_parameters!(MS.statistics, nsolutions(MS))
     nothing
 end

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -40,6 +40,13 @@ end
         @test length(HC.UniquePoints(result.solutions).points) == 21
         @test isempty(sprint(show, result)) == false
 
+        # test seed
+        result2 = monodromy_solve(F, x₀, p₀, parameters=p,
+                target_solutions_count=21,
+                max_loops_no_progress=20,
+                seed=result.seed)
+        @test result2.statistics.ntrackedpaths == result.statistics.ntrackedpaths
+
         # test input of length > 1
         result = monodromy_solve(F, [x₀ for _ in 1:30], p₀, parameters=p)
         @test length(solutions(result)) == 21

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -143,6 +143,27 @@ end
                         target_solutions_count=7,
                         max_loops_no_progress=200)
         @test length(result.solutions) == 7
+
+
+        # test reuse strategies
+        result = monodromy_solve(F_p, x₀, p₀,
+                        group_action=roots_of_unity,
+                        target_solutions_count=7,
+                        reuse_loops=:all,
+                        max_loops_no_progress=200)
+        @test length(result.solutions) == 7
+        result = monodromy_solve(F_p, x₀, p₀,
+                        group_action=roots_of_unity,
+                        target_solutions_count=7,
+                        reuse_loops=:random,
+                        max_loops_no_progress=200)
+        @test length(result.solutions) == 7
+        result = monodromy_solve(F_p, x₀, p₀,
+                        group_action=roots_of_unity,
+                        target_solutions_count=7,
+                        reuse_loops=:none,
+                        max_loops_no_progress=200)
+        @test length(result.solutions) == 7
     end
 
     @testset "Method of Moments" begin


### PR DESCRIPTION
In our monodromy routine we so far created a loop and threw aways the old one.
This introduces the possibility to reuse the old loops with the keyword `reuse_loops`. The possible options are:

* `:none`: Old behaviour
* `:all`: If we find a new solution schedule jobs to also move the solution along all other loops
* `:random`: If we find a new solution schedule a job to also move the solution along a random other loop.

I compared the performance of the different options with our method of moments example using the group actions and setting the target solutions count for 50 random runs.

Triangle strategy:

| | :none | :all | :random |
|----------|-------|------|---------|
|     mean |  1909 | 1678 |    1795 |
|   median |  1863 | 1673 |    1849 |
|      max |  2769 | 2648 |    4101 |
|      min |  1167 | 1205 |    1205 |

Petal strategy:

| | :none | :all | :random |
|----------|-------|------|---------|
|     mean |  1448 | 1278 |    1379 |
|   median |  1310 | 1276 |    1245 |
|      max |  3637 | 2268 |    3061 |
|      min |   715 |  785 |     785 |


From this data I decided to set all `:all` as the default.

This also contains a slight refactor of the internals to accommodate the changes.