### PR TITLE
Broadcasting fix for Julia 1.5

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          julia-version: [1.4.0]
+          julia-version: ['1.4','1.5']
           os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/src/norm.jl
+++ b/src/norm.jl
@@ -90,6 +90,7 @@ weights(WN::WeightedNorm) = WN.weights
 
 Base.length(WN::WeightedNorm) = length(WN.weights)
 Base.size(WN::WeightedNorm) = (length(WN),)
+Base.ndims(::Type{<:WeightedNorm}) = 1
 Base.copyto!(WN::WeightedNorm, x) = copyto!(WN.weights, x)
 @propagate_inbounds Base.getindex(WN::WeightedNorm, i::Integer) = getindex(WN.weights, i)
 @propagate_inbounds Base.setindex!(WN::WeightedNorm, x, i::Integer) =


### PR DESCRIPTION
Hello!  Julia 1.5 very minimally changes what is required of an object to support its use on the left-hand-side of a `.=` assignment.  This adds the one extra overload that is needed to get tests passing on 1.5 and adds version 1.5 to the CI test matrix.

That said, I'm not entirely sure you want to use`.=` for this purpose — it's a little strange that `WeightedNorm` only supports appearing on the left hand side of a broadcast expression and not on the right.  I'd be happy to help you make `WeightedNorm` work more fully in broadcast if that makes sense for your uses.

See https://github.com/JuliaLang/julia/issues/36105 for the core language discussion and more details if you're interested.