### PR TITLE
Optimize memory allocations in subspace homotopies

### DIFF
--- a/src/homotopies/subspace_homotopies.jl
+++ b/src/homotopies/subspace_homotopies.jl
@@ -83,6 +83,15 @@ const PROJECTIVE_INTRINSIC_LRU =
     )
 
 
+@inline function copy_first!(dest::AbstractVector, src)
+    axes(dest) == axes(src) || throw(DimensionMismatch("vectors must have matching axes"))
+    @inbounds for i in eachindex(dest, src)
+        dest[i] = first(src[i])
+    end
+    dest
+end
+
+
 """
     ExtrinsicSubspaceHomotopy(F::System, V::LinearSubspace, W::LinearSubspace)
     ExtrinsicSubspaceHomotopy(F::AbstractSystem, V::LinearSubspace, W::LinearSubspace)
@@ -724,7 +733,7 @@ function ModelKit.taylor!(
     m = first(size(H.system))
     k = size(γ̇, 2) # recall that A(t) = transpose(γ(t)), so A(t) is kxn
 
-    H.v .= first.(v)
+    copy_first!(H.v, v)
 
     LA.mul!(H.L̇, transpose(γ̇), H.v)
     offset_at_t!(H, t)
@@ -893,7 +902,7 @@ function set_solution!(u::Vector, H::IntrinsicSubspaceHomotopy, x::AbstractVecto
 
     set_solution!(H.x, H.system, x)
     offset_at_t!(H, t)
-    H.x .= H.x .- H.offset
+    LA.axpy!(-1, H.offset, H.x)
 
     if isone(t)
         LA.mul!(u, H.path.γ1', H.x)
@@ -975,7 +984,7 @@ function ModelKit.taylor!(
     γ = γ!(H, t)
     γ̇ = γ̇!(H, t)
 
-    H.v .= first.(v)
+    copy_first!(H.v, v)
     LA.mul!(H.x, γ, H.v)
     LA.mul!(H.ẋ, γ̇, H.v)
 
@@ -1212,7 +1221,7 @@ function ModelKit.taylor!(
     γ = γ!(H, t)
     γ̇ = γ̇!(H, t)
 
-    H.v .= first.(v)
+    copy_first!(H.v, v)
     LA.mul!(H.x, γ, H.v)
     LA.mul!(H.ẋ, γ̇, H.v)
 


### PR DESCRIPTION
There were some unnecessary memory allocations in subspace homotopies. This PR removes them.