### PR TITLE
Improve inference in `solve` pipeline

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -128,11 +128,13 @@ function solver_startsolutions(
     p₀ = generic_parameters,
     target_parameters = p₀,
     compile::Union{Bool,Symbol} = COMPILE_DEFAULT[],
+    ishomogeneous::Union{Bool,Nothing} = nothing,
     start_subspace = nothing,
     target_subspace = nothing,
     intrinsic = nothing,
     kwargs...,
 )
+    Base.@constprop :aggressive
     !isnothing(seed) && Random.seed!(seed)
 
 
@@ -159,6 +161,7 @@ function solver_startsolutions(
                 start_parameters = start_parameters,
                 target_parameters = target_parameters,
                 compile = compile,
+                ishomogeneous = ishomogeneous,
                 kwargs...,
             )
         elseif start_system == :polyhedral
@@ -221,9 +224,11 @@ function parameter_homotopy_tracker(
     F::Union{System,AbstractSystem};
     tracker_options = TrackerOptions(),
     endgame_options = EndgameOptions(),
+    ishomogeneous::Union{Bool,Nothing} = nothing,
     kwargs...,
 )
-    H = parameter_homotopy(F; kwargs...)
+    Base.@constprop :aggressive
+    H = parameter_homotopy(F; ishomogeneous = ishomogeneous, kwargs...)
     EndgameTracker(H; tracker_options = tracker_options, options = endgame_options)
 end
 
@@ -243,13 +248,16 @@ function parameter_homotopy(
     tracker_options = TrackerOptions(),
     endgame_options = EndgameOptions(),
     compile::Union{Bool,Symbol} = COMPILE_DEFAULT[],
+    ishomogeneous::Union{Bool,Nothing} = nothing,
     kwargs...,
 )
+    Base.@constprop :aggressive
     unsupported_kwargs(kwargs)
     m, n = size(F)
     H = ParameterHomotopy(fixed(F; compile = compile), start_parameters, target_parameters)
     f = System(F)
-    if is_homogeneous(f)
+    ish = isnothing(ishomogeneous) ? is_homogeneous(f) : ishomogeneous
+    if ish
         vargroups = variable_groups(f)
         if vargroups === nothing
             m ≥ (n - 1) || throw(FiniteException(n - 1 - m))


### PR DESCRIPTION
This package makes heavy use of polyalgorithms. This provides a lot of flexibility and performance, but one downside is that it hinders inferrability. The lack of inferrability does not seem to cause serious performance issues, but it does stand in the way of being able to precompile the package via direct-chain-of-inference. (See #643 for issues that prevent usage of PrecompileTools.jl, which otherwise would be an easy solution because it circumvents the need for high-quality inference.)

The goal of this PR is to make at least a subset of the `solve` pipeline (specifically, the part I'm using!) inferrable. It targets the following usage:

```julia
    solver, starts = solver_startsolutions(S, sols; start_parameters, target_parameters, ishomogeneous=false)
    Ssolve = solve(solver, starts; show_progress=false)
```

where `S` is a `CompiledSystem`. The eventual goal is that if users write their code this way, the entire pipeline can inferred and thus precompiled.

To get closer to this goal, this PR adds:

- the `ishomogeneous` keyword to bypass a non-inferrable branch in `parameter_homotopy`
- several `Base.@constprop :aggressive` annotations to help the compiler optimize branches that depend on keyword arguments

This does not put it over the finish line, however: the current point of failure is https://github.com/JuliaHomotopyContinuation/HomotopyContinuation.jl/blob/6a6ce8609f942d25336202fc1c644457f6a32043/src/linear_algebra.jl#L36
in the construction of the `MatrixWorkspace` for the Jacobian.  It would seem that the best option is to allow the user to supply their own `MatrixWorkspace` to `Jacobian` and `TrackerState`, but that's starting to look pretty intrusive. So I decided to stop here and gauge thoughts from the maintainers.