### PR TITLE
Update coefficienttype for depwarn

### DIFF
--- a/src/model_kit/symbolic.jl
+++ b/src/model_kit/symbolic.jl
@@ -1447,7 +1447,7 @@ function system_with_coefficents_as_params(
     param_name = gensym(:c)
     k = 1
     params = Variable[]
-    target_params = MP.coefficienttype(F)[]
+    target_params = MP.coefficient_type(F)[]
     G = map(F) do f
         sum(MP.terms(f)) do t
             c = Variable(param_name, k)


### PR DESCRIPTION
```
HomotopyContinuation Extension: Error During Test at /home/runner/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: `coefficienttype` is deprecated, use `coefficient_type` instead.
  Stacktrace:
    [1] depwarn(msg::String, funcsym::Symbol; force::Bool)
      @ Base ./deprecated.jl:124
    [2] depwarn(msg::String, funcsym::Symbol)
      @ Base ./deprecated.jl:121
    [3] coefficienttype(args::Vector{DynamicPolynomials.Polynomial{DynamicPolynomials.Commutative{DynamicPolynomials.CreationOrder}, MultivariatePolynomials.Graded{MultivariatePolynomials.LexOrder}, Float64}}; kwargs::@Kwargs{})
      @ MultivariatePolynomials ./deprecated.jl:115
    [4] coefficienttype(args::Vector{DynamicPolynomials.Polynomial{DynamicPolynomials.Commutative{DynamicPolynomials.CreationOrder}, MultivariatePolynomials.Graded{MultivariatePolynomials.LexOrder}, Float64}})
      @ MultivariatePolynomials ./deprecated.jl:113
    [5] system_with_coefficents_as_params(F::Vector{DynamicPolynomials.Polynomial{DynamicPolynomials.Commutative{DynamicPolynomials.CreationOrder}, MultivariatePolynomials.Graded{MultivariatePolynomials.LexOrder}, Float64}}; variables::Vector{DynamicPolynomials.Variable{DynamicPolynomials.Commutative{DynamicPolynomials.CreationOrder}, MultivariatePolynomials.Graded{MultivariatePolynomials.LexOrder}}}, variable_groups::Nothing)
      @ HomotopyContinuation.ModelKit ~/.julia/packages/HomotopyContinuation/HHk7W/src/model_kit/symbolic.jl:1450
    [6] system_with_coefficents_as_params
```