### PR TITLE
Fix SemialgebraicSets support for system with redundancy

### DIFF
--- a/src/semialgebraic_sets.jl
+++ b/src/semialgebraic_sets.jl
@@ -58,9 +58,6 @@ function SemialgebraicSets.solvealgebraicequations(
     solver::SemialgebraicSetsHCSolver,
 )
     F = System(V)
-    m, n = size(F)
-    # Check that we can have isolated solutions
-    m ≥ n || return nothing
     # Only return real, non-singular solutions
     return real_solutions(solve(F; solver.options...); only_nonsingular = true)
 end

--- a/test/semialgebraic_sets_test.jl
+++ b/test/semialgebraic_sets_test.jl
@@ -5,4 +5,20 @@
     S = collect(V)
     S = sort!(map(s -> round.(s, digits = 2), S))
     @test S == [[-1.0, -1.41], [-1.0, 1.41], [1.0, -1.41], [1.0, 1.41]]
+
+    V = SemialgebraicSets.@set x == 1 && x == 1 solver
+    S = collect(V)
+    S = sort!(map(s -> round.(s, digits = 2), S))
+    @test S == [[1.0]]
+
+    # Inspired from https://jump.dev/SumOfSquares.jl/v0.4.6/generated/Polynomial%20Optimization/
+    V = SemialgebraicSets.algebraicset([
+        -x - y + 1,
+        -x*y + y^2 - y,
+        -x^2 + y^2 - 2y + 1],
+        solver,
+    )
+    S = collect(V)
+    S = sort!(map(s -> round.(s, digits = 2), S))
+    @test S == [[0.0, 1.0], [1.0, 0.0]]
 end


### PR DESCRIPTION
I've tried using HomotopyContinuation as solver for extracting the solutions from the moment matrix for finding the solution of polynomial optimisation problem here:
https://jump.dev/SumOfSquares.jl/v0.4.6/generated/Polynomial%20Optimization/
It didn't work because the system generated has 3 equations for 2 variables although the third equation is redundant.
Just removing the check as in this PR seems to resolve the issue. It finds a solution at infinity and an excess solution but they are correctly filtered out.