### PR TITLE
Automatically compute start pair for monodromy in simple cases

### DIFF
--- a/test/valuation_test.jl
+++ b/test/valuation_test.jl
@@ -168,7 +168,7 @@
         S = collect(starts)
         state = tracker.state
         val = HC.Valuation(state.x; affine = true)
-        init!(tracker, S[1], 0.0, 20.0)
+        init!(tracker, S[1], 0.0, 25.0)
         for _ in tracker
             if !state.last_step_failed
                 HC.update!(val, state.x, state.ẋ, state.s)
@@ -197,7 +197,7 @@
         # PROJECTIVE VALUATIONS
 
         val = HC.Valuation(state.x; affine = false)
-        init!(tracker, S[1], 0.0, 20.0)
+        init!(tracker, S[1], 0.0, 25.0)
         for _ in tracker
             if !state.last_step_failed
                 HC.update!(val, state.x, state.ẋ, state.s)
@@ -211,7 +211,7 @@
         # Use analytic estimates for ν̇ and ν̈
         init!(val)
         @test all(isnan, val.ν)
-        init!(tracker, S[1], 0.0, 20.0)
+        init!(tracker, S[1], 0.0, 25.0)
         for _ in tracker
             if !state.last_step_failed
                 HC.update!(val, state.x, state.ẋ, state.s, tracker.predictor)


### PR DESCRIPTION
In general, it would be nice to automatically try to compute a start pair for the monodromy method using, for example, a newton homotopy. 
If the system is over parameterized and all parameters are only linear in the parameters, then the computation of a start pair for the monodromy method is trivial since it is basically solving a linear system. This PR implements exactly this case and throws an error if this approach fails.