### PR TITLE
Fix an error in the display of witness sets

### DIFF
--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1180,7 +1180,7 @@ function Base.show(io::IO, N::NumericalIrreducibleDecomposition)
     println(io, header)
 
     mdim = max_dim(N)
-    if mdim > 0
+    if mdim >= 0
         for d = max_dim(N):-1:0
             if haskey(D, d)
                 ℓ = length(D[d])


### PR DESCRIPTION
There was a bug that witness sets with only zero-dimensional components was not displayed correctly.