### PR TITLE
Monodromy with predefined tolerance for unique points

### DIFF
--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -915,11 +915,7 @@ function serial_monodromy_solve!(
                 loop_tracked!(stats)
 
                 # 1) check whether solutions already exists
-                id, got_added = add!(
-                    MS,
-                    res,
-                    length(results) + 1
-                )
+                id, got_added = add!(MS, res, length(results) + 1)
 
                 if MS.options.permutations
                     add_permutation!(stats, job.loop_id, job.id, id)
@@ -1039,11 +1035,7 @@ function threaded_monodromy_solve!(
 
                         # 1) check whether solutions already exists
                         lock(data_lock)
-                        id, got_added = add!(
-                            MS,
-                            res,
-                            length(results) + 1
-                        )
+                        id, got_added = add!(MS, res, length(results) + 1)
 
                         if MS.options.permutations
                             add_permutation!(stats, job.loop_id, job.id, id)

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -22,7 +22,6 @@ Options for [`monodromy_solve`](@ref).
 """
 Base.@kwdef struct MonodromyOptions{D,GA<:Union{Nothing,GroupActions}}
     check_startsolutions::Bool = true
-    distance::D = EuclideanNorm()
     group_actions::GA = nothing
     loop_finished_callback = always_false
     parameter_sampler = independent_normal
@@ -36,6 +35,10 @@ Base.@kwdef struct MonodromyOptions{D,GA<:Union{Nothing,GroupActions}}
     max_loops_no_progress::Int = 5
     reuse_loops::Symbol = :all
     permutations::Bool = false
+    # unique points options
+    distance::D = EuclideanNorm()
+    unique_points_atol::Union{Nothing,Float64} = nothing
+    unique_points_rtol::Union{Nothing,Float64} = nothing
 end
 
 """
@@ -448,6 +451,7 @@ function MonodromySolver(
 
     unique_points =
         UniquePoints(x₀, 1; metric = options.distance, group_actions = group_actions)
+
     trace = zeros(ComplexF64, length(x₀) + 1, 3)
     MonodromySolver(
         trackers,
@@ -547,7 +551,8 @@ See also [`linear_subspace_homotopy`](@ref) for the `intrinsic` option.
   See also [`trace_test`](@ref).
 * `trace_test_tol = 1e-10`: The tolerance for the trace test to be successfull.
   The trace is divided by the number of solutions before compared to the trace_test_tol.
-
+* `unique_points_rtol`: the relative tolerance for [`unique_points`](@ref).
+* `unique_points_atol`: the absolute tolerance for [`unique_points`](@ref).
 """
 function monodromy_solve(F::Vector{<:ModelKit.Expression}, args...; parameters, kwargs...)
     monodromy_solve(System(F; parameters = parameters), args...; kwargs...)
@@ -636,6 +641,7 @@ function monodromy_solve(
         tracker_options = tracker_options,
         intrinsic = intrinsic,
     )
+
     monodromy_solve(
         MS,
         S,
@@ -837,8 +843,18 @@ function check_start_solutions(MS::MonodromySolver, X, p)
 end
 
 function add!(MS::MonodromySolver, res::PathResult, id)
-    rtol = clamp(0.25 * inv(res.ω)^2, 1e-14, sqrt(res.accuracy))
-    add!(MS.unique_points, solution(res), id; atol = 1e-14, rtol = rtol)
+    if isnothing(MS.options.unique_points_rtol)
+        rtol = uniqueness_rtol(res)
+    else
+        rtol = MS.options.unique_points_rtol
+    end
+    if isnothing(MS.options.unique_points_atol)
+        atol = 1e-14
+    else
+        atol = MS.options.unique_points_atol
+    end
+
+    add!(MS.unique_points, solution(res), id; atol = atol, rtol = rtol)
 end
 
 function serial_monodromy_solve!(
@@ -900,11 +916,9 @@ function serial_monodromy_solve!(
 
                 # 1) check whether solutions already exists
                 id, got_added = add!(
-                    MS.unique_points,
-                    solution(res),
-                    length(results) + 1;
-                    atol = 1e-14,
-                    rtol = uniqueness_rtol(res),
+                    MS,
+                    res,
+                    length(results) + 1
                 )
 
                 if MS.options.permutations
@@ -1026,11 +1040,9 @@ function threaded_monodromy_solve!(
                         # 1) check whether solutions already exists
                         lock(data_lock)
                         id, got_added = add!(
-                            MS.unique_points,
-                            solution(res),
-                            length(results) + 1;
-                            atol = 1e-14,
-                            rtol = uniqueness_rtol(res),
+                            MS,
+                            res,
+                            length(results) + 1
                         )
 
                         if MS.options.permutations

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -436,7 +436,10 @@
                          target_solutions_count = 305
                          )
 
-        UP = unique_points(solutions(points), metric = dist, rtol = 1e-8, atol = 1e-14)
+        UP = unique_points(solutions(points),
+                            metric = dist,
+                            rtol = 1e-8,
+                            atol = 1e-14)
 
         @test length(solutions(points)) == length(UP)
    end

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -442,6 +442,5 @@
                             atol = 1e-14)
 
         @test length(solutions(points)) == length(UP)
-   end
-
+    end
 end

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -374,34 +374,35 @@
     end
 
     @testset "monodromy with predefined tolerance for unique_points" begin
-        d = 3; n = 4
+        d = 3
+        n = 4
         M = binomial(d - 1 + 2, 2)
-        D = (n-1) * M + 3
+        D = (n - 1) * M + 3
         N = binomial(n - 1 + d, d)
         # Example from
         # https://www.juliahomotopycontinuation.org/examples/symmetroids/
-        
+
         @var x[0:n-1] a[1:D]
         A = map(0:n-2) do ℓ
-            Aᵢ  = []
-            for i in 1:d
-                     k = ℓ * M + sum(d-j for j in 0:i-1)
-                     push!(Aᵢ, [zeros(i-1); a[k-(d-i):k]])
+            Aᵢ = []
+            for i = 1:d
+                k = ℓ * M + sum(d - j for j = 0:i-1)
+                push!(Aᵢ, [zeros(i - 1); a[k-(d-i):k]])
             end
             Aᵢ = hcat(Aᵢ...)
             (Aᵢ + transpose(Aᵢ)) ./ 2
         end
 
         A₀ = [a[D-2] 0 0; 0 a[D-1] 0; 0 0 a[D]]
-        μ = x[1] .* A₀ + sum(x[i+1] .* A[i] for i in 1:n-1)
+        μ = x[1] .* A₀ + sum(x[i+1] .* A[i] for i = 1:n-1)
         f = System(coefficients(det(μ), x))
 
-        J₀ = jacobian(InterpretedSystem(f), randn(ComplexF64,D))
+        J₀ = jacobian(InterpretedSystem(f), randn(ComplexF64, D))
         dimQ = rank(J₀)
-        dim_fibers = D  - dimQ
+        dim_fibers = D - dimQ
         S1 = qr(randn(ComplexF64, D, D)).Q
         S = S1[:, 1:dimQ]
-        s = S1[:, dimQ + 1]
+        s = S1[:, dimQ+1]
 
         @var b[1:dimQ]
         L₁ = System(S * b + s)
@@ -413,32 +414,26 @@
         R = [transpose(k[1:N]); R1[1:(dimQ-1), :]]
         r = [k[N+1]; R[2:end, :] * f₁]
 
-        L₂ = System(
-                 R * f₀ - r,
-                 variables = f₀;
-                 parameters = k
-                 );
+        L₂ = System(R * f₀ - r, variables = f₀; parameters = k)
 
 
         p₁ = randn(ComplexF64, N)
         params = [p₁; transpose(p₁) * f₁]
 
-        dist(x,y) = norm(f(L₁(x)) - f(L₁(y)), Inf)
+        dist(x, y) = norm(f(L₁(x)) - f(L₁(y)), Inf)
 
-        points = monodromy_solve(L₂ ∘ f ∘ L₁,
-                         [b₁],
-                         params,
-                         distance = dist,
-                         compile = false,
-                         unique_points_rtol = 1e-8,
-                         unique_points_atol = 1e-14,
-                         target_solutions_count = 305
-                         )
+        points = monodromy_solve(
+            L₂ ∘ f ∘ L₁,
+            [b₁],
+            params,
+            distance = dist,
+            compile = false,
+            unique_points_rtol = 1e-8,
+            unique_points_atol = 1e-14,
+            target_solutions_count = 305,
+        )
 
-        UP = unique_points(solutions(points),
-                            metric = dist,
-                            rtol = 1e-8,
-                            atol = 1e-14)
+        UP = unique_points(solutions(points), metric = dist, rtol = 1e-8, atol = 1e-14)
 
         @test length(solutions(points)) == length(UP)
     end

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -374,14 +374,13 @@
     end
 
     @testset "monodromy with predefined tolerance for unique_points" begin
-
-        # Example from
-        # https://www.juliahomotopycontinuation.org/examples/symmetroids/
         d = 3; n = 4
         M = binomial(d - 1 + 2, 2)
         D = (n-1) * M + 3
         N = binomial(n - 1 + d, d)
-
+        # Example from
+        # https://www.juliahomotopycontinuation.org/examples/symmetroids/
+        
         @var x[0:n-1] a[1:D]
         A = map(0:n-2) do ℓ
             Aᵢ  = []

--- a/test/monodromy_test.jl
+++ b/test/monodromy_test.jl
@@ -372,4 +372,73 @@
             trace_tol = 1e-60,
         )
     end
+
+    @testset "monodromy with predefined tolerance for unique_points" begin
+
+        # Example from
+        # https://www.juliahomotopycontinuation.org/examples/symmetroids/
+        d = 3; n = 4
+        M = binomial(d - 1 + 2, 2)
+        D = (n-1) * M + 3
+        N = binomial(n - 1 + d, d)
+
+        @var x[0:n-1] a[1:D]
+        A = map(0:n-2) do ℓ
+            Aᵢ  = []
+            for i in 1:d
+                     k = ℓ * M + sum(d-j for j in 0:i-1)
+                     push!(Aᵢ, [zeros(i-1); a[k-(d-i):k]])
+            end
+            Aᵢ = hcat(Aᵢ...)
+            (Aᵢ + transpose(Aᵢ)) ./ 2
+        end
+
+        A₀ = [a[D-2] 0 0; 0 a[D-1] 0; 0 0 a[D]]
+        μ = x[1] .* A₀ + sum(x[i+1] .* A[i] for i in 1:n-1)
+        f = System(coefficients(det(μ), x))
+
+        J₀ = jacobian(InterpretedSystem(f), randn(ComplexF64,D))
+        dimQ = rank(J₀)
+        dim_fibers = D  - dimQ
+        S1 = qr(randn(ComplexF64, D, D)).Q
+        S = S1[:, 1:dimQ]
+        s = S1[:, dimQ + 1]
+
+        @var b[1:dimQ]
+        L₁ = System(S * b + s)
+        @var k[1:N+1] f₀[1:length(f)]
+        b₁ = randn(ComplexF64, dimQ)
+        f₁ = f(L₁(b₁))
+
+        R1 = qr(randn(ComplexF64, N, N)).Q
+        R = [transpose(k[1:N]); R1[1:(dimQ-1), :]]
+        r = [k[N+1]; R[2:end, :] * f₁]
+
+        L₂ = System(
+                 R * f₀ - r,
+                 variables = f₀;
+                 parameters = k
+                 );
+
+
+        p₁ = randn(ComplexF64, N)
+        params = [p₁; transpose(p₁) * f₁]
+
+        dist(x,y) = norm(f(L₁(x)) - f(L₁(y)), Inf)
+
+        points = monodromy_solve(L₂ ∘ f ∘ L₁,
+                         [b₁],
+                         params,
+                         distance = dist,
+                         compile = false,
+                         unique_points_rtol = 1e-8,
+                         unique_points_atol = 1e-14,
+                         target_solutions_count = 305
+                         )
+
+        UP = unique_points(solutions(points), metric = dist, rtol = 1e-8, atol = 1e-14)
+
+        @test length(solutions(points)) == length(UP)
+   end
+
 end


### PR DESCRIPTION
Previously, it was not possible to pass tolerance options to `unique_points` through the `monodromy_solve` function. The goal of this pull request is to change this.

There is one thing up for discussion: currently, `monodromy_solve` by default uses the function `uniqueness_rtol` for setting the relative tolerance. This is a different default than is used by `unique_points`. Should two functions have different defaults?