### PR TITLE
Detect singular jacobian for invalid start values

### DIFF
--- a/docs/src/model_kit.md
+++ b/docs/src/model_kit.md
@@ -36,6 +36,9 @@ variables(::Expression)
 ## System
 ```@docs
 System
+evaluate(F::System, x, p = nothing)
+jacobian(F::System)
+jacobian(F::System, x, p = nothing)
 degrees(F::System)
 expressions(F::System)
 optimize(::System)

--- a/src/endgame_tracker.jl
+++ b/src/endgame_tracker.jl
@@ -81,6 +81,7 @@ The possible states an `EndgameTracker` can be in:
 * `EndgameTrackerCode.terminated_accuracy_limit`
 * `EndgameTrackerCode.terminated_ill_conditioned`
 * `EndgameTrackerCode.terminated_invalid_startvalue`
+* `EndgameTrackerCode.terminated_invalid_startvalue_singular_jacobian`
 * `EndgameTrackerCode.terminated_max_winding_number`
 * `EndgameTrackerCode.terminated_max_steps`
 * `EndgameTrackerCode.terminated_step_size_too_small`
@@ -95,6 +96,7 @@ using ..TrackerCode: TrackerCode
     at_zero
     terminated_accuracy_limit
     terminated_invalid_startvalue
+    terminated_invalid_startvalue_singular_jacobian
     terminated_ill_conditioned
     terminated_max_steps
     terminated_max_extended_steps
@@ -117,6 +119,8 @@ function Base.convert(::Type{codes}, code::TrackerCode.codes)
         return terminated_ill_conditioned
     elseif code == TrackerCode.terminated_invalid_startvalue
         return terminated_invalid_startvalue
+    elseif code == TrackerCode.terminated_invalid_startvalue_singular_jacobian
+        return terminated_invalid_startvalue_singular_jacobian
     elseif code == TrackerCode.terminated_step_size_too_small
         return terminated_step_size_too_small
     elseif code == TrackerCode.terminated_unknown

--- a/src/model_kit/symbolic.jl
+++ b/src/model_kit/symbolic.jl
@@ -956,7 +956,13 @@ struct System
             vars == reduce(vcat, variable_groups) ||
                 throw(ArgumentError("Variable groups and variables don't match."))
         end
-        new(exprs, vars, params, variable_groups, Ref{Union{Nothing,Matrix{Expression}}}(nothing))
+        new(
+            exprs,
+            vars,
+            params,
+            variable_groups,
+            Ref{Union{Nothing,Matrix{Expression}}}(nothing),
+        )
     end
 end
 

--- a/src/model_kit/symbolic.jl
+++ b/src/model_kit/symbolic.jl
@@ -943,6 +943,7 @@ struct System
     variables::Vector{Variable}
     parameters::Vector{Variable}
     variable_groups::Union{Nothing,Vector{Vector{Variable}}}
+    _jacobian::Ref{Union{Nothing,Matrix{Expression}}}
 
     function System(
         exprs::Vector{Expression},
@@ -955,7 +956,7 @@ struct System
             vars == reduce(vcat, variable_groups) ||
                 throw(ArgumentError("Variable groups and variables don't match."))
         end
-        new(exprs, vars, params, variable_groups)
+        new(exprs, vars, params, variable_groups, Ref{Union{Nothing,Matrix{Expression}}}(nothing))
     end
 end
 
@@ -1105,12 +1106,82 @@ function Base.show(io::IO, F::System)
     end
 end
 
+"""
+    evaluate(F::System, x, p = nothing)
+
+Evaluates the system `F` at `(x, p)`.
+
+# Example
+
+```julia
+@var x y
+F = System([x^2 + 3y, (y*x+1)^3])
+evaluate(F, [2, 3])
+```
+```
+2-element Array{Int32,1}:
+  13
+ 343
+```
+"""
+
 evaluate(F::System, x::AbstractVector) = evaluate(F.expressions, F.variables => x)
 function evaluate(F::System, x::AbstractVector, p::AbstractVector)
     evaluate(F.expressions, F.variables => x, F.parameters => p)
 end
 (F::System)(x::AbstractVector, p::Nothing = nothing) = evaluate(F, x)
 (F::System)(x::AbstractVector, p::AbstractVector) = evaluate(F, x, p)
+
+"""
+    jacobian(F::System)
+
+Computes the symbolic Jacobian of the system `F`.
+
+# Example
+
+```julia
+@var x y
+F = System([x^2 + 3y, (y*x+1)^3])
+jacobian(F)
+```
+```
+2×2 Array{Expression,2}:
+             2*x                3
+ 3*y*(1 + x*y)^2  3*x*(1 + x*y)^2
+```
+"""
+function jacobian(F::System)
+    if isnothing(F._jacobian[])
+        F._jacobian[] = differentiate(F.expressions, F.variables)
+    end
+    F._jacobian[]::Matrix{Expression}
+end
+
+"""
+    jacobian(F::System, x, p = nothing)
+
+Evaluates the Jacobian of the system `F` at `(x, p)`.
+
+# Example
+
+```julia
+@var x y
+F = System([x^2 + 3y, (y*x+1)^3])
+jacobian(F, [2, 3])
+```
+```
+2×2 Array{Int32,2}:
+   4    3
+ 441  294
+```
+"""
+function jacobian(F::System, x, p = nothing)
+    if p isa Nothing
+        evaluate(jacobian(F), F.variables => x)
+    else
+        evaluate(jacobian(F), F.variables => x, F.parameters => p)
+    end
+end
 
 function Base.:(==)(F::System, G::System)
     F.expressions == G.expressions &&


### PR DESCRIPTION
This adds a special return code if the path tracker refuses to start due to a singular Jacobian. Hopefully, this helps to detect cases as in #454 faster.

I also added helper functions `jacobian(F::System)` and `jacobian(F::System, x, p = nothing)` to compute more easily the Jacobian of a system resp. to evaluate it at a given point.