### PR TITLE
Fix certification routine

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HomotopyContinuation"
 uuid = "f213a82b-91d6-5c5d-acf7-10f1c761b327"
 authors = ["Sascha Timme <sascha@timme.xyz>", "Paul Breiding <p.breiding@tu-berlin.de>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 Arblib = "fb37089c-8514-4489-9461-98f9c8763369"


### PR DESCRIPTION
Previously the Newton refinement in double precision arithmetic could 
reject a solution too easily.