### PR TITLE
Fixing a bug in row scaling

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -424,7 +424,7 @@ end
 Compute optimal scaling factors `d` for the matrix `A` following Skeel [^S79]
 if `c` is approximately of the order of the solution of the linear system
 of interest.
-The scaling factors are rounded to powers `e` of the base radix 2. Row scaling is only applied to rows with `e - m ≥ scaling_threshold` to prevent zero rows from being scaled, where `2^m` is approximately the maximum norm of a row of `A`. 
+The scaling factors are rounded to powers `e` of the base radix 2. Row scaling is only applied to rows with `e - m ≥ scaling_threshold` (this is an inequality of norms at log-scale) to prevent zero rows from being scaled, where `2^m` is approximately the maximum norm of a row of `A`. 
 
 [^S79]: Skeel, Robert D. "Scaling for numerical stability in Gaussian elimination." Journal of the ACM (JACM) 26.3 (1979): 494-526.
 """
@@ -444,9 +444,10 @@ function skeel_row_scaling!(
     end
 
     m = maximum(d)
+    s = scaling_threshold + m
     @inbounds for i = 1:n
         e = last(frexp(d[i]))
-        if e - m < scaling_threshold
+        if e < s
             d[i] = 1.0
         else
             d[i] = exp2(-e)

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -424,7 +424,7 @@ end
 Compute optimal scaling factors `d` for the matrix `A` following Skeel [^S79]
 if `c` is approximately of the order of the solution of the linear system
 of interest.
-The scaling factors are rounded to powers `e` of the base radix 2. Row scaling is only applied to rows with `e < scaling_threshold` to prevent zero rows from being scaled.
+The scaling factors are rounded to powers `e` of the base radix 2. Row scaling is only applied to rows with `e - m ≥ scaling_threshold` to prevent zero rows from being scaled, where `2^m` is approximately the maximum norm of a row of `A`. 
 
 [^S79]: Skeel, Robert D. "Scaling for numerical stability in Gaussian elimination." Journal of the ACM (JACM) 26.3 (1979): 494-526.
 """

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -442,9 +442,11 @@ function skeel_row_scaling!(
             d[i] += fast_abs(A[i, j]) * cj
         end
     end
+
+    m = maximum(d)
     @inbounds for i = 1:n
         e = last(frexp(d[i]))
-        if e < scaling_threshold
+        if e - m < scaling_threshold
             d[i] = 1.0
         else
             d[i] = exp2(-e)

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -418,19 +418,21 @@ end
 
 """
     skeel_row_scaling!(W::MatrixWorkspace, c)
-    skeel_row_scaling!(d, A, c)
+    skeel_row_scaling!(d, A, c;
+    scaling_threshold = -30.0)
 
 Compute optimal scaling factors `d` for the matrix `A` following Skeel [^S79]
 if `c` is approximately of the order of the solution of the linear system
 of interest.
-The scaling factors are rounded to powers of the base radix 2.
+The scaling factors are rounded to powers `e` of the base radix 2. Row scaling is only applied to rows with `e < scaling_threshold` to prevent zero rows from being scaled.
 
 [^S79]: Skeel, Robert D. "Scaling for numerical stability in Gaussian elimination." Journal of the ACM (JACM) 26.3 (1979): 494-526.
 """
 function skeel_row_scaling!(
     d::AbstractVector{<:Real},
     A::AbstractMatrix{<:Complex},
-    c::AbstractVector{<:Real},
+    c::AbstractVector{<:Real};
+    scaling_threshold::Float64 = -30.0,
 )
     n = length(c)
     @inbounds d .= zero(eltype(d))
@@ -441,7 +443,12 @@ function skeel_row_scaling!(
         end
     end
     @inbounds for i = 1:n
-        d[i] = exp2(-last(frexp(d[i])))
+        e = last(frexp(d[i]))
+        if e < scaling_threshold
+            d[i] = 1.0
+        else
+            d[i] = exp2(-e)
+        end
     end
 
     d
@@ -456,10 +463,11 @@ function row_scaling!(
     d::AbstractVector{<:Real},
     WS::MatrixWorkspace,
     c::AbstractVector{<:Real},
+    scaling_threshold::Float64,
 )
     m, n = size(WS)
     if m == n
-        skeel_row_scaling!(d, WS.A, c)
+        skeel_row_scaling!(d, WS.A, c; scaling_threshold = scaling_threshold)
     else
         d .= 1.0
     end
@@ -754,6 +762,7 @@ function LA.cond(
             rmax = max(rmax, rᵢ)
             rmin = min(rmin, rᵢ)
         end
+        #@show (rmax, rmin)
         rmax / rmin
     else
         inverse_inf_norm_est(WS, d_l, d_r) * inf_norm(WS, d_l, d_r)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -449,7 +449,7 @@ function regeneration!(
     endgame_options = EndgameOptions(;
         max_endgame_steps = 100,
         max_endgame_extended_steps = 100,
-        sing_accuracy = 1e-10,
+        sing_cond = 1e10,
     ),
     threading::Bool = true,
     seed = rand(UInt32),

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -449,7 +449,7 @@ function regeneration!(
     endgame_options = EndgameOptions(;
         max_endgame_steps = 100,
         max_endgame_extended_steps = 100,
-        sing_cond = 1e10,
+        sing_cond = 1e12,
     ),
     threading::Bool = true,
     seed = rand(UInt32),

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -28,6 +28,9 @@
         N = nid(F; seed = nothing)
         @test isnothing(seed(N))
 
+        # bad seed
+        N = nid(F; seed = 0xc770fa47)
+
         # progress
         N = nid(F; show_progress = false)
         @test isa(N, NumericalIrreducibleDecomposition)


### PR DESCRIPTION
Row scaling is also applied when a row is (almost) zero. This causes some unintended behavior. This PR attempts to fix this.