### PR TITLE
Share `is_real` between HC and MK

### DIFF
--- a/src/HomotopyContinuation.jl
+++ b/src/HomotopyContinuation.jl
@@ -29,6 +29,9 @@ import Base: push!
 
 const LA = LinearAlgebra
 
+# To ensure that ModelKit and HomotopyContinuation define methods of the same `is_real` function:
+function is_real end
+
 include("DoubleDouble.jl")
 using .DoubleDouble
 

--- a/src/ModelKit.jl
+++ b/src/ModelKit.jl
@@ -52,6 +52,7 @@ export @var,
     vectors
 
 using ..DoubleDouble: ComplexDF64
+import ..is_real    # required to ensure that ModelKit and HomotopyContinuation define methods of the same `is_real` function
 
 import Arblib: Arblib, Acb, AcbRef, AcbRefVector
 import SimpleGraphs


### PR DESCRIPTION
It turns out `ModelKit.is_real` was not the same function as
`HomotopyContinuation.is_real`. This caused a conflict in the tests,
where both `using HomotopyContinuation.ModelKit` and `using
HomotopyContinuation` were used.

This PR causes them to both define methods of the same `is_real`
function.