### PR TITLE
Run CompatHelper.yml with latest

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.4.0]
+        julia-version: [1]
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:


### PR DESCRIPTION
This is required since otherwise packages which have a minimum on the latest lts will no longer be compathelper tracked.