### PR TITLE
fix type error for real subspaces

### DIFF
--- a/src/homotopies/intrinsic_subspace_homotopy.jl
+++ b/src/homotopies/intrinsic_subspace_homotopy.jl
@@ -141,7 +141,11 @@ start_parameters!(H::IntrinsicSubspaceHomotopy, p::LinearSubspace) =
 target_parameters!(H::IntrinsicSubspaceHomotopy, q::LinearSubspace) =
     set_subspaces!(H, H.start, convert(LinearSubspace{ComplexF64}, q))
 parameters!(H::IntrinsicSubspaceHomotopy, p::LinearSubspace, q::LinearSubspace) =
-    set_subspaces!(H, convert(LinearSubspace{ComplexF64}, p), convert(LinearSubspace{ComplexF64}, q))
+    set_subspaces!(
+        H,
+        convert(LinearSubspace{ComplexF64}, p),
+        convert(LinearSubspace{ComplexF64}, q),
+    )
 
 function γ!(H::IntrinsicSubspaceHomotopy, t::Number)
     H.t_cache[] != t || return first(H.taylor_γ)

--- a/src/homotopies/intrinsic_subspace_homotopy.jl
+++ b/src/homotopies/intrinsic_subspace_homotopy.jl
@@ -137,11 +137,11 @@ function set_subspaces!(
     H
 end
 start_parameters!(H::IntrinsicSubspaceHomotopy, p::LinearSubspace) =
-    set_subspaces!(H, p, H.target)
+    set_subspaces!(H, convert(LinearSubspace{ComplexF64}, p), H.target)
 target_parameters!(H::IntrinsicSubspaceHomotopy, q::LinearSubspace) =
-    set_subspaces!(H, H.start, q)
+    set_subspaces!(H, H.start, convert(LinearSubspace{ComplexF64}, q))
 parameters!(H::IntrinsicSubspaceHomotopy, p::LinearSubspace, q::LinearSubspace) =
-    set_subspaces!(H, p, q)
+    set_subspaces!(H, convert(LinearSubspace{ComplexF64}, p), convert(LinearSubspace{ComplexF64}, q))
 
 function γ!(H::IntrinsicSubspaceHomotopy, t::Number)
     H.t_cache[] != t || return first(H.taylor_γ)


### PR DESCRIPTION
Fixing the bug in #512 

The problem was that the iterator for solving many subspaces promotes the first real subspace to type LinearSubspace{ComplexF64}, but not the rest. Fixed it in the code.