### PR TITLE
Make monodromy work correctly with projective vectors

### DIFF
--- a/src/HomotopyContinuation.jl
+++ b/src/HomotopyContinuation.jl
@@ -23,6 +23,7 @@ using DynamicPolynomials: @polyvar, subs, differentiate
 using ProjectiveVectors: PVector,
                          dims,
                          dimension_indices,
+                         fubini_study,
                          affine_chart,
                          ×,
                          component,
@@ -39,7 +40,15 @@ const SP = StaticPolynomials
 export @polyvar, subs, differentiate
 export mixed_volume
 export cond
-export PVector, dims, dimension_indices, affine_chart, ×, component, components, combine
+export PVector,
+       dims,
+       dimension_indices,
+       affine_chart,
+       fubini_study,
+       ×,
+       component,
+       components,
+       combine
 
 include("progress_meter.jl")
 import .ProgressMeter

--- a/src/HomotopyContinuation.jl
+++ b/src/HomotopyContinuation.jl
@@ -53,8 +53,8 @@ export PVector,
 include("progress_meter.jl")
 import .ProgressMeter
 
-include("utilities.jl")
 include("norms.jl")
+include("utilities.jl")
 include("linear_algebra.jl")
 include("affine_patches.jl")
 

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -465,7 +465,7 @@ nsolutions(res::MonodromyResult) = length(res.solutions)
 Returns the solutions of `res` whose imaginary part has norm less than 1e-6.
 """
 function real_solutions(res::MonodromyResult; tol = 1e-6)
-    map(r -> real.(r), filter(r -> LinearAlgebra.norm(imag.(r)) < tol, res.solutions))
+    map(r -> real_vector(r), filter(r -> is_real_vector(r, tol), res.solutions))
 end
 
 """
@@ -474,7 +474,7 @@ end
 Counts how many solutions of `res` have imaginary part norm less than 1e-6.
 """
 function nreal(res::MonodromyResult; tol = 1e-6)
-    count(r -> LinearAlgebra.norm(imag.(r)) < tol, res.solutions)
+    count(r -> is_real_vector(r, tol), res.solutions)
 end
 
 """

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -809,7 +809,7 @@ function problem_startsolutions(
         F, variable_groups, homvars = homogenize_if_necessary(
             input.system,
             hominfo;
-            variables = variables,
+            vars = variables,
             parameters = input.parameters,
         )
     end

--- a/src/result.jl
+++ b/src/result.jl
@@ -430,7 +430,7 @@ julia> real_solutions(result)
 ```
 """
 function real_solutions(result::Results; only_real = true, tol = 1e-6, kwargs...)
-    mapresults(r -> real.(solution(r)), result; only_real = true, real_tol = tol, kwargs...)
+    mapresults(r -> real_vector(solution(r)), result; only_real = true, real_tol = tol, kwargs...)
 end
 @deprecate realsolutions(result; kwargs...) real_solutions(result; kwargs...)
 

--- a/src/result.jl
+++ b/src/result.jl
@@ -430,7 +430,7 @@ julia> real_solutions(result)
 ```
 """
 function real_solutions(result::Results; only_real = true, tol = 1e-6, kwargs...)
-    mapresults(r -> real_vector(solution(r)), result; only_real = true, real_tol = tol, kwargs...)
+    mapresults(real_vector ∘ solution, result; only_real = true, real_tol = tol, kwargs...)
 end
 @deprecate realsolutions(result; kwargs...) real_solutions(result; kwargs...)
 

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -254,17 +254,6 @@ than `norm(z, Inf)`.
 """
 infinity_norm(z::AbstractVector{<:Complex}) = sqrt(maximum(abs2, z))
 
-"""
-    fubini_study(x::PVector, y::PVector)
-
-Computes the Fubini-Study distance between `x` and `y`.
-"""
-function fubini_study(x::PVector{<:Number,1}, y::PVector{<:Number,1})
-    acos(min(1.0, abs(first(LinearAlgebra.dot(x, y)))))
-end
-function fubini_study(x::PVector{<:Number,M}, y::PVector{<:Number,M}) where {M}
-    sqrt(sum(abs2.(acos.(min.(1.0, abs.(LinearAlgebra.dot(x, y)))))))
-end
 
 function randomish_gamma()
     # Usually values near 1, i, -i, -1 are not good randomization

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -221,6 +221,30 @@ is_real_vector(z::NTuple{N,T}, tol = 1e-6) where {N,T} = is_real_vector(SVector{
 is_real_vector(v::PVector, tol = 1e-6) = isreal(v, tol)
 
 """
+    real_vector(v)
+
+Obtain the real part of a vector.
+"""
+function real_vector(v::PVector{T}) where {T}
+    w = LA.normalize(v)
+    λ = map(dimension_indices(w)) do rᵢ
+        maxᵢ = zero(real(T))
+        max_ind = 0
+        for i in rᵢ
+            wᵢ = abs(w[i])
+            if wᵢ > maxᵢ
+                max_ind = i
+                maxᵢ = wᵢ
+            end
+        end
+        cis(-angle(w[max_ind]))
+    end
+    LA.rmul!(w, λ)
+    real.(w)
+end
+real_vector(v::AbstractVector) = real.(v)
+
+"""
     randseed(range=1_000:1_000_000)
 
 Return a random seed in the range `range`.

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -437,4 +437,29 @@
         @test_throws ArgumentError HC.find_start_pair(C, u)
     end
 
+    @testset "projective" begin
+        @polyvar x y z a b c
+        f = x^2 + y^2 - z^2
+        l = a * x + b * y + c * z
+
+        v = PVector([-0.6 - 0.8im, -1.2 + 0.4im, 1])
+        res = monodromy_solve([f, l], v, [1, 2, 3]; parameters = [a, b, c])
+        @test is_heuristic_stop(res)
+        @test nsolutions(res) == 2
+        @test isempty(real_solutions(res))
+
+        @polyvar x y u v a b
+        f = [x * y - a * u * v, x^2 - b * u^2]
+        res = monodromy_solve(
+            f,
+            PVector([√2, 1], [√2, 1]),
+            [2, 2];
+            variable_groups = [[x, u], [y, v]],
+            parameters = [a, b],
+        )
+        @test is_heuristic_stop(res)
+        @test nsolutions(res) == 2
+        @test nreal(res) == 2
+        @test sum(fubini_study.(real_solutions(res), solutions(res))) ≈ 0.0 atol = 1e-6
+    end
 end

--- a/test/result_test.jl
+++ b/test/result_test.jl
@@ -129,5 +129,6 @@
         @polyvar x y v w
         res = solve([x * y - 6 * v * w, x^2 - 5 * v^2], variable_groups = [(x, v), (y, w)])
         @test all(is_real, res)
+        @test sum(fubini_study.(real_solutions(res), solutions(res))) ≈ 0.0
     end
 end

--- a/test/result_test.jl
+++ b/test/result_test.jl
@@ -129,6 +129,6 @@
         @polyvar x y v w
         res = solve([x * y - 6 * v * w, x^2 - 5 * v^2], variable_groups = [(x, v), (y, w)])
         @test all(is_real, res)
-        @test sum(fubini_study.(real_solutions(res), solutions(res))) ≈ 0.0
+        @test sum(fubini_study.(real_solutions(res), solutions(res))) ≈ 0.0 atol = 1e-6
     end
 end


### PR DESCRIPTION
Previously we produced garbage by doing monodromy with projective vectors since the unique points check didn't work as intended.
Now, we also obtain correctly a "real vector" from a projective vector (by first moving the representative in the real plane and then taking the real part).