### PR TITLE
Improve certification performance

### DIFF
--- a/test/certification_test.jl
+++ b/test/certification_test.jl
@@ -32,7 +32,7 @@
 
         # Double solutions
         S = solutions(result)
-        cert = certify(F, [S; S])
+        cert = certify(F, [S; S]; extended_certificate = true)
         @test ncertified(cert) == 36
         @test ndistinct_certified(cert) == 18
         @test nreal_certified(cert) == 8


### PR DESCRIPTION
Two improvements:

1. Reduces memory footprint of our certificates. We stored previously also the interval Jacobian used in the certification step. This change reduces the stored `AcbMatrix` to only one interval that contains the unique solution. On my test on a small 8 x 8 system this should reduce the memory footprint of a single certificate ca. by a good amount. I did not benchmark it but from my investigation a 5 - 10x reduction should be possible (more dramatic for larger system due to the n^2 elements of the Jacobian). My motivation is that I need to certify a system with almost 5 Million solutions and my Julia process ended up allocating almost 70gb of memory (and as a result ended up doing lots of memory swapping). So a 5 - 10x reduction makes the whole computation much more feasible again. (Did not yet run the computation again but will report back what peak memory consumption was).

2. Enable multi threading of the certificate computation. Obvious easy win here. The 3264 certification got a speed up of 4x using 8 threads. I expect a bigger speed up when the system is larger


