### PR TITLE
test: add JET and fix issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/build/
 **/**/tmp_params.txt
 **/**/tmp_sols.txt
 **/**/tmp_cert.txt
+.claude/*

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HomotopyContinuation"
 uuid = "f213a82b-91d6-5c5d-acf7-10f1c761b327"
+version = "2.18.0"
 authors = ["Sascha Timme <sascha@timme.xyz>", "Paul Breiding <pbrdng@gmail.com>"]
-version = "2.18"
 
 [deps]
 Arblib = "fb37089c-8514-4489-9461-98f9c8763369"

--- a/benchmarks/judge_system_benchmark.jl
+++ b/benchmarks/judge_system_benchmark.jl
@@ -49,4 +49,3 @@ function judge_results(result1_name, result2_name)
     pretty_table(data; header = ["System", "evaluate", "evaluate_and_jacobian"])
     return r1, r2
 end
-

--- a/src/DoubleDouble.jl
+++ b/src/DoubleDouble.jl
@@ -348,8 +348,8 @@ Base.rem(a::DoubleF64, b::Union{Float64,DoubleF64}, r::RoundingMode) =
 end
 
 function Base.mod(x::DoubleF64, y::DoubleF64)
-    n = round(a / b)
-    return (a - b * n)
+    n = round(x / y)
+    return (x - y * n)
 end
 
 #
@@ -1029,7 +1029,7 @@ function Base.asin(a::DoubleF64)
     abs_a = abs(a)
 
     if abs_a > 1.0
-        throw(DomainError())
+        throw(DomainError(a, "asin requires abs(a) <= 1"))
     end
 
     if isone(abs_a)
@@ -1043,7 +1043,7 @@ function Base.acos(a::DoubleF64)
     abs_a = abs(a)
 
     if abs_a > 1.0
-        throw(DomainError())
+        throw(DomainError(a, "acos requires abs(a) <= 1"))
     end
 
     if isone(abs_a)

--- a/src/certification.jl
+++ b/src/certification.jl
@@ -245,7 +245,7 @@ function squared_distance_interval(
     n = length(solution_candidate(cert))
     d = zero(IntervalArithmetic.Interval{Float64})
     for i = 1:n
-        yᵢ = IComplexF64(cert.I[i], a, b)
+        yᵢ = IComplexF64(something(cert.I)[i], a, b)
         d +=
             IntervalArithmetic.sqr(real(yᵢ) - real(reference_point[i])) +
             IntervalArithmetic.sqr(imag(yᵢ) - imag(reference_point[i]))
@@ -331,7 +331,7 @@ function add_certificate!(
     d = squared_distance_interval(cert, distinct_sols.reference_point)
     for match in IntervalTrees.intersect(distinct_sols.distinct_tree, d)
         certᵢ = IntervalTrees.value(match)
-        if Bool(Arblib.overlaps(cert.I, certᵢ.I))
+        if Bool(Arblib.overlaps(something(cert.I), something(certᵢ.I)))
             return (false, certᵢ)
             break
         end
@@ -362,7 +362,7 @@ function is_solution_candidate_guaranteed_duplicate(
         end
 
         # Check if s is contained in certᵢ.I
-        if Bool(Arblib.contains(certᵢ.I, distinct_sols.acb_solution_candidate))
+        if Bool(Arblib.contains(something(certᵢ.I), distinct_sols.acb_solution_candidate))
             return true
             break
         end
@@ -608,7 +608,7 @@ function CertificationCache(F::AbstractSystem)
         jac_interpreter_F64 = jac_interpreter_F64,
         eval_interpreter_acb = eval_interpreter_acb,
         jac_interpreter_acb = jac_interpreter_acb,
-        newton_cache = NewtonCache(F; optimize_data_structure = false),
+        newton_cache = NewtonCache(F; optimize_data_structure = false)::NewtonCache{MatrixWorkspace{Matrix{ComplexF64}}},
         C = zeros(ComplexF64, m, m),
         r₀ = zeros(IComplexF64, m),
         Δx₀ = zeros(IComplexF64, m),
@@ -1173,9 +1173,13 @@ function extended_prec_certify_solution(
 end
 
 
-function Base.Vector{ComplexF64}(A::Arblib.AcbMatrixLike)
+function Base.Vector{ComplexF64}(A::Arblib.AcbMatrix)
     @assert size(A, 2) == 1
-    [ComplexF64(Arblib.ref(A, i, 1).acb_ptr) for i = 1:size(A, 1)]
+    [ComplexF64(Arblib.ref(A, i, 1)) for i = 1:size(A, 1)]
+end
+function Base.Vector{ComplexF64}(A::Arblib.AcbRefMatrix)
+    @assert size(A, 2) == 1
+    [ComplexF64(Arblib.ref(A, i, 1)) for i = 1:size(A, 1)]
 end
 
 function ε_inflation_krawczyk(x̃₀, p::Union{Nothing,CertificationParameters}, C, cert_cache)
@@ -1509,7 +1513,7 @@ Base.@kwdef mutable struct DistinctCertifiedSolutions{
     C<:AbstractSolutionCertificate,
 }
     system::Vector{S}
-    parameters::Union{Vector{Nothing},Vector{CertificationParameters}}
+    parameters::Vector{Union{Nothing,CertificationParameters}}
     cache::Vector{CertificationCache}
     access_lock::ReentrantLock
     distinct_solution_certificates::DistinctSolutionCertificates{C}
@@ -1543,7 +1547,7 @@ function DistinctCertifiedSolutions(
     nthreads = thread_safe ? Threads.nthreads() : 1
     return DistinctCertifiedSolutions(
         [F; [deepcopy(F) for _ = 2:nthreads]],
-        [parameters; [deepcopy(parameters) for _ = 2:nthreads]],
+        Union{Nothing,CertificationParameters}[parameters; [deepcopy(parameters) for _ = 2:nthreads]],
         [cache; [deepcopy(cache) for _ = 2:nthreads]],
         access_lock,
         distinct_solution_certificates,

--- a/src/certification.jl
+++ b/src/certification.jl
@@ -608,7 +608,10 @@ function CertificationCache(F::AbstractSystem)
         jac_interpreter_F64 = jac_interpreter_F64,
         eval_interpreter_acb = eval_interpreter_acb,
         jac_interpreter_acb = jac_interpreter_acb,
-        newton_cache = NewtonCache(F; optimize_data_structure = false)::NewtonCache{MatrixWorkspace{Matrix{ComplexF64}}},
+        newton_cache = NewtonCache(
+            F;
+            optimize_data_structure = false,
+        )::NewtonCache{MatrixWorkspace{Matrix{ComplexF64}}},
         C = zeros(ComplexF64, m, m),
         r₀ = zeros(IComplexF64, m),
         Δx₀ = zeros(IComplexF64, m),
@@ -1547,7 +1550,10 @@ function DistinctCertifiedSolutions(
     nthreads = thread_safe ? Threads.nthreads() : 1
     return DistinctCertifiedSolutions(
         [F; [deepcopy(F) for _ = 2:nthreads]],
-        Union{Nothing,CertificationParameters}[parameters; [deepcopy(parameters) for _ = 2:nthreads]],
+        Union{Nothing,CertificationParameters}[
+            parameters
+            [deepcopy(parameters) for _ = 2:nthreads]
+        ],
         [cache; [deepcopy(cache) for _ = 2:nthreads]],
         access_lock,
         distinct_solution_certificates,

--- a/src/endgame_tracker.jl
+++ b/src/endgame_tracker.jl
@@ -595,7 +595,7 @@ function singular_endgame_step!(endgame_tracker::EndgameTracker, debug::Bool = f
     end
 
     @label prediction
-    m = state.winding_number
+    m = something(state.winding_number)
     κ = state.sample_conds[3]
     zero_cond = 1 / (m + 1)
     for i = 1:length(state.prediction)

--- a/src/homotopies/mixed_homotopy.jl
+++ b/src/homotopies/mixed_homotopy.jl
@@ -10,7 +10,7 @@ struct MixedHomotopy{ID} <: AbstractHomotopy
     compiled::CompiledHomotopy{ID}
     interpreted::InterpretedHomotopy
 end
-MixedHomotopy(H::Homotopy) = MixedHomotopy(CompiledHomotopy(H), InterpretedHomotopy(H))
+MixedHomotopy(H::Homotopy; kwargs...) = MixedHomotopy(CompiledHomotopy(H), InterpretedHomotopy(H))
 
 Base.size(H::MixedHomotopy) = size(H.compiled)
 ModelKit.variables(H::MixedHomotopy) = variables(H.interpreted)

--- a/src/homotopies/mixed_homotopy.jl
+++ b/src/homotopies/mixed_homotopy.jl
@@ -10,7 +10,8 @@ struct MixedHomotopy{ID} <: AbstractHomotopy
     compiled::CompiledHomotopy{ID}
     interpreted::InterpretedHomotopy
 end
-MixedHomotopy(H::Homotopy; kwargs...) = MixedHomotopy(CompiledHomotopy(H), InterpretedHomotopy(H))
+MixedHomotopy(H::Homotopy; kwargs...) =
+    MixedHomotopy(CompiledHomotopy(H), InterpretedHomotopy(H))
 
 Base.size(H::MixedHomotopy) = size(H.compiled)
 ModelKit.variables(H::MixedHomotopy) = variables(H.interpreted)

--- a/src/homotopies/subspace_homotopies.jl
+++ b/src/homotopies/subspace_homotopies.jl
@@ -43,6 +43,8 @@ function GrassmannianGeodesic(start, target; embedded_projective::Bool = false)
         else
             Q_cos = target.Y * U
         end
+    else
+        error("start must be an ExtrinsicDescription or IntrinsicDescription")
     end
 
 
@@ -104,8 +106,8 @@ Base.@kwdef mutable struct ExtrinsicSubspaceHomotopy{S<:AbstractSystem} <: Abstr
     b0::Vector{ComplexF64}
 
     # For the offset part (linear interpolation)
-    a_minus_b::Union{Nothing,Vector{ComplexF64}}
-    offset::Union{Nothing,Vector{ComplexF64}}
+    a_minus_b::Vector{ComplexF64}
+    offset::Vector{ComplexF64}
 
     # caches for t
     t_cache::Base.RefValue{ComplexF64}
@@ -177,8 +179,8 @@ function ExtrinsicSubspaceHomotopy(
     # get correct coordinates for A and b in the Stiefel homotopy
     # extrinsic(start).A is replaced by transpose(path.γ1)
     # extrinsic(target).A is replaced by transpose(path.Q_cos)    
-    a0 = path.B_start * extrinsic(start).b
-    b0 = path.B_target * extrinsic(target).b
+    a0 = something(path.B_start) * extrinsic(start).b
+    b0 = something(path.B_target) * extrinsic(target).b
 
     # Prepare offset data for linear interpolation
     a_minus_b = a0 - b0
@@ -237,10 +239,10 @@ Base.@kwdef mutable struct IntrinsicSubspaceHomotopy{S<:AbstractSystem} <: Abstr
     path::GrassmannianGeodesic
 
     # For the offset part (linear interpolation)
-    a_minus_b::Union{Nothing,Vector{ComplexF64}}
-    offset::Union{Nothing,Vector{ComplexF64}}
+    a_minus_b::Vector{ComplexF64}
+    offset::Vector{ComplexF64}
 
-    # cache for t 
+    # cache for t
     t_cache::Base.RefValue{ComplexF64}
     offset_t_cache::Base.RefValue{ComplexF64}
 
@@ -493,8 +495,8 @@ function set_subspaces!(H::SubspaceHomotopy, start::LinearSubspace, target::Line
 
     # Update the offsets
     if isa(H, ExtrinsicSubspaceHomotopy)
-        LA.mul!(H.a0, H.path.B_start, extrinsic(start).b)
-        LA.mul!(H.b0, H.path.B_target, extrinsic(target).b)
+        LA.mul!(H.a0, something(H.path.B_start), extrinsic(start).b)
+        LA.mul!(H.b0, something(H.path.B_target), extrinsic(target).b)
         H.a_minus_b .= H.a0 .- H.b0
         H.offset .= H.b0
     elseif isa(H, IntrinsicSubspaceHomotopy)

--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -47,7 +47,7 @@ is_valid_interval(a::Real, b::Real) = isfinite(a) && isfinite(b) && a ≤ b
     )
 end
 
-Base.hash(x::Interval, h::UInt) = hash(x.hi, hash(x.lo, u))
+Base.hash(x::Interval, h::UInt) = hash(x.hi, hash(x.lo, h))
 Base.:(==)(a::Interval, b::Interval) = a.lo == b.lo && a.hi == b.hi
 Base.eltype(x::Interval{T}) where {T} = T
 
@@ -246,7 +246,7 @@ Base.literal_pow(::typeof(^), a::Interval, ::Val{2}) = sqr(a)
 
 function ^(x::Interval, n::Integer)  # fast integer power
     if n < 0
-        return inv(pow(x, -n))
+        return inv(x ^ (-n))
     end
     isempty(x) && return x
     if iseven(n) && 0 ∈ x

--- a/src/interval_arithmetic.jl
+++ b/src/interval_arithmetic.jl
@@ -246,7 +246,7 @@ Base.literal_pow(::typeof(^), a::Interval, ::Val{2}) = sqr(a)
 
 function ^(x::Interval, n::Integer)  # fast integer power
     if n < 0
-        return inv(x ^ (-n))
+        return inv(x^(-n))
     end
     isempty(x) && return x
     if iseven(n) && 0 ∈ x

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -27,15 +27,20 @@ function MatrixWorkspace(Â::AbstractMatrix; optimize_data_structure = true)
     m, n = size(Â)
     m ≥ n || throw(ArgumentError("Expected system with more rows than columns."))
 
-    A = Matrix{ComplexF64}(Â)
-    d = ones(m)
-    factorized = Ref(false)
-    qr = LA.qrfactUnblocked!(copy(A))
+    A_mat = Matrix{ComplexF64}(Â)
     # experiments show that for m > 25 the data layout as a
     # struct array is beneficial
     if m > 25 && optimize_data_structure
-        A = StructArrays.StructArray(A)
+        return _make_matrix_workspace(StructArrays.StructArray(A_mat), A_mat, m, n)
+    else
+        return _make_matrix_workspace(A_mat, A_mat, m, n)
     end
+end
+
+function _make_matrix_workspace(A, A_mat::Matrix{ComplexF64}, m, n)
+    d = ones(m)
+    factorized = Ref(false)
+    qr = LA.qrfactUnblocked!(copy(A_mat))
     row_scaling = ones(m)
     scaled = Ref(false)
 
@@ -339,7 +344,7 @@ function ldiv_adj_upper!(
         for i = 1:j-1
             z -= conj(A[i, j]) * x[i]
         end
-        iszero(A[j, j]) && singular_exception && throw(SingularException(j))
+        iszero(A[j, j]) && singular_exception && throw(LA.SingularException(j))
         x[j] = @fastmath conj(A[j, j]) \ z
     end
     x
@@ -752,7 +757,7 @@ function LA.cond(
         if isa(d_l, Nothing) && isa(d_r, Nothing)
             inv(abs(WS.A[1, 1]))
         elseif isa(d_l, Nothing)
-            inv(abs(WS.A[1, 1]) * d_r[1])
+            inv(abs(WS.A[1, 1]) * something(d_r)[1])
         elseif isa(d_r, Nothing)
             inv(d_l[1] * abs(WS.A[1, 1]))
         else

--- a/src/model_kit/compiled_system_homotopy.jl
+++ b/src/model_kit/compiled_system_homotopy.jl
@@ -19,7 +19,7 @@ struct CompiledSystem{HI} <: AbstractSystem
     system::System
 end
 
-function CompiledSystem(F::System)
+function CompiledSystem(F::System; kwargs...)
     n = length(F)
     nvars = nvariables(F)
     nparams = nparameters(F)
@@ -104,7 +104,7 @@ struct CompiledHomotopy{HI} <: AbstractHomotopy
     homotopy::Homotopy
 end
 
-function CompiledHomotopy(H::Homotopy)
+function CompiledHomotopy(H::Homotopy; kwargs...)
     n = length(H)
     nvars = nvariables(H)
     nparams = nparameters(H)

--- a/src/model_kit/instruction_interpreter.jl
+++ b/src/model_kit/instruction_interpreter.jl
@@ -275,7 +275,7 @@ for has_parameters in [true, false],
     has_second_output in [true, false]
 
     @eval Base.@propagate_inbounds function execute!(
-        u::Union{Nothing,AbstractArray},
+        $(has_second_output ? :(u::Union{Nothing,AbstractArray}) : :(u::AbstractArray)),
         $((has_second_output ? (:(U::AbstractArray),) : ())...),
         I::Interpreter,
         x::AbstractArray,
@@ -288,9 +288,11 @@ for has_parameters in [true, false],
         checkbounds(x, 1:length(vars_range))
         isnothing(parameters) || checkbounds(parameters, 1:length(params_range))
 
-        @inbounds for (i, k) in enumerate(params_range)
-            I.tape[k] = parameters[i]
-        end
+        $(has_parameters ? quote
+            @inbounds for (i, k) in enumerate(params_range)
+                I.tape[k] = parameters[i]
+            end
+        end : :())
         $(
             has_continuation_parameter ?
             quote
@@ -451,7 +453,7 @@ end
 for has_parameters in [true, false], has_continuation_parameter in [true, false]
 
     @eval Base.@propagate_inbounds function execute_taylor!(
-        u::Union{Nothing,AbstractArray},
+        u::AbstractArray,
         V::Val{K},
         I::Interpreter,
         x::AbstractArray,
@@ -466,9 +468,11 @@ for has_parameters in [true, false], has_continuation_parameter in [true, false]
         checkbounds(x, 1:length(vars_range))
         isnothing(parameters) || checkbounds(parameters, 1:length(params_range))
 
-        @inbounds for (i, k) in enumerate(params_range)
-            I.tape[k] = parameters[i]
-        end
+        $(has_parameters ? quote
+            @inbounds for (i, k) in enumerate(params_range)
+                I.tape[k] = parameters[i]
+            end
+        end : :())
         $(
             has_continuation_parameter ?
             quote

--- a/src/model_kit/intermediate_representation.jl
+++ b/src/model_kit/intermediate_representation.jl
@@ -381,7 +381,7 @@ function split_into_num_denom!(ir, ex, cse, pse)
             xref = expr_to_ir_statements!(ir, x, cse, pse)
             k = to_number(k_ex)
             if k isa Basic
-                throw(ExprError("Cannot handle non-constant exponents"))
+                error("Cannot handle non-constant exponents")
             end
             if k < 0
                 push!(denoms, pow!(ir, xref, -k))

--- a/src/model_kit/interpreted_homotopy.jl
+++ b/src/model_kit/interpreted_homotopy.jl
@@ -23,7 +23,7 @@ mutable struct InterpretedHomotopy <: AbstractHomotopy
     jac_acb::Union{Nothing,Interpreter{AcbRefVector}}
 end
 
-function InterpretedHomotopy(H::Homotopy)
+function InterpretedHomotopy(H::Homotopy; kwargs...)
     eval_ComplexF64 = interpreter(ComplexF64, H)
     eval_ComplexDF64 = interpreter(ComplexDF64, eval_ComplexF64)
     eval_acb = nothing
@@ -46,6 +46,7 @@ Base.size(H::InterpretedHomotopy) = size(H.homotopy)
 variables(H::InterpretedHomotopy) = variables(H.homotopy)
 parameters(H::InterpretedHomotopy) = parameters(H.homotopy)
 variable_groups(H::InterpretedHomotopy) = variable_groups(H.homotopy)
+Homotopy(H::InterpretedHomotopy) = H.homotopy
 Base.:(==)(H::InterpretedHomotopy, G::InterpretedHomotopy) = H.homotopy == G.homotopy
 
 function Base.show(io::IO, H::InterpretedHomotopy)
@@ -211,14 +212,16 @@ function evaluate!(
     u::AbstractArray{<:Union{Acb,AcbRef}},
     H::InterpretedHomotopy,
     x::AbstractArray{<:Union{Acb,AcbRef}},
+    t,
     p = nothing;
     prec = max(precision(first(u)), precision(first(x))),
 )
     if isnothing(H.eval_acb)
         H.eval_acb = interpreter(AcbRefVector, H.eval_ComplexF64)
     end
-    setprecision!(H.eval_acb, prec)
-    execute!(u, H.eval_acb, x, t, p)
+    I = H.eval_acb::Interpreter{AcbRefVector}
+    setprecision!(I, prec)
+    execute!(u, I, x, t, p)
 end
 
 function evaluate_and_jacobian!(
@@ -233,9 +236,10 @@ function evaluate_and_jacobian!(
     if isnothing(H.jac_acb)
         H.jac_acb = interpreter(AcbRefVector, H.jac_ComplexF64)
     end
-    setprecision!(H.jac_acb, prec)
+    I = H.jac_acb::Interpreter{AcbRefVector}
+    setprecision!(I, prec)
 
-    execute!(u, U, H.jac_acb, x, t, p)
+    execute!(u, U, I, x, t, p)
     nothing
 end
 

--- a/src/model_kit/interpreted_system.jl
+++ b/src/model_kit/interpreted_system.jl
@@ -31,7 +31,7 @@ mutable struct InterpretedSystem <: AbstractSystem
     jac_acb::Union{Nothing,Interpreter{AcbRefVector}}
 end
 
-function InterpretedSystem(F::System)
+function InterpretedSystem(F::System; kwargs...)
     eval_ComplexF64 = interpreter(ComplexF64, F)
     eval_ComplexDF64 = interpreter(ComplexDF64, eval_ComplexF64)
     eval_acb = nothing
@@ -78,6 +78,7 @@ function jacobian!(U, F::InterpretedSystem, x, p = nothing)
     execute!(nothing, U, F.jac_ComplexF64, x, p;)
     U
 end
+jacobian!(U, F::InterpretedSystem, x, p, cache) = jacobian!(U, F, x, p)
 
 @generated function taylor!(
     u::AbstractVector,
@@ -206,8 +207,9 @@ function evaluate!(
     if isnothing(F.eval_acb)
         F.eval_acb = interpreter(AcbRefVector, F.eval_ComplexF64)
     end
-    setprecision!(F.eval_acb, prec)
-    execute!(u, F.eval_acb, x, p)
+    I = F.eval_acb::Interpreter{AcbRefVector}
+    setprecision!(I, prec)
+    execute!(u, I, x, p)
 end
 
 function evaluate_and_jacobian!(
@@ -221,9 +223,10 @@ function evaluate_and_jacobian!(
     if isnothing(F.jac_acb)
         F.jac_acb = interpreter(AcbRefVector, F.jac_ComplexF64)
     end
-    setprecision!(F.jac_acb, prec)
+    I = F.jac_acb::Interpreter{AcbRefVector}
+    setprecision!(I, prec)
 
-    execute!(u, U, F.jac_acb, x, p)
+    execute!(u, U, I, x, p)
     nothing
 end
 

--- a/src/model_kit/symbolic.jl
+++ b/src/model_kit/symbolic.jl
@@ -627,6 +627,8 @@ Return a matrix `M` containing the exponents for all occuring terms
 Expands the given expression `f` unless `expanded = true`.
 Throws a `PolynomialError` if a rational expression is encountered.
 """
+exponents_coefficients(f::Expression, var::Variable; kwargs...) =
+    exponents_coefficients(f, [var]; kwargs...)
 function exponents_coefficients(
     f::Expression,
     vars::AbstractVector{Variable};
@@ -786,7 +788,7 @@ function is_homogeneous(f::Expression, vars::Vector{Variable}; expanded::Bool = 
         if err isa PolynomialError
             return false
         else
-            rethrow(e)
+            rethrow(err)
         end
     end
 end
@@ -811,7 +813,8 @@ julia> horner(f)
 c₁ + v*(c₂ + u^3*c₃ + u^2*v*c₃)
 ```
 """
-function horner(f::Expression, vars = variables(f))
+horner(f::Expression, var::Variable) = horner(f, [var])
+function horner(f::Expression, vars::AbstractVector{Variable} = variables(f))
     try
         M, coeffs = exponents_coefficients(f, vars; expanded = true, unpack_coeffs = false)
         multivariate_horner(M, coeffs, vars)
@@ -938,7 +941,7 @@ function check_vars_params(f, vars, params)
     isempty(Δ) || throw(
         ArgumentError(
             "Not all variables or parameters of the system are given. Missing: " *
-            join(Δ, ", "),
+            string(join(Δ, ", ")),
         ),
     )
     if params !== nothing
@@ -1088,18 +1091,23 @@ function System(
     variable_groups = nothing,
 )
     vars = map(variables) do v
+        v isa Variable && return v
         name, ind = MP.name_base_indices(v)
         Variable(name, ind...)
     end
     params = Variable[]
     for v in parameters
-        name, ind = MP.name_base_indices(v)
-        push!(params, Variable(name, ind...))
+        if v isa Variable
+            push!(params, v)
+        else
+            name, ind = MP.name_base_indices(v)
+            push!(params, Variable(name, ind...))
+        end
     end
     if variable_groups === nothing
         var_groups = nothing
     else
-        var_groups = map(var_groups) do group
+        var_groups = map(variable_groups) do group
             map(group) do v
                 name, ind = MP.name_base_indices(v)
                 Variable(name, ind...)
@@ -1248,7 +1256,7 @@ jacobian(F, [2, 3])
  441  294
 ```
 """
-function jacobian(F::System, x, p = nothing)
+function jacobian(F::System, x::AbstractVector, p::Union{Nothing,AbstractVector} = nothing)
     if p isa Nothing
         evaluate(jacobian(F), F.variables => x)
     else
@@ -1439,7 +1447,7 @@ function system_with_coefficents_as_params(
     if variable_groups === nothing
         var_groups = nothing
     else
-        var_groups = map(var_groups) do group
+        var_groups = map(variable_groups) do group
             map(group) do v
                 name, ind = MP.name_base_indices(v)
                 Variable(name, ind...)
@@ -1615,6 +1623,7 @@ variables(H::Homotopy) = H.variables
 Returns the parameters of the given homotopy `H`.
 """
 parameters(H::Homotopy) = H.parameters
+variable_groups(::Homotopy) = nothing
 
 """
     to_smallest_eltype(A::AbstractArray)

--- a/src/model_kit/symengine.jl
+++ b/src/model_kit/symengine.jl
@@ -313,7 +313,7 @@ function get_error(error_code::Cuint, str = nothing)
     elseif error_code == 4
         return DomainError(str)
     elseif error_code == 5
-        return Meta.ParseError(str)
+        return Meta.ParseError(something(str, "SymEngine parse error"))
     else
         return ErrorException("Unexpected SymEngine error code")
     end
@@ -519,6 +519,7 @@ function Base.getindex(s::ExpressionSet, n::Int)
 end
 
 _variables(ex::Variable) = [ex]
+_variables(ex::ExpressionRef) = _variables(Expression(ex))
 function _variables(ex::Expression)
     syms = ExpressionSet()
     ccall(
@@ -638,10 +639,8 @@ function Base.getindex(v::ExprVec, n)
     @boundscheck checkbounds(v, n)
     if v.m === nothing
         vec_set_ptr!(v)
-        unsafe_load(v.m, n)
-    else
-        unsafe_load(v.m, n)
     end
+    unsafe_load(v.m::Ptr{ModelKit.ExpressionRef}, n)
 end
 
 function Base.push!(v::ExprVec, x::Basic)

--- a/src/model_kit/taylor.jl
+++ b/src/model_kit/taylor.jl
@@ -277,7 +277,7 @@ function taylor_op_cb(V::Val{K}, x::TruncatedTaylorSeries{M}) where {K,M}
     taylor_op_mul(V, taylor_op_sqr(V, x), x)
 end
 # OP_COS and OP_SIN
-function taylor_sin_helper!(list, D, k)
+function taylor_sin_helper!(list::IntermediateRepresentation, D, k)
     k == 0 && return :s₀
     s_k = nothing
     for j = 1:k
@@ -286,7 +286,7 @@ function taylor_sin_helper!(list, D, k)
     end
     div!(list, s_k, k)
 end
-function taylor_cos_helper!(list, D, k)
+function taylor_cos_helper!(list::IntermediateRepresentation, D, k)
     k == 0 && return :c₀
     c_k = nothing
     for j = 1:k

--- a/src/norm.jl
+++ b/src/norm.jl
@@ -24,7 +24,8 @@ distance(u, v, norm::AbstractNorm) = throw(MethodError(distance, (u, v, norm)))
 
 Compute the norm ||u|| with respect to the given norm `norm`.
 """
-LinearAlgebra.norm(u, norm::AbstractNorm) = throw(MethodError(LinearAlgebra.norm, (u, norm)))
+LinearAlgebra.norm(u, norm::AbstractNorm) =
+    throw(MethodError(LinearAlgebra.norm, (u, norm)))
 
 (N::AbstractNorm)(x) = norm(x, N)
 (N::AbstractNorm)(x, y) = distance(x, y, N)

--- a/src/norm.jl
+++ b/src/norm.jl
@@ -17,14 +17,14 @@ abstract type AbstractNorm end
 
 Compute the distance ||u-v|| with respect to the given norm `norm`.
 """
-distance(u, v, norm::AbstractNorm) = MethodError(distance, (u, v, norm))
+distance(u, v, norm::AbstractNorm) = throw(MethodError(distance, (u, v, norm)))
 
 """
     norm(u, norm::AbstractNorm)
 
 Compute the norm ||u|| with respect to the given norm `norm`.
 """
-LinearAlgebra.norm(u, norm::AbstractNorm) = MethodError(LinearAlgebra.norm, (u, norm))
+LinearAlgebra.norm(u, norm::AbstractNorm) = throw(MethodError(LinearAlgebra.norm, (u, norm)))
 
 (N::AbstractNorm)(x) = norm(x, N)
 (N::AbstractNorm)(x, y) = distance(x, y, N)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -339,10 +339,11 @@ function _regeneration(
     # it is covenient to use the WitnessSet wrapper here, because this also keeps track of the equation
     # as a linear subspace we take the linear subspace for out[1], that sets u=0.
     update_progress!(progress; is_computing_hypersurfaces = true)
-    H = initialize_hypersurfaces(F, vars, linear_subspace(out[1]); threading = threading)
-    if any(isnothing, H)
+    H_maybe = initialize_hypersurfaces(F, vars, linear_subspace(out[1]); threading = threading)
+    if isnothing(H_maybe) || any(isnothing, H_maybe)
         return nothing
     end
+    H = H_maybe::Vector{WitnessSet}
 
     # sort expressions by degree
     if sorted
@@ -610,8 +611,8 @@ end
 This is the core routine of the regeneration algorithm. It intersects a set of [`WitnessPoints`](@ref) with a hypersurface.
 """
 function intersect_with_hypersurface!(
-    W,
-    H,
+    W::WitnessPoints,
+    H::WitnessSet,
     X,
     cache;
     threading::Bool = Threads.nthreads() > 1,
@@ -674,7 +675,7 @@ function manage_initial_points!(P, m)
     return P_next
 end
 
-function serial_intersection!(X, P, roots, egtracker, progress)
+function serial_intersection!(X, P, roots, egtracker::EndgameTracker, progress)
     start = Iterators.product(P, roots)
     l_start = length(P) * length(roots)
 
@@ -701,7 +702,7 @@ function serial_intersection!(X, P, roots, egtracker, progress)
     nothing
 end
 
-function threaded_intersection!(X, P, roots, tracker, progress)
+function threaded_intersection!(X, P, roots, tracker::EndgameTracker, progress)
 
     l_P = length(P)
     l_roots = length(roots)
@@ -969,7 +970,7 @@ end
 The core function for decomposing a witness set into irreducible components.
 """
 function decompose_with_monodromy!(
-    W,
+    W::WitnessSet,
     show_monodromy_progress,
     options,
     max_iters,
@@ -1980,7 +1981,7 @@ end
 
 
 
-function prepare_for_u_homotopy(H, W, vars, u)
+function prepare_for_u_homotopy(H::WitnessSet, W::WitnessSet, vars::Vector{Variable}, u)
     # prepare polynomials 
     FH0 = deepcopy(System(system(H)))
     FW0 = deepcopy(System(system(W)))

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -339,7 +339,8 @@ function _regeneration(
     # it is covenient to use the WitnessSet wrapper here, because this also keeps track of the equation
     # as a linear subspace we take the linear subspace for out[1], that sets u=0.
     update_progress!(progress; is_computing_hypersurfaces = true)
-    H_maybe = initialize_hypersurfaces(F, vars, linear_subspace(out[1]); threading = threading)
+    H_maybe =
+        initialize_hypersurfaces(F, vars, linear_subspace(out[1]); threading = threading)
     if isnothing(H_maybe) || any(isnothing, H_maybe)
         return nothing
     end

--- a/src/polyhedral.jl
+++ b/src/polyhedral.jl
@@ -68,7 +68,7 @@ function Base.iterate(iter::PolyhedralStartSolutionsIterator)
     isnothing(first_cell) && return nothing
     cell, inner_state = first_cell
 
-    solve(iter.BSS, iter.support, iter.start_coefficients, cell)
+    solve(iter.BSS, iter.support, iter.start_coefficients, cell::MixedCell)
     x = [iter.BSS.X[i, 1] for i = 1:length(iter.support)]
 
     # return the value _and_ the combined state:
@@ -91,7 +91,7 @@ function Base.iterate(iter::PolyhedralStartSolutionsIterator, state::Tuple{Any,A
         next_cell === nothing && return nothing
         cell2, new_inner_state = next_cell
 
-        solve(iter.BSS, iter.support, iter.start_coefficients, cell2)
+        solve(iter.BSS, iter.support, iter.start_coefficients, cell2::MixedCell)
         x = [iter.BSS.X[i, 1] for i = 1:length(iter.support)]
 
         return (cell2, x), (cell2, new_inner_state, 1)
@@ -208,12 +208,13 @@ function polyhedral(
             @var x[1:n]
             support, target_coeffs = support_coefficients(System(F(x), x))
         else
+            F = f
             support, target_coeffs = support_coefficients(f)
         end
     end
     tracker, starts = polyhedral(support, target_coeffs; compile = compile, kwargs...)
     if m > n
-        tracker = OverdeterminedTracker(tracker, F)
+        tracker = OverdeterminedTracker(tracker, F::RandomizedSystem)
     end
     tracker, starts
 end
@@ -269,7 +270,7 @@ function paths_to_track(
         MixedSubdivisions.mixed_volume(supp′)
     end
 end
-MixedSubdivisions.mixed_volume(f::Union{System,AbstractSystem}) =
+MixedSubdivisions.mixed_volume(f::System) =
     paths_to_track(f; start_system = :polyhedral, only_torus = true)
 
 function polyhedral(

--- a/src/result.jl
+++ b/src/result.jl
@@ -134,6 +134,7 @@ seed(R::Result) = R.seed
 Returns the stored [`PathResult`](@ref)s.
 """
 path_results(R::Result) = R.path_results
+path_results(R::AbstractVector{<:PathResult}) = R
 
 multiple_indicator(::AbstractResult) =
     error("[`multiple_indicator`] Not defined for abstract results yet")

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -731,11 +731,7 @@ end
 
 Returns the number of paths tracked when calling [`solve`](@ref) with the given arguments.
 """
-function paths_to_track(
-    f::System;
-    start_system::Symbol = :polyhedral,
-    kwargs...,
-)
+function paths_to_track(f::System; start_system::Symbol = :polyhedral, kwargs...)
     paths_to_track(f, Val(start_system); kwargs...)
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -732,7 +732,7 @@ end
 Returns the number of paths tracked when calling [`solve`](@ref) with the given arguments.
 """
 function paths_to_track(
-    f::Union{System,AbstractSystem};
+    f::System;
     start_system::Symbol = :polyhedral,
     kwargs...,
 )

--- a/src/systems/affine_chart_system.jl
+++ b/src/systems/affine_chart_system.jl
@@ -30,7 +30,7 @@ on_affine_chart(
 ) = on_affine_chart(fixed(F; compile = compile), dims)
 function on_affine_chart(
     F::AbstractSystem,
-    dims = nothing,
+    dims = nothing;
     compile::Union{Bool,Symbol} = true,
 )
     vargroups = variable_groups(F)

--- a/src/total_degree.jl
+++ b/src/total_degree.jl
@@ -494,7 +494,4 @@ function paths_to_track(f, ::Val{:total_degree})
         length(starts)
     end
 end
-@deprecate bezout_number(f::System) paths_to_track(
-    f;
-    start_system = :total_degree,
-)
+@deprecate bezout_number(f::System) paths_to_track(f; start_system = :total_degree)

--- a/src/total_degree.jl
+++ b/src/total_degree.jl
@@ -109,7 +109,7 @@ function total_degree_variables(
     end
     T = EndgameTracker(H, tracker_options = tracker_options, options = endgame_options)
     if overdetermined
-        T = OverdeterminedTracker(T, F)
+        T = OverdeterminedTracker(T, F::RandomizedSystem)
     end
     starts = total_degree_start_solutions(D; homogeneous = homogeneous)
 
@@ -172,7 +172,7 @@ function total_degree_variable_groups(
     end
     T = EndgameTracker(H, tracker_options = tracker_options, options = endgame_options)
     if overdetermined
-        T = OverdeterminedTracker(T, F)
+        T = OverdeterminedTracker(T, F::RandomizedSystem)
     end
     T, starts
 end
@@ -204,11 +204,7 @@ function multi_homogeneous_system(D, vargroups; homogeneous::Bool)
 
     P = variables(C)
 
-    if homogeneous
-        Z = vargroups
-    else
-        Z = vcat.(vargroups, 1)
-    end
+    Z = homogeneous ? vargroups : vcat.(vargroups, 1)
 
     m, n = size(D)
     g = map(1:n) do i
@@ -401,6 +397,13 @@ end
 Base.show(io::IO, ::MIME"application/prs.juno.inline", x::MultiBezoutSolutionsIterator) = x
 Base.IteratorSize(::Type{<:MultiBezoutSolutionsIterator}) = Base.SizeUnknown()
 Base.eltype(::Type{MultiBezoutSolutionsIterator}) = Vector{ComplexF64}
+function Base.length(iter::MultiBezoutSolutionsIterator)
+    k = 0
+    for _ in iter
+        k += 1
+    end
+    k
+end
 
 function Base.iterate(iter::MultiBezoutSolutionsIterator)
     (_, perm), indices_state = iterate(iter.indices)
@@ -491,7 +494,7 @@ function paths_to_track(f, ::Val{:total_degree})
         length(starts)
     end
 end
-@deprecate bezout_number(f::Union{System,AbstractSystem}) paths_to_track(
+@deprecate bezout_number(f::System) paths_to_track(
     f;
     start_system = :total_degree,
 )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,7 +60,7 @@ julia> read_solutions("solutions.txt")
 ```
 """
 function read_solutions(filename)
-    A = DelimitedFiles.readdlm(filename; skipblanks = false)
+    A = DelimitedFiles.readdlm(filename; skipblanks = false)::Matrix
     n = convert(Int, A[1, 1])
     # figure out number of variables
     nvars = 0
@@ -130,7 +130,7 @@ julia> read_parameters("parameters.txt")
 ```
 """
 function read_parameters(filename)
-    A = DelimitedFiles.readdlm(filename)
+    A = DelimitedFiles.readdlm(filename)::Matrix
     n = A[1, 1]
     map(1:n) do i
         A[i+1, 1] + im * A[i+1, 2]
@@ -481,7 +481,7 @@ for (fJ, fC) in ((:add!, :add), (:mul!, :mul))
             )
             return z
         end
-        ($fJ)(c::Float64, x::BigFloat) = ($fJ)(x, c)
+        ($fJ)(c::Float64, x::BigFloat) = ($fJ)(x, x, c)
 
         function ($fJ)(z::BigFloat, x::BigFloat, c::Int64)
             ccall(
@@ -495,7 +495,7 @@ for (fJ, fC) in ((:add!, :add), (:mul!, :mul))
             )
             return z
         end
-        ($fJ)(c::Int64, x::BigFloat) = ($fJ)(x, c)
+        ($fJ)(c::Int64, x::BigFloat) = ($fJ)(x, x, c)
 
         # BigInt
         function ($fJ)(z::BigFloat, x::BigFloat, c::BigInt)
@@ -510,7 +510,7 @@ for (fJ, fC) in ((:add!, :add), (:mul!, :mul))
             )
             return z
         end
-        ($fJ)(c::BigInt, x::BigFloat) = ($fJ)(x, c)
+        ($fJ)(c::BigInt, x::BigFloat) = ($fJ)(x, x, c)
     end
 end
 

--- a/src/witness_set.jl
+++ b/src/witness_set.jl
@@ -268,7 +268,7 @@ mutable struct MembershipCache
     progress::Union{MembershipProgress,Nothing}
 end
 
-function MembershipCache(W, EO, TO, progress)
+function MembershipCache(W::WitnessSet, EO, TO, progress)
     F = system(W)
     m, n = size(F)
     i = codim(W)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 ElasticArrays = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MixedSubdivisions = "291d046c-3347-11e9-1e74-c3d251d406c6"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"

--- a/test/jet_test.jl
+++ b/test/jet_test.jl
@@ -1,25 +1,30 @@
-using JET
 using Test
-using HomotopyContinuation
 
-# Filter known reports: cos/sin/sqrt(::IComplexF64) are not implemented because
-# adding them to Base causes +4s TTFX regression via @generated execute_instructions! recompilation.
-# These only trigger when certifying systems with transcendental functions.
-const KNOWN_MISSING = Set(["cos", "sin", "sqrt"])
+@static if VERSION >= v"1.12"
+    using JET
+    using HomotopyContinuation
 
-function is_known_icomplexf64_report(r)
-    s = sprint(show, r)
-    occursin("IComplexF64", s) &&
-        any(f -> occursin("no matching method found `$f(", s), KNOWN_MISSING)
-end
+    # Filter known reports: cos/sin/sqrt(::IComplexF64) are not implemented because
+    # adding them to Base causes +4s TTFX regression via @generated execute_instructions! recompilation.
+    # These only trigger when certifying systems with transcendental functions.
+    const KNOWN_MISSING = Set(["cos", "sin", "sqrt"])
 
-@testset "JET checks" begin
-    rep = JET.report_package(HomotopyContinuation; target_modules = (HomotopyContinuation,))
-    reports = JET.get_reports(rep)
-    filtered = filter(!is_known_icomplexf64_report, reports)
-    @show rep
-    if length(filtered) != length(reports)
-        @info "Filtered $(length(reports) - length(filtered)) known IComplexF64 reports"
+    function is_known_icomplexf64_report(r)
+        s = sprint(show, r)
+        occursin("IComplexF64", s) &&
+            any(f -> occursin("no matching method found `$f(", s), KNOWN_MISSING)
     end
-    @test length(filtered) == 0
+
+    @testset "JET checks" begin
+        rep = JET.report_package(HomotopyContinuation; target_modules = (HomotopyContinuation,))
+        reports = JET.get_reports(rep)
+        filtered = filter(!is_known_icomplexf64_report, reports)
+        @show rep
+        if length(filtered) != length(reports)
+            @info "Filtered $(length(reports) - length(filtered)) known IComplexF64 reports"
+        end
+        @test length(filtered) == 0
+    end
+else
+    @info "Skipping JET checks on Julia $VERSION (requires ≥ 1.12)"
 end

--- a/test/jet_test.jl
+++ b/test/jet_test.jl
@@ -1,0 +1,24 @@
+using JET
+using Test
+using HomotopyContinuation
+
+# Filter known reports: cos/sin/sqrt(::IComplexF64) are not implemented because
+# adding them to Base causes +4s TTFX regression via @generated execute_instructions! recompilation.
+# These only trigger when certifying systems with transcendental functions.
+const KNOWN_MISSING = Set(["cos", "sin", "sqrt"])
+
+function is_known_icomplexf64_report(r)
+    s = sprint(show, r)
+    occursin("IComplexF64", s) && any(f -> occursin("no matching method found `$f(", s), KNOWN_MISSING)
+end
+
+@testset "JET checks" begin
+    rep = JET.report_package(HomotopyContinuation; target_modules=(HomotopyContinuation,))
+    reports = JET.get_reports(rep)
+    filtered = filter(!is_known_icomplexf64_report, reports)
+    @show rep
+    if length(filtered) != length(reports)
+        @info "Filtered $(length(reports) - length(filtered)) known IComplexF64 reports"
+    end
+    @test length(filtered) == 0
+end

--- a/test/jet_test.jl
+++ b/test/jet_test.jl
@@ -16,7 +16,10 @@ using Test
     end
 
     @testset "JET checks" begin
-        rep = JET.report_package(HomotopyContinuation; target_modules = (HomotopyContinuation,))
+        rep = JET.report_package(
+            HomotopyContinuation;
+            target_modules = (HomotopyContinuation,),
+        )
         reports = JET.get_reports(rep)
         filtered = filter(!is_known_icomplexf64_report, reports)
         @show rep

--- a/test/jet_test.jl
+++ b/test/jet_test.jl
@@ -9,11 +9,12 @@ const KNOWN_MISSING = Set(["cos", "sin", "sqrt"])
 
 function is_known_icomplexf64_report(r)
     s = sprint(show, r)
-    occursin("IComplexF64", s) && any(f -> occursin("no matching method found `$f(", s), KNOWN_MISSING)
+    occursin("IComplexF64", s) &&
+        any(f -> occursin("no matching method found `$f(", s), KNOWN_MISSING)
 end
 
 @testset "JET checks" begin
-    rep = JET.report_package(HomotopyContinuation; target_modules=(HomotopyContinuation,))
+    rep = JET.report_package(HomotopyContinuation; target_modules = (HomotopyContinuation,))
     reports = JET.get_reports(rep)
     filtered = filter(!is_known_icomplexf64_report, reports)
     @show rep

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,3 +61,5 @@ Random.seed!(0x8b868a97)
     #     include("extensive/extensive_test.jl")
     # end
 end
+
+include("jet_test.jl")


### PR DESCRIPTION
# Fix 148 JET.jl static analysis reports (151 → 3)

Hey, I am looking to improve the TTFX of the package a bit. I thought a good start would be to add [JET.jl](https://github.com/aviatesk/JET.jl) to the test suite.
This PR used Claude during development to solve the JET reports. The overview below was also made with Claude.
It found a couple of serious bugs like:
```julia
function Base.mod(x::DoubleF64, y::DoubleF64)
    n = round(a / b)
    return (a - b * n)
end
```
However, since the current test suite didn't catch it. These methods can likely be removed?

Anyway let me know what you think.

## Summary

Ran `JET.report_package(HomotopyContinuation; target_modules=(HomotopyContinuation,))` and systematically fixed 148 of 151 reports. The remaining 3 are filtered as known (`cos`/`sin`/`sqrt` for `IComplexF64` — implementing them causes +4s TTFX regression via `@generated execute_instructions!` recompilation).

**Zero performance regression** on precompilation, load time, TTFX, and steady-state runtime. Full test suite passes (2549/2549).

## Highlights

### Real bugs found (12 fixes)

JET uncovered genuine bugs that would crash at runtime — meaning these code paths are never exercised by the test suite and may be candidates for removal:

- **`DoubleDouble.jl:351`** — `mod(x, y)` used undefined `a`, `b` (copy-paste from `divrem` above)
- **`interval_arithmetic.jl:50`** — `hash(::Interval, h)` used undefined `u` instead of `h`
- **`interval_arithmetic.jl:249`** — `inv(pow(x, -n))` where `pow` is never defined
- **`symbolic.jl:789`** — `rethrow(e)` but the catch variable is `err`
- **`symbolic.jl:1102,1442`** — `map(var_groups)` before `var_groups` is assigned (should be `map(variable_groups)`)
- **`intermediate_representation.jl:384`** — `throw(ExprError(...))` but `ExprError` is never defined
- **`interpreted_homotopy.jl:221`** — Acb `evaluate!` missing `t` parameter entirely
- **`linear_algebra.jl:342`** — unqualified `SingularException` (needs `LA.SingularException`)
- **`utils.jl:484/498/513`** — `mul!(c::Float64, x::BigFloat) = mul!(x, c)` — 2-arg form doesn't exist (infinite recursion)
- **`norm.jl:20,27`** — `distance`/`norm` fallbacks return a `MethodError` object instead of throwing it
- **`DoubleDouble.jl:1032,1046`** — `DomainError()` with no arguments

These all crash unconditionally when reached, proving the code paths have zero test coverage. In particular `mod(::DoubleF64, ::DoubleF64)`, `hash(::Interval)`, `Interval^(-n)`, and the `BigFloat` `mul!`/`add!` 2-arg forms are completely broken — worth considering whether they should be removed rather than fixed.

### Type narrowing (JET can't prove runtime invariants)

The bulk of fixes help JET verify types through patterns it can't reason about. For example, many mutable structs store `Union{Nothing,T}` fields that are lazily initialized:

```julia
# Before: JET reports no matching method `setprecision!(::Nothing, ...)`
if isnothing(H.eval_acb)
    H.eval_acb = interpreter(AcbRefVector, H.eval_ComplexF64)
end
setprecision!(H.eval_acb, prec)  # JET still sees Union{Nothing, Interpreter}

# After: type assertion tells JET (and the runtime) that Nothing is impossible here
if isnothing(H.eval_acb)
    H.eval_acb = interpreter(AcbRefVector, H.eval_ComplexF64)
end
I = H.eval_acb::Interpreter{AcbRefVector}  # narrows type; throws TypeError if wrong
setprecision!(I, prec)
```

For the same reason `something()` is used throughout — it unwraps `Union{Nothing,T}` and throws a clear `ArgumentError("nothing")` instead of a confusing `MethodError`:

```julia
# Before: JET reports no matching method `overlaps(::Nothing, ::Nothing)`
Arblib.overlaps(cert.I, certᵢ.I)

# After: something() unwraps or throws with a clear message
Arblib.overlaps(something(cert.I), something(certᵢ.I))
```

Other type narrowing patterns used:
- Struct field types narrowed from `Union{Nothing,Vector}` to `Vector` where constructors always provide concrete values (`subspace_homotopies.jl` `a_minus_b`/`offset`)
- Type assertions at union-split call sites (`F::RandomizedSystem`, `cell::MixedCell`, `NewtonCache(...)::NewtonCache{...}`)
- Type annotations on untyped function parameters throughout `numerical_irreducible_decomposition.jl` and `witness_set.jl`

### Dispatch / missing method fixes

- `on_affine_chart(::AbstractSystem)` had `compile` as positional instead of keyword — actual dispatch failure
- 5 constructors (`CompiledSystem`, `InterpretedSystem`, `CompiledHomotopy`, `InterpretedHomotopy`, `MixedHomotopy`) didn't accept `kwargs...` passed by `fixed()`
- Missing methods: `variable_groups(::Homotopy)`, `Homotopy(::InterpretedHomotopy)`, `path_results(::AbstractVector{<:PathResult})`, `jacobian!(::InterpretedSystem, 5-arg)`, `_variables(::ExpressionRef)`, `horner(::Expression, ::Variable)`
- `MatrixWorkspace` constructor refactored for type-stability (extracted helper to avoid `Union{Matrix, StructArray}` in constructor body)

### Filtered reports (3)

`cos`/`sin`/`sqrt` for `IComplexF64` are not implemented. Adding them (whether on `Base.cos` or on the package-internal `op_cos`) triggers recompilation of the `@generated execute_instructions!` interpreter for all `IComplex` tape types, causing +4s TTFX on first `certify()`. These only matter when certifying systems with transcendental functions. The test filters them with a comment explaining the trade-off.

## Test integration

Added `test/jet_test.jl` as part of the regular test suite (JET added as test dependency). Filters the 3 known `IComplexF64` reports and asserts 0 remaining.

## Benchmarks (vs main)

| Metric | Verdict |
|--------|---------|
| Precompilation | No change (9.49s vs 9.51s) |
| Load time | No change (1.70s vs 1.71s) |
| TTFX solve | No change (32.7s vs 33.0s) |
| TTFX certify | No change (20.6s vs 20.3s) |
| Runtime (cyclic-5, certify, param) | No change |

Benchmarked sequentially (no concurrency), alternating branches, 3 runs each.

- **Precompilation**: `@elapsed Pkg.precompile()` after clearing `~/.julia/compiled/*HomotopyContinuation*`
- **Load time**: `@elapsed using HomotopyContinuation` with cache present
- **TTFX**: `@time` on first call (includes JIT):
  ```julia
  using HomotopyContinuation
  @var x y
  F = System([x^2 + y^2 - 1, x - y])
  @time solve(F; show_progress=false)                    # TTFX solve
  F2 = System([x^2 + y^2 - 1, x*y - 1])
  res = solve(F2; show_progress=false)
  @time certify(F2, res; show_progress=false)            # TTFX certify
  ```
- **Runtime**: `@benchmark` after full warmup:
  ```julia
  using HomotopyContinuation, BenchmarkTools
  @var x y z[1:5] a b

  # cyclic-5
  n = 5
  polys = [sum(prod(z[mod1(j+k,n)] for j in 1:i) for k in 1:n) - (-1)^(i-1)*i for i in 1:n-1]
  push!(polys, prod(z) - 1); F_c = System(polys)
  solve(F_c; show_progress=false)  # warmup
  @benchmark solve($F_c; show_progress=false)

  # certify
  F2 = System([x^2 + y^2 - 1, x*y - 1])
  r = solve(F2; show_progress=false); certify(F2, r; show_progress=false)
  @benchmark certify($F2, $r; show_progress=false)

  # parameter homotopy
  G = System([x^2 - a, y^2 - b]; parameters=[a, b])
  solve(G; target_parameters=[1.0, 1.0], show_progress=false)
  @benchmark solve($G; target_parameters=[2.0, 3.0], show_progress=false)
  ```

  | Benchmark | main (median) | JET (median) | main (allocs) | JET (allocs) |
  |-----------|--------------|--------------|---------------|--------------|
  | cyclic-5 | 19.59 ms | 19.73 ms | 23732 | 23732 |
  | certify | 362.9 μs | 373.4 μs | 3127 | 3142 |
  | param homotopy | 547.0 μs | 546.9 μs | 4776 | 4775 |

  **No runtime regression.** Identical allocation counts (±15 allocs on certify from the split Arblib method).

```julia
julia> versioninfo()
Julia Version 1.12.5
Commit 5fe89b8ddc1 (2026-02-09 16:05 UTC)
Build Info:
  Official https://julialang.org release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 12 × AMD Ryzen 5 5600X 6-Core Processor
  WORD_SIZE: 64
  LLVM: libLLVM-18.1.7 (ORCJIT, znver3)
  GC: Built with stock GC
Threads: 1 default, 1 interactive, 1 GC (on 12 virtual cores)
```