### PR TITLE
replace the resize_nthreads! function

### DIFF
--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -1015,14 +1015,22 @@ function threaded_monodromy_solve!(
     progress,
 )
     queue = Channel{LoopTrackingJob}(Inf)
-    Threads.resize_nthreads!(MS.trackers)
+
+    tracker = MS.trackers[1]
+    ntrackers = length(MS.trackers)
+    nthr = Threads.nthreads()
+    resize!(MS.trackers, nthr)
+    for i = ntrackers+1:nthr
+        MS.trackers[i] = deepcopy(tracker)
+    end
+
     data_lock = ReentrantLock()
     t₀ = time()
     retcode = :in_progress
     stats = MS.statistics
     notify_lock = ReentrantLock()
     cond_queue_emptied = Threads.Condition(notify_lock)
-    workers_idle = fill(true, Threads.nthreads())
+    workers_idle = fill(true, nthr)
     interrupted = Ref(false)
     queued = Ref(0)
     try

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -592,7 +592,15 @@ function threaded_solve(
     started = Threads.Atomic{Int}(0)
     finished = Threads.Atomic{Int}(0)
     try
-        Threads.resize_nthreads!(solver.trackers)
+        tracker = solver.trackers[1]
+        ntrackers = length(solver.trackers)
+        nthr = Threads.nthreads()
+
+        resize!(solver.trackers, nthr)
+        for i = ntrackers+1:nthr
+            solver.trackers[i] = deepcopy(tracker)
+        end
+
         tasks = map(enumerate(solver.trackers)) do (i, tracker)
             @tspawnat i begin
                 while (k = Threads.atomic_add!(started, 1) + 1) ≤ N && !interrupted

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -149,7 +149,7 @@ function KeywordArgumentException(key, given)
     KeywordArgumentException(key, given, "")
 end
 function Base.showerror(io::IO, E::KeywordArgumentException)
-    print(io, "Invalid argument $given for $key. ", E.msg)
+    print(io, "Invalid argument $(E.given) for $(E.key). ", E.msg)
 end
 
 struct FiniteException <: Exception


### PR DESCRIPTION
The function `Threads.resize_nthreads!` is deprecated. This PR removes this function from the code.