### PR TITLE
Promote parametric type in IComplex constructor.

### DIFF
--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -278,7 +278,7 @@ function IComplex(x::Real, y::Real)
     IComplex(Interval(ix), Interval(iy))
 end
 IComplex(re::Interval{T}, im::Interval{S}) where {T<:Real,S<:Real} =
-    IComplex{promote_type(T,S)}(promote(re, im)...)
+    IComplex{promote_type(T, S)}(promote(re, im)...)
 IComplex(x::Union{Interval,Real}) = IComplex(x, zero(x))
 IComplex(z::Complex) = IComplex(real(z), imag(z))
 IComplex(z::IComplex) = z

--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -277,6 +277,8 @@ function IComplex(x::Real, y::Real)
     ix, iy = promote(x, y)
     IComplex(Interval(ix), Interval(iy))
 end
+IComplex(re::Interval{T}, im::Interval{S}) where {T<:Real,S<:Real} =
+    IComplex{promote_type(T,S)}(promote(re, im)...)
 IComplex(x::Union{Interval,Real}) = IComplex(x, zero(x))
 IComplex(z::Complex) = IComplex(real(z), imag(z))
 IComplex(z::IComplex) = z


### PR DESCRIPTION
Working with polynomials with big coefficients I had an "ERROR: MethodError:..." for the `IComplex` constructor.
This PR solved the problem.
An MWE to reproduce the error:
```
const HCIA = HomotopyContinuation.IntervalArithmetic
HCIA.IComplex(HCIA.Interval(1, big(2)), HCIA.Interval(0,1))
```
`Interval` constructor handles the type promotion in line 30, but for `IComplex` is missing. This PR aims to add it.