### PR TITLE
Fix finding start pair linear in parameters

### DIFF
--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -725,7 +725,7 @@ function find_start_pair_linear_in_params(F; kwargs...)
             # don't want to have 0 as a parameter
             m == n && return nothing
             N = LA.nullspace(A)
-            p₀ = N*randn(ComplexF64, size(N, 2))
+            p₀ = N * randn(ComplexF64, size(N, 2))
         else
             p₀ = LA.qr(A, Val(true)) \ b
         end

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -724,7 +724,8 @@ function find_start_pair_linear_in_params(F; kwargs...)
         if iszero(b)
             # don't want to have 0 as a parameter
             m == n && return nothing
-            p₀ = LA.nullspace(A)[:, 1]
+            N = LA.nullspace(A)
+            p₀ = N*randn(ComplexF64, size(N, 2))
         else
             p₀ = LA.qr(A, Val(true)) \ b
         end


### PR DESCRIPTION
Julia's `nullspace(A)` returns the result in some normal form. Sometimes the nullspace of A has dimension a lot more than 1, and in that case the first column will have a lot of zeros and picking it as p0 may result into picking a singular pair (x0, p0).