### PR TITLE
Support sqrt in modelkit

### DIFF
--- a/src/DoubleDouble.jl
+++ b/src/DoubleDouble.jl
@@ -467,9 +467,10 @@ Base.abs(a::DoubleF64) = a.hi < 0.0 ? -a : a
 Base.eps(::DoubleF64) = double_eps
 Base.eps(::Type{DoubleF64}) = double_eps # 2^-104
 
+Base.floatmin(::Type{DoubleF64}) = 2.0041683600089728e-292 # = 2^(-1022 + 53)
 # Base.realmin(::Type{DoubleF64}) = 2.0041683600089728e-292 # = 2^(-1022 + 53)
-# Base.realmin(::Type{DoubleF64}) = 2.0041683600089728e-292 # = 2^(-1022 + 53)
-# Base.realmax(::Type{DoubleF64}) = DoubleF64(1.79769313486231570815e+308, 9.97920154767359795037e+291);
+Base.floatmax(::Type{DoubleF64}) =
+    DoubleF64(1.79769313486231570815e+308, 9.97920154767359795037e+291)
 # Base.realmax(::Type{DoubleF64}) = DoubleF64(1.79769313486231570815e+308, 9.97920154767359795037e+291);
 
 Base.isnan(a::DoubleF64) = isnan(a.hi) || isnan(a.lo)

--- a/src/model_kit/taylor.jl
+++ b/src/model_kit/taylor.jl
@@ -399,8 +399,13 @@ end
     taylor_impl(K, M - 1) do list, D
         v₀ = add_op!(list, OP_SQRT, D[:x, 0])
         d = mul!(list, 2, v₀)
-        ids = [v₀]
-        for k = 1:K
+        ids = []
+        push!(ids, v₀)
+        if K >= 1
+            v₁ = div!(list, D[:x, 1], d)
+            push!(ids, v₁)
+        end
+        for k = 2:K
             s = nothing
             for j = 1:(k-1)
                 s = muladd!(list, ids[j+1], ids[k-j+1], s)

--- a/test/test_systems.jl
+++ b/test/test_systems.jl
@@ -994,6 +994,12 @@ function small_rational()
     )
 end
 
+function sqrt_parameters()
+    @var x y a b
+
+    System([sqrt(a + b) * x^2 - y, (x * y + a - sqrt(b))^2 - 3], [x, y], [a, b])
+end
+
 TEST_SYSTEM_COLLECTION = [
     ("moments3", moments3()),
     ("fano_quintic", fano_quintic()),
@@ -1008,4 +1014,5 @@ TEST_SYSTEM_COLLECTION = [
     ("steiner", steiner()),
     ("four_bar", four_bar()),
     ("small_rational", small_rational()),
+    ("sqrt_parameters", sqrt_parameters()),
 ]


### PR DESCRIPTION
Handles the sqrt case in #536 and throws now an explicit error if we have any other exponent.

To allow arbitrary number exponents we need to first implement `exp` and `log` and then express `a^b` as $\{exp}(\{log}(a^b))=\{exp}(b*\{log}(a))$ and use the existing subroutines