### PR TITLE
Hoist variable in lu out of loop

### DIFF
--- a/src/utilities/linear_algebra.jl
+++ b/src/utilities/linear_algebra.jl
@@ -354,8 +354,9 @@ end
             end
             # Update the rest
             for j = k+1:n
+                A_kj = A[k,j]
                 for i = k+1:m
-                    A[i,j] -= A[i,k]*A[k,j]
+                    A[i,j] -= A[i,k] * A_kj
                 end
             end
         end


### PR DESCRIPTION
This small change seems to speedup our LU by 7% - 10%:

```
n = 2
Old:
  46.589 ns (0 allocations: 0 bytes)
New:
  45.304 ns (0 allocations: 0 bytes)
n = 3
Old:
  65.330 ns (0 allocations: 0 bytes)
New:
  63.602 ns (0 allocations: 0 bytes)
n = 4
Old:
  90.784 ns (0 allocations: 0 bytes)
New:
  87.070 ns (0 allocations: 0 bytes)
n = 5
Old:
  137.552 ns (0 allocations: 0 bytes)
New:
  128.467 ns (0 allocations: 0 bytes)
n = 6
Old:
  188.314 ns (0 allocations: 0 bytes)
New:
  188.592 ns (0 allocations: 0 bytes)
n = 7
Old:
  260.409 ns (0 allocations: 0 bytes)
New:
  234.216 ns (0 allocations: 0 bytes)
n = 8
Old:
  357.719 ns (0 allocations: 0 bytes)
New:
  318.561 ns (0 allocations: 0 bytes)
n = 9
Old:
  479.436 ns (0 allocations: 0 bytes)
New:
  431.528 ns (0 allocations: 0 bytes)
n = 10
Old:
  613.529 ns (0 allocations: 0 bytes)
New:
  563.371 ns (0 allocations: 0 bytes)
n = 11
Old:
  773.916 ns (0 allocations: 0 bytes)
New:
  714.000 ns (0 allocations: 0 bytes)
n = 12
Old:
  961.391 ns (0 allocations: 0 bytes)
New:
  885.961 ns (0 allocations: 0 bytes)
n = 13
Old:
  1.190 μs (0 allocations: 0 bytes)
New:
  1.111 μs (0 allocations: 0 bytes)
n = 14
Old:
  1.417 μs (0 allocations: 0 bytes)
New:
  1.324 μs (0 allocations: 0 bytes)
n = 15
Old:
  1.683 μs (0 allocations: 0 bytes)
New:
  1.580 μs (0 allocations: 0 bytes)
```