### PR TITLE
vector functions for IA

### DIFF
--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -371,12 +371,32 @@ rad(z::IComplex) = max(rad(real(z)), rad(imag(z)))
 mag(z::IComplex) = max(mag(real(z)), mag(imag(z)))
 isinterior(a::IComplex, b::IComplex) =
     isinterior(real(a), real(b)) && isinterior(imag(a), imag(b))
+function isinterior(a::Vector{IComplex}, b::Vector{IComplex})
+    iter = zip(a, b)
+    all(map(I -> isinterior(I[1],I[2]), iter))
+end
 Base.issubset(a::IComplex, b::IComplex) = real(a) ⊆ real(b) && imag(a) ⊆ imag(b)
+function Base.issubset(a::Vector{IComplex}, b::Vector{IComplex})
+    iter = zip(a, b)
+    all(map(I -> Base.issubset(I[1],I[2]), iter))
+end
 isdisjoint(a::IComplex, b::IComplex) =
     isdisjoint(real(a), real(b)) || isdisjoint(imag(a), imag(b))
+function isdisjoint(a::Vector{IComplex}, b::Vector{IComplex})
+    iter = zip(a, b)
+    any(map(I -> isdisjoint(I[1],I[2]), iter))
+end
 Base.intersect(a::IComplex, b::IComplex) =
     IComplex(intersect(real(a), real(b)), intersect(imag(a), imag(b)))
+function Base.intersect(a::Vector{IComplex}, b::Vector{IComplex})
+    iter = zip(a, b)
+    map(I -> intersect(I[1],I[2]), iter)
+end
 Base.in(x::Number, a::IComplex) = in(real(x), real(a)) && in(imag(x), imag(a))
+function Base.in(a::Vector{Number}, b::Vector{IComplex})
+    iter = zip(a, b)
+    all(map(I -> Base.in(I[1],I[2]), iter))
+end
 
 
 function inf_norm_bound(A::AbstractMatrix{IComplex{T}}) where {T}

--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -378,7 +378,7 @@ end
 Base.issubset(a::IComplex, b::IComplex) = real(a) ⊆ real(b) && imag(a) ⊆ imag(b)
 function Base.issubset(a::Vector{IComplex}, b::Vector{IComplex})
     iter = zip(a, b)
-    all(map(I -> Base.issubset(I[1], I[2]), iter))
+    all(I -> Base.issubset(I[1], I[2]), iter)
 end
 isdisjoint(a::IComplex, b::IComplex) =
     isdisjoint(real(a), real(b)) || isdisjoint(imag(a), imag(b))

--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -373,29 +373,29 @@ isinterior(a::IComplex, b::IComplex) =
     isinterior(real(a), real(b)) && isinterior(imag(a), imag(b))
 function isinterior(a::Vector{IComplex}, b::Vector{IComplex})
     iter = zip(a, b)
-    all(map(I -> isinterior(I[1],I[2]), iter))
+    all(map(I -> isinterior(I[1], I[2]), iter))
 end
 Base.issubset(a::IComplex, b::IComplex) = real(a) ⊆ real(b) && imag(a) ⊆ imag(b)
 function Base.issubset(a::Vector{IComplex}, b::Vector{IComplex})
     iter = zip(a, b)
-    all(map(I -> Base.issubset(I[1],I[2]), iter))
+    all(map(I -> Base.issubset(I[1], I[2]), iter))
 end
 isdisjoint(a::IComplex, b::IComplex) =
     isdisjoint(real(a), real(b)) || isdisjoint(imag(a), imag(b))
 function isdisjoint(a::Vector{IComplex}, b::Vector{IComplex})
     iter = zip(a, b)
-    any(map(I -> isdisjoint(I[1],I[2]), iter))
+    any(map(I -> isdisjoint(I[1], I[2]), iter))
 end
 Base.intersect(a::IComplex, b::IComplex) =
     IComplex(intersect(real(a), real(b)), intersect(imag(a), imag(b)))
 function Base.intersect(a::Vector{IComplex}, b::Vector{IComplex})
     iter = zip(a, b)
-    map(I -> intersect(I[1],I[2]), iter)
+    map(I -> intersect(I[1], I[2]), iter)
 end
 Base.in(x::Number, a::IComplex) = in(real(x), real(a)) && in(imag(x), imag(a))
 function Base.in(a::Vector{Number}, b::Vector{IComplex})
     iter = zip(a, b)
-    all(map(I -> Base.in(I[1],I[2]), iter))
+    all(map(I -> Base.in(I[1], I[2]), iter))
 end
 
 

--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -384,7 +384,7 @@ isdisjoint(a::IComplex, b::IComplex) =
     isdisjoint(real(a), real(b)) || isdisjoint(imag(a), imag(b))
 function isdisjoint(a::Vector{IComplex}, b::Vector{IComplex})
     iter = zip(a, b)
-    any(map(I -> isdisjoint(I[1], I[2]), iter))
+    any(I -> isdisjoint(I[1], I[2]), iter)
 end
 Base.intersect(a::IComplex, b::IComplex) =
     IComplex(intersect(real(a), real(b)), intersect(imag(a), imag(b)))

--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -395,7 +395,7 @@ end
 Base.in(x::Number, a::IComplex) = in(real(x), real(a)) && in(imag(x), imag(a))
 function Base.in(a::Vector{Number}, b::Vector{IComplex})
     iter = zip(a, b)
-    all(map(I -> Base.in(I[1], I[2]), iter))
+    all(I -> Base.in(I[1], I[2]), iter)
 end
 
 


### PR DESCRIPTION
I had some issues with the [basic functions](https://github.com/JuliaHomotopyContinuation/HomotopyContinuation.jl/blob/b4158fc4c822b0a7ead65c24abb30686f9a1e71f/src/interval_arithmetic.jl#L372) for `IComplex` types when applying them to tuples of type `Vector{IComplex}`. This is why I added the basic functions also for type `Vector{IComplex}`. (I can reproduce the error only for a really complicated example (should I put it here?).)