### PR TITLE
This PR attempts to fix a dependency bug with Arblib

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ SymEngine_jll = "3428059b-622b-5399-b16f-d347a77089a4"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 
 [compat]
-Arblib = "0.7,0.8"
+Arblib = "1.2"
 DynamicPolynomials = "0.5, 0.6"
 ElasticArrays = "1"
 FiniteDiff = "2.15"

--- a/src/certification.jl
+++ b/src/certification.jl
@@ -621,7 +621,7 @@ function CertificationCache(F::AbstractSystem)
     )
 end
 
-Base.setprecision(M::AcbRefMatrix, p::Int) = AcbRefMatrix(M.acb_mat; prec = p)
+Base.setprecision(M::AcbRefMatrix, p::Int) = AcbRefMatrix(M.acb_mat; shallow = true, prec = p)
 function set_arb_precision!(cache::CertificationCache, p::Int)
     cache.arb_prec == p && return cache
     cache.arb_prec = p

--- a/src/certification.jl
+++ b/src/certification.jl
@@ -621,7 +621,7 @@ function CertificationCache(F::AbstractSystem)
     )
 end
 
-Base.setprecision(M::AcbRefMatrix, p::Int) = AcbRefMatrix(M.acb_mat, p)
+Base.setprecision(M::AcbRefMatrix, p::Int) = AcbRefMatrix(M.acb_mat; prec = p)
 function set_arb_precision!(cache::CertificationCache, p::Int)
     cache.arb_prec == p && return cache
     cache.arb_prec = p

--- a/src/certification.jl
+++ b/src/certification.jl
@@ -621,7 +621,8 @@ function CertificationCache(F::AbstractSystem)
     )
 end
 
-Base.setprecision(M::AcbRefMatrix, p::Int) = AcbRefMatrix(M.acb_mat; shallow = true, prec = p)
+Base.setprecision(M::AcbRefMatrix, p::Int) =
+    AcbRefMatrix(M.acb_mat; shallow = true, prec = p)
 function set_arb_precision!(cache::CertificationCache, p::Int)
     cache.arb_prec == p && return cache
     cache.arb_prec = p


### PR DESCRIPTION
The correct usage for `AcbRefMatrix` in `Arblib` is  `AcbRefMatrix(M; prec = p)` (before it was `AcbRefMatrix(M, p)`). 