### PR TITLE
Fix polyhedral homotopy for univariate polynomials

### DIFF
--- a/src/utilities/linear_algebra.jl
+++ b/src/utilities/linear_algebra.jl
@@ -557,6 +557,12 @@ function hnf!(A, U)
         #5
         reduce_off_diagonal!(A, U, ii)
     end
+    # Special case for 1 × 1 matrices to guarantee that the diagonal is positive
+    # This comes up in polyhedral homotopy for univariate polynomials
+    if n == 1
+        U[1,1] = flipsign(U[1,1], A[1,1])
+        A[1,1] = flipsign(A[1,1], A[1,1])
+    end
 
     nothing
 end

--- a/test/polyhedral_test.jl
+++ b/test/polyhedral_test.jl
@@ -35,6 +35,11 @@
         @test [3,2] ≈ solutions(result1)[1] atol=1e-8
         result1 = solve([(x-3),(y-2)], start_system=:polyhedral, system_scaling=:equations_and_variables)
         @test [3,2] ≈ solutions(result1)[1] atol=1e-8
+
+        g = (x-3)*(x+2)*(x-0.5)
+        result2 = solve([g], start_system=:polyhedral)
+        @test nsolutions(result2) == 3
+        @test sort!(first.(real_solutions(result2))) ≈ [-2,0.5,3] atol=1e-10
     end
 
     @testset "All affine solutions" begin

--- a/test/utilities_test.jl
+++ b/test/utilities_test.jl
@@ -380,9 +380,15 @@
         @test string(segment) == "ComplexSegment(2.0 + 0.0im, 4.0 + 0.0im)"
     end
 
-    @testset "Linear Algebra" begin
+    @testset "Hermite Normal Form" begin
         A = [0 3 1 0; -2 2 -1 2; 1 -1 2 3; -3 3 3 2]
         H, U = HC.hnf(A)
         @test A * U == H
+
+        D = zeros(Int, 1,1)
+        D[1,1] = -2
+        H, U = HC.hnf(D)
+        @test H[1,1] == 2
+        @test U[1,1] == -1
     end
 end


### PR DESCRIPTION
The Hermite Normal Form of a 1 by 1 matrix did not guarantee that the diagonal 
is positive. This then trickled down...