### PR TITLE
Nid patch

### DIFF
--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -2,6 +2,7 @@ export monodromy_solve,
     find_start_pair,
     MonodromyOptions,
     MonodromyResult,
+    independent_normal,
     is_success,
     is_heuristic_stop,
     ncertified_distinct,
@@ -9,7 +10,8 @@ export monodromy_solve,
     parameters,
     permutations,
     trace,
-    verify_solution_completeness
+    verify_solution_completeness,
+    weighted_normal
 
 #####################
 # Monodromy Options #
@@ -678,7 +680,7 @@ See also [`linear_subspace_homotopy`](@ref) for the `intrinsic` option.
 * `trace_test = true`: If `true` a trace test is performed to check whether all solutions
   are found. This is only applicable if monodromy is performed with a linear subspace.
   See also [`trace_test`](@ref).
-* `trace_test_tol = 1e-10`: The tolerance for the trace test to be successfull.
+* `trace_test_tol = 1e-6`: The tolerance for the trace test to be successfull.
   The trace is divided by the number of solutions before compared to the trace_test_tol.
 * `unique_points_rtol`: the relative tolerance for [`unique_points`](@ref).
 * `unique_points_atol`: the absolute tolerance for [`unique_points`](@ref).

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -350,6 +350,13 @@ solutions(r::MonodromyResult) =
     isnothing(r.certified_solutions) ? solutions(r.results) : r.certified_solutions
 
 """
+    indexed_solutions(result::MonodromyResult)
+
+Return the solutions in the index order used by [`permutations`](@ref).
+"""
+indexed_solutions(r::MonodromyResult) = solution.(results(r))
+
+"""
     nsolutions(result::MonodromyResult)
 
 Returns the number solutions of the `result`. When `duplicate_check = :certified`, this
@@ -434,15 +441,21 @@ and `permutations(S, reduced = false)` returns
 """
 function permutations(r::MonodromyResult; reduced::Bool = true)
     π = r.statistics.permutations
-    N = nresults(r)
 
-    π = filter(πⱼ -> length(πⱼ) == N, π)
     if reduced
         π = unique(π)
     end
 
+    N = nresults(r)
+    for πⱼ in π
+        N = max(N, length(πⱼ))
+        if !isempty(πⱼ)
+            N = max(N, maximum(πⱼ))
+        end
+    end
+
     A = zeros(Int, N, length(π))
-    for (j, πⱼ) in enumerate(π), i = 1:N
+    for (j, πⱼ) in enumerate(π), i = 1:length(πⱼ)
         A[i, j] = πⱼ[i]
     end
 
@@ -1089,7 +1102,7 @@ function serial_monodromy_solve!(
                 MS.trace_lock;
                 collect_trace = MS.options.trace_test && nloops(MS) == job.loop_id,
             )
-            if !isnothing(res)
+            if !isnothing(res) && !res.singular
                 loop_tracked!(stats)
 
                 # 1) check whether solutions already exists
@@ -1229,7 +1242,7 @@ function threaded_monodromy_solve!(
                                                 nloops(MS) == job.loop_id,
                             )
 
-                            if !isnothing(res)
+                            if !isnothing(res) && !res.singular
                                 loop_tracked!(stats)
 
                                 # 1) check whether solutions already exists

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -976,7 +976,7 @@ function monodromy_solve(
     MonodromyResult(
         retcode,
         results,
-        eachindex(results),
+        1:length(results),
         p,
         MS.loops,
         MS.statistics,

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -940,7 +940,9 @@ function monodromy_solve(
     end
     reset_trace!(MS)
     reset_loops!(MS)
-    results = check_start_solutions(MS, X, p)
+    results =
+        MS.options.check_startsolutions ? check_start_solutions(MS, X, p) :
+        initialize_start_solutions(MS, X)
     if isempty(results)
         if warning
             @warn "None of the provided solutions is a valid start solution (Newton's method did not converge)."
@@ -1004,6 +1006,36 @@ function check_start_solutions(MS::MonodromySolver, X, p)
         end
     end
 
+    results
+end
+
+function initialize_start_solutions(MS::MonodromySolver, X)
+    results = PathResult[]
+    for (i, x) in enumerate(X)
+        p = convert(Vector{ComplexF64}, x)
+        res = PathResult(
+            return_code = :success,
+            solution = p,
+            t = 1.0,
+            accuracy = eps(),
+            residual = NaN,
+            singular = false,
+            condition_jacobian = NaN,
+            winding_number = nothing,
+            extended_precision = false,
+            path_number = nothing,
+            start_solution = x,
+            last_path_point = (p, 1.0),
+            valuation = nothing,
+            ω = 1.0,
+            μ = eps(),
+            accepted_steps = 0,
+            rejected_steps = 0,
+            extended_precision_used = false,
+        )
+        add!(MS, res, i)
+        push!(results, res)
+    end
     results
 end
 

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -229,7 +229,7 @@ also stored separately and returned by [`solutions`](@ref) and [`nsolutions`](@r
 struct MonodromyResult{P,LP}
     returncode::Symbol
     results::Vector{PathResult}
-    indexed_solution_indices::Vector{Int}
+    indexed_solution_indices::UnitRange{Int}
     parameters::P
     loops::Vector{MonodromyLoop{LP}}
     statistics::MonodromyStatistics
@@ -976,7 +976,7 @@ function monodromy_solve(
     MonodromyResult(
         retcode,
         results,
-        collect(eachindex(results)),
+        eachindex(results),
         p,
         MS.loops,
         MS.statistics,

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -1048,8 +1048,10 @@ function find_existing_point(MS::MonodromySolver, res::PathResult)
     search_in_radius(MS.unique_points, solution(res), rad)
 end
 
-function validate_new_result(MS::MonodromySolver, res::PathResult, tid::Int = 1)
-    validated_res = track(MS.trackers[tid], solution(res))
+function validate_new_result(MS::MonodromySolver, res::PathResult, p, tid::Int = 1)
+    tracker = MS.trackers[tid]
+    parameters!(tracker, p, p)
+    validated_res = track(tracker, solution(res))
     if is_success(validated_res) && !validated_res.singular
         validated_res
     else
@@ -1057,7 +1059,7 @@ function validate_new_result(MS::MonodromySolver, res::PathResult, tid::Int = 1)
     end
 end
 
-function add_tracked_result!(MS::MonodromySolver, res::PathResult, id, tid::Int = 1)
+function add_tracked_result!(MS::MonodromySolver, res::PathResult, id, p, tid::Int = 1)
     if duplicate_check_is_certified(MS)
         added_id, got_added = add!(MS, res, id, tid)
         return added_id, got_added, res
@@ -1068,7 +1070,7 @@ function add_tracked_result!(MS::MonodromySolver, res::PathResult, id, tid::Int 
         return (existing_id, false, res)
     end
 
-    validated_res = validate_new_result(MS, res, tid)
+    validated_res = validate_new_result(MS, res, p, tid)
     if isnothing(validated_res)
         return (0, false, res)
     end
@@ -1182,7 +1184,7 @@ function serial_monodromy_solve!(
 
                 # 1) check whether solution already exists. In heuristic mode, validate
                 # genuinely new endpoints before later monodromy calls can use them as starts.
-                id, got_added, res = add_tracked_result!(MS, res, length(results) + 1)
+                id, got_added, res = add_tracked_result!(MS, res, length(results) + 1, p)
 
                 if MS.options.permutations
                     add_permutation!(stats, job.loop_id, job.id, id)
@@ -1330,6 +1332,7 @@ function threaded_monodromy_solve!(
                                         MS,
                                         res,
                                         length(results) + 1,
+                                        p,
                                         tid,
                                     )
 

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -1039,6 +1039,44 @@ function initialize_start_solutions(MS::MonodromySolver, X)
     results
 end
 
+function find_existing_point(MS::MonodromySolver, res::PathResult)
+    atol, rtol = monodromy_add_tolerances(MS, res)
+    rad = max(
+        atol,
+        rtol * MS.unique_points.tree.distance(solution(res), MS.unique_points.zero_vec),
+    )
+    search_in_radius(MS.unique_points, solution(res), rad)
+end
+
+function validate_new_result(MS::MonodromySolver, res::PathResult, tid::Int = 1)
+    validated_res = track(MS.trackers[tid], solution(res))
+    if is_success(validated_res) && !validated_res.singular
+        validated_res
+    else
+        nothing
+    end
+end
+
+function add_tracked_result!(MS::MonodromySolver, res::PathResult, id, tid::Int = 1)
+    if duplicate_check_is_certified(MS)
+        added_id, got_added = add!(MS, res, id, tid)
+        return added_id, got_added, res
+    end
+
+    existing_id = find_existing_point(MS, res)
+    if !isnothing(existing_id)
+        return (existing_id, false, res)
+    end
+
+    validated_res = validate_new_result(MS, res, tid)
+    if isnothing(validated_res)
+        return (0, false, res)
+    end
+
+    added_id, got_added = add!(MS, validated_res, id, tid)
+    added_id, got_added, validated_res
+end
+
 function add!(MS::MonodromySolver, res::PathResult, id, tid::Int = 1)
     atol, rtol = monodromy_add_tolerances(MS, res)
     if !duplicate_check_is_certified(MS)
@@ -1142,8 +1180,9 @@ function serial_monodromy_solve!(
             if !isnothing(res) && !res.singular
                 loop_tracked!(stats)
 
-                # 1) check whether solutions already exists
-                id, got_added = add!(MS, res, length(results) + 1)
+                # 1) check whether solution already exists. In heuristic mode, validate
+                # genuinely new endpoints before later monodromy calls can use them as starts.
+                id, got_added, res = add_tracked_result!(MS, res, length(results) + 1)
 
                 if MS.options.permutations
                     add_permutation!(stats, job.loop_id, job.id, id)
@@ -1282,11 +1321,17 @@ function threaded_monodromy_solve!(
                             if !isnothing(res) && !res.singular
                                 loop_tracked!(stats)
 
-                                # 1) check whether solutions already exists
+                                # 1) check whether solution already exists. In heuristic mode,
+                                # validate genuinely new endpoints before insertion.
                                 lock(data_lock)
                                 if length(results) <
                                    something(MS.options.target_solutions_count, Inf)
-                                    id, got_added = add!(MS, res, length(results) + 1, tid)
+                                    id, got_added, res = add_tracked_result!(
+                                        MS,
+                                        res,
+                                        length(results) + 1,
+                                        tid,
+                                    )
 
                                     if MS.options.permutations
                                         add_permutation!(stats, job.loop_id, job.id, id)

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -229,6 +229,7 @@ also stored separately and returned by [`solutions`](@ref) and [`nsolutions`](@r
 struct MonodromyResult{P,LP}
     returncode::Symbol
     results::Vector{PathResult}
+    indexed_solution_indices::Vector{Int}
     parameters::P
     loops::Vector{MonodromyLoop{LP}}
     statistics::MonodromyStatistics
@@ -294,7 +295,8 @@ function TreeViews.nodelabel(
 end
 function TreeViews.treenode(r::MonodromyResult, i::Integer)
     if i == 1
-        return isnothing(r.certified_solutions) ? r.results : r.certified_solutions
+        return isnothing(r.certified_solutions) ? indexed_solutions(r) :
+               r.certified_solutions
     elseif i == 2
         return r.returncode
     elseif i == 3
@@ -354,7 +356,9 @@ solutions(r::MonodromyResult) =
 
 Return the solutions in the index order used by [`permutations`](@ref).
 """
-indexed_solutions(r::MonodromyResult) = solution.(results(r))
+indexed_solutions(r::MonodromyResult) =
+    map(i -> solution(r.results[i]), r.indexed_solution_indices)
+nindexed_solutions(r::MonodromyResult) = length(r.indexed_solution_indices)
 
 """
     nsolutions(result::MonodromyResult)
@@ -972,6 +976,7 @@ function monodromy_solve(
     MonodromyResult(
         retcode,
         results,
+        collect(eachindex(results)),
         p,
         MS.loops,
         MS.statistics,

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -1011,7 +1011,7 @@ end
 
 function initialize_start_solutions(MS::MonodromySolver, X)
     results = PathResult[]
-    for (i, x) in enumerate(X)
+    for x in X
         p = convert(Vector{ComplexF64}, x)
         res = PathResult(
             return_code = :success,
@@ -1033,8 +1033,10 @@ function initialize_start_solutions(MS::MonodromySolver, X)
             rejected_steps = 0,
             extended_precision_used = false,
         )
-        add!(MS, res, i)
-        push!(results, res)
+        _, added = add!(MS, res, length(results) + 1)
+        if added
+            push!(results, res)
+        end
     end
     results
 end

--- a/src/monodromy.jl
+++ b/src/monodromy.jl
@@ -703,6 +703,7 @@ function monodromy_solve(
     seed = rand(UInt32),
     tracker_options = TrackerOptions(),
     show_progress::Bool = true,
+    progress = nothing,
     threading::Bool = Threads.nthreads() > 1,
     compile::Union{Bool,Symbol} = COMPILE_DEFAULT[],
     catch_interrupt::Bool = true,
@@ -778,6 +779,7 @@ function monodromy_solve(
         p,
         seed;
         show_progress = show_progress,
+        progress = progress,
         threading = threading,
         catch_interrupt = catch_interrupt,
         warning = warning,
@@ -898,13 +900,12 @@ function monodromy_solve(
     p,
     seed;
     show_progress::Bool = true,
+    progress = nothing,
     threading::Bool = Threads.nthreads() > 1,
     catch_interrupt::Bool = true,
     warning::Bool = true,
 )
-    if !show_progress
-        progress = nothing
-    else
+    if isnothing(progress) && show_progress
         if MS.options.equivalence_classes
             desc = "Solutions (modulo group action) found:"
         else

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -334,7 +334,6 @@ function _regeneration(
         sing_cond = 1e12,
     ),
     monodromy_options::MonodromyOptions = MonodromyOptions(;
-        trace_test = true,
         parameter_sampler = weighted_normal,
     ),
     show_monodromy_progress::Bool = false,
@@ -1443,7 +1442,6 @@ function decompose(
     show_progress::Bool = true,
     show_monodromy_progress::Bool = false,
     monodromy_options::MonodromyOptions = MonodromyOptions(;
-        trace_test_tol = 1e-10,
         parameter_sampler = weighted_normal,
     ),
     max_iters::Int = 50,
@@ -1783,11 +1781,10 @@ function numerical_irreducible_decomposition(
         sing_accuracy = 1e-10,
     ),
     monodromy_options_for_regeneration = MonodromyOptions(;
-        trace_test = true,
         parameter_sampler = weighted_normal,
     ),
     monodromy_options_for_decompose::MonodromyOptions = MonodromyOptions(;
-        trace_test_tol = 1e-10,
+        parameter_sampler = weighted_normal,
     ),
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
@@ -2075,7 +2072,6 @@ function _intersect(
         sing_cond = 1e12,
     ),
     monodromy_options::MonodromyOptions = MonodromyOptions(;
-        trace_test = true,
         parameter_sampler = weighted_normal,
     ),
     show_monodromy_progress::Bool = false,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1105,7 +1105,7 @@ function decompose_with_monodromy!(
         initial_points = check_start_solutions(MS, P, L)
         res = monodromy_solve(
             MS,
-            initial_points,
+            solution.(initial_points),
             L,
             seed;
             threading = threading,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -645,13 +645,16 @@ function intersect_with_hypersurface!(
     # Step 2:
     # the points in P_next are used as starting points for a homotopy.
     # where u^d-1 (u is the extra variable in u-regeneration) is deformed into g 
-    Hom, d = set_up_u_homotopy(W, f, X, H, h, vars, u)
+    Hom, d = set_up_u_homotopy(W, f, X, h, vars, u)
 
-    tracker = EndgameTracker(
-        Hom;
-        tracker_options = cache.tracker_options,
-        options = cache.endgame_options,
-    )
+    trackers = map(Hom) do H
+        EndgameTracker(
+            H;
+            tracker_options = cache.tracker_options,
+            options = cache.endgame_options,
+        )
+    end
+    
 
     # the start solutions are the Cartesian product between P_next and the d-th roots of unity.
     roots = [exp(2 * pi * im * k / d) for k = 0:(d-1)]
@@ -664,9 +667,9 @@ function intersect_with_hypersurface!(
         is_monodromy = false,
     )
     if threading
-        threaded_intersection!(X, P_next, roots, tracker, progress)
+        threaded_intersection!(X, P_next, roots, trackers, progress)
     else
-        serial_intersection!(X, P_next, roots, tracker, progress)
+        serial_intersection!(X, P_next, roots, trackers, progress)
     end
     nothing
 end
@@ -677,7 +680,27 @@ function manage_initial_points!(P, m)
     return P_next
 end
 
-function serial_intersection!(X, P, roots, egtracker, progress)
+function track_intersection_path(egtrackers, p)
+    # Stage 1: L -> random linear space L1
+    res1 = track(egtrackers[1], p, 1)
+    is_success(res1) && is_finite(res1) && is_nonsingular(res1) || return nothing
+
+    # Stage 2: replace u^d - 1 by hypersurface equation
+    p1 = solution(egtrackers[1])
+    res2 = track(egtrackers[2], p1, 1)
+    is_success(res2) && is_finite(res2) && is_nonsingular(res2) || return nothing
+
+    # Stage 3: L1 -> {u = c}
+    p2 = solution(egtrackers[2])
+    res3 = track(egtrackers[3], p2, 1)
+    is_success(res3) && is_finite(res3) && is_nonsingular(res3) || return nothing
+
+    q = copy(solution(egtrackers[3]))
+
+    q
+end
+
+function serial_intersection!(X, P, roots, egtrackers, progress)
     start = Iterators.product(P, roots)
     l_start = length(P) * length(roots)
 
@@ -687,24 +710,16 @@ function serial_intersection!(X, P, roots, egtracker, progress)
         p = s[1]
         p[end] = s[2] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
 
-        res = track(egtracker, p, 1)
-        if is_success(res) && is_finite(res) && is_nonsingular(res)
-            q = copy(egtracker.state.solution)
-            # we only want nonsingular solutions q
-            # an additional check is whether q can be tracked the reverse homotopy from 0 to 1
-            # it's enough to go from t = 0 to t = 0.1, since singularities can only be expected at t = 0.
-            tracker = egtracker.tracker
-            track!(tracker, q, 0.0, 0.1)
-            if is_success(status(tracker))
-                push!(X, q)
-            end
+        q = track_intersection_path(egtrackers, p)
+        if !isnothing(q)
+            push!(X, q)
         end
     end
 
     nothing
 end
 
-function threaded_intersection!(X, P, roots, tracker, progress)
+function threaded_intersection!(X, P, roots, trackers, progress)
 
     l_P = length(P)
     l_roots = length(roots)
@@ -712,7 +727,7 @@ function threaded_intersection!(X, P, roots, tracker, progress)
 
     # Pre-allocate one tracker per thread
     nthr = Threads.nthreads()
-    trackers = [deepcopy(tracker) for _ = 1:nthr]
+    trackers_per_thread = [deepcopy(trackers) for _ = 1:nthr]
 
     # Use a lock for thread-safe operations on X and progress
     progress_lock = ReentrantLock()
@@ -720,7 +735,7 @@ function threaded_intersection!(X, P, roots, tracker, progress)
     next_idx = Threads.Atomic{Int}(1)
     Threads.@sync begin
         for tid = 1:nthr
-            let local_egtracker = trackers[tid]
+            let local_egtrackers = trackers_per_thread[tid]
                 Threads.@spawn begin
                     while true
 
@@ -738,19 +753,10 @@ function threaded_intersection!(X, P, roots, tracker, progress)
                         p = copy(P[p_idx])
                         p[end] = roots[r_idx] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
 
-                        res = track(local_egtracker, p, 1)
-
-                        if is_success(res) && is_finite(res) && is_nonsingular(res)
-                            q = copy(local_egtracker.state.solution)
-                            # we only want nonsingular solutions q
-                            # an additional check is whether q can be tracked the reverse homotopy from 0 to 1
-                            # it's enough to go from t = 0 to t = 0.1, since singularities can only be expected at t = 0.
-                            local_tracker = local_egtracker.tracker
-                            track!(local_tracker, q, 0.0, 0.1)
-                            if is_success(status(local_tracker))
-                                lock(progress_lock) do
-                                    push!(X, q)
-                                end
+                        q = track_intersection_path(local_egtrackers, p)
+                        if !isnothing(q)
+                            lock(progress_lock) do
+                                push!(X, q)
                             end
                         end
                     end
@@ -762,22 +768,26 @@ function threaded_intersection!(X, P, roots, tracker, progress)
     nothing
 end
 
-function set_up_u_homotopy(W, f, X, H, h, vars, u)
+function set_up_u_homotopy(W, f, X, h, vars, u)
 
     P, Q = get_num_den(h)
     d = degree(P)
     h0 = (u^d - 1) / Q
 
     # we start with the linear space L which does not use pose conditions on u, so that u^d=1
-    # we end with the linear space K with u=c.
+    # we end with the linear space L2 with u=c.
     L = linear_subspace_u(W)
-    K = linear_subspace(X)
+    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
+    L2 = linear_subspace(X)
 
-    F₀ = slice(System([f; h0], variables = vars), L; compile = false)
-    G₀ = slice(System([f; h], variables = vars), K; compile = false)
-    Hom = StraightLineHomotopy(F₀, G₀; gamma = cis(2 * pi * rand()))
+    F = fixed(System([f; h0], variables = vars); compile = false)
+    G = fixed(System([f; h], variables = vars); compile = false)
 
-    return Hom, d
+    Hom1 = linear_subspace_homotopy(F, L, L1)
+    Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
+    Hom3 = linear_subspace_homotopy(G, L1, L2)
+    
+    return (Hom1, Hom2, Hom3), d
 end
 
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1112,14 +1112,14 @@ function decompose_with_monodromy!(
             progress = show_monodromy_progress ? nothing : progress,
         )
         update_progress!(progress; is_monodromy = false)
-        update_progress_npts!(progress, nsolutions(res))
+        update_progress_npts!(progress, length(indexed_solutions(res)))
 
         if warning && (trace(res) > options.trace_test_tol)
             @warn "Trying to decompose non-complete set of witness points for codimension $(dim(L)) (trace test failed). Will try to compute the missing points. The output will contain all components, for which the trace test was successfull."
         end
 
         iter = 0
-        non_complete_points = solutions(res)
+        non_complete_points = indexed_solutions(res)
         d = length(non_complete_points) # the total degree (i.e., number of points on all irreducible components)
         non_complete_orbits = Vector{Set{Int}}()
 
@@ -1144,8 +1144,9 @@ function decompose_with_monodromy!(
                 update_progress!(progress; is_monodromy = false)
             end
 
-            d += nresults(res) - length(non_complete_points) # update total degree in case we found new points.
-            non_complete_points = solutions(res)
+            updated_points = indexed_solutions(res)
+            d += length(updated_points) - length(non_complete_points) # update total degree in case we found new points.
+            non_complete_points = updated_points
             ℓ = length(non_complete_points) # once for a later check
             k = length(non_complete_points) # and once for counting progress
             update_progress_npts!(progress, k)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1026,7 +1026,7 @@ function showstatus(progress::DecomposeProgress)
                 text,
                 (
                     "Status",
-                    "running monodromy ($(progress.monodromy_tracked_loops) loops tracked ($(progress.monodromy_generated_loops) generated, $(progress.monodromy_no_change) no change)",
+                    "running monodromy ($(progress.monodromy_tracked_loops) loops tracked, $(progress.monodromy_generated_loops) generated, $(progress.monodromy_no_change) no change)",
                 ),
             )
         else

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -705,7 +705,7 @@ function intersect_with_hypersurface!(
             options = cache.endgame_options,
         )
     end
-    
+
 
     # the start solutions are the Cartesian product between P_next and the d-th roots of unity.
     roots = [exp(2 * pi * im * k / d) for k = 0:(d-1)]
@@ -837,7 +837,7 @@ function set_up_u_homotopy(W, f, X, h, vars, u)
     Hom1 = linear_subspace_homotopy(F, L, L1)
     Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
     Hom3 = linear_subspace_homotopy(G, L1, L2)
-    
+
     return (Hom1, Hom2, Hom3), d
 end
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1023,13 +1023,17 @@ function showstatus(progress::DecomposeProgress)
     end
     if !progress.is_finished
         if progress.is_monodromy
-            push!(
-                text,
-                (
-                    "Status",
-                    "running monodromy ($(progress.monodromy_solutions) solutions, $(progress.monodromy_generated_loops) loops generated, $(progress.monodromy_no_change) no change)",
-                ),
-            )
+            if progress.monodromy_solutions > 0
+                push!(
+                    text,
+                    (
+                        "Status",
+                        "running monodromy ($(progress.monodromy_solutions) solutions, $(progress.monodromy_generated_loops) loops generated, $(progress.monodromy_no_change) no change)",
+                    ),
+                )
+            else
+                push!(text, ("Status", "running monodromy"))
+            end
         else
             push!(text, ("Status", "partitioning points"))
         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1407,7 +1407,7 @@ function decompose_with_monodromy_options(M::MonodromyOptions)
         permutations = true,
         trace_test = true,
         single_loop_per_start_solution = true,
-        check_startsolutions = M.check_startsolutions,
+        check_startsolutions = false,
         group_actions = M.group_actions,
         loop_finished_callback = M.loop_finished_callback,
         parameter_sampler = M.parameter_sampler,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -55,6 +55,10 @@ Base.@kwdef mutable struct WitnessSetsProgress
     ntasks::Int = 0
     current_hypersurface::Int = 1
     nhypersurfaces::Int
+    monodromy_codim::Int = 0
+    monodromy_solutions::Int = 0
+    monodromy_tracked_loops::Int = 0
+    monodromy_no_change::Int = 0
 end
 WitnessSetsProgress(n::Int, nhypersurfaces::Int, progress_meter::PM.ProgressUnknown) =
     WitnessSetsProgress(
@@ -86,6 +90,45 @@ function update_progress!(
         progress.progress_meter,
         progress.current_hypersurface,
         showvalues = showvalues(progress);
+    )
+end
+function update_progress!(
+    progress::WitnessSetsProgress,
+    stats::MonodromyStatistics;
+    queued::Int,
+    solutions::Int,
+    finish::Bool = false,
+)
+    progress.monodromy_solutions = solutions
+    progress.monodromy_tracked_loops = stats.tracked_loops[]
+    progress.monodromy_no_change = loops_no_change(stats, solutions)
+
+    if finish
+        PM.update!(
+            progress.progress_meter,
+            progress.current_hypersurface,
+            showvalues = showvalues(progress),
+        )
+    elseif time() > progress.progress_meter.tlast + progress.progress_meter.dt
+        PM.update!(
+            progress.progress_meter,
+            progress.current_hypersurface,
+            showvalues = showvalues(progress),
+        )
+    end
+
+    nothing
+end
+update_progress_monodromy_witness!(progress::Nothing, W) = nothing
+function update_progress_monodromy_witness!(progress::WitnessSetsProgress, W)
+    progress.monodromy_codim = codim(W)
+    progress.monodromy_solutions = degree(W)
+    progress.monodromy_tracked_loops = 0
+    progress.monodromy_no_change = 0
+    PM.update!(
+        progress.progress_meter,
+        progress.current_hypersurface,
+        showvalues = showvalues(progress),
     )
 end
 update_progress_hypersurface!(progress::Nothing, i::Int) = nothing
@@ -159,8 +202,8 @@ function showvalues(progress::WitnessSetsProgress)
                 push!(
                     text,
                     (
-                        "Track paths",
-                        "$(progress.current_path) / $(progress.npaths) (fill up points...)",
+                        "Fill up points",
+                        "$(progress.monodromy_tracked_loops) loops tracked, $(progress.monodromy_no_change) no change",
                     ),
                 )
             elseif progress.is_membership_test
@@ -178,6 +221,9 @@ function showvalues(progress::WitnessSetsProgress)
     for c = 1:progress.current_hypersurface
         d = progress.ambient_dim - c
         deg = get(progress.degrees, c, nothing)
+        if progress.is_monodromy && c == progress.monodromy_codim
+            deg = progress.monodromy_solutions
+        end
         if !isnothing(deg) && deg > 0
             push!(text, ("Dimension $d", "$(deg)"))
         end
@@ -561,12 +607,14 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
     )
     for W in out
         if !isnothing(W) && dim(W) > 0 && degree(W) > 0
+            update_progress_monodromy_witness!(progress, W)
             res = monodromy_solve(
                 Fᵢ,
                 W.R,
                 linear_subspace(W);
                 options = regeneration_monodromy_options(monodromy_options, W),
                 show_progress = show_monodromy_progress,
+                progress = show_monodromy_progress ? nothing : progress,
                 threading = threading,
                 warning = false,
             )

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1173,7 +1173,7 @@ function decompose_with_monodromy!(
                 if trace(res_orbit) < options.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
-                    if length(orbit) > 1 || iter ≥ 5
+                    if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
                         W_new = WitnessSet(G, L, P_orbit; is_irreducible = true)
 
                         push!(decomposition, W_new)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1885,6 +1885,10 @@ Base.@kwdef mutable struct IntersectProgress
     ntasks::Int = 0
     current_path::Int = 0
     npaths::Int = 0
+    monodromy_solutions::Int = 0
+    monodromy_tracked_loops::Int = 0
+    monodromy_generated_loops::Int = 0
+    monodromy_no_change::Int = 0
 end
 IntersectProgress(progress_meter::PM.ProgressUnknown) =
     IntersectProgress(progress_meter = progress_meter)
@@ -1898,9 +1902,42 @@ function update_progress!(
     isnothing(is_membership_test) ? nothing :
     progress.is_membership_test = is_membership_test
     isnothing(is_monodromy) ? nothing : progress.is_monodromy = is_monodromy
+    if is_monodromy === true
+        progress.monodromy_solutions = 0
+        progress.monodromy_tracked_loops = 0
+        progress.monodromy_generated_loops = 0
+        progress.monodromy_no_change = 0
+    end
     PM.update!(progress.progress_meter, showvalues = showvalues(progress))
 end
+function update_progress!(
+    progress::IntersectProgress,
+    stats::MonodromyStatistics;
+    queued::Int,
+    solutions::Int,
+    finish::Bool = false,
+)
+    progress.monodromy_solutions = solutions
+    progress.monodromy_tracked_loops = stats.tracked_loops[]
+    progress.monodromy_generated_loops = stats.generated_loops[]
+    progress.monodromy_no_change = loops_no_change(stats, solutions)
+
+    if finish
+        PM.update!(progress.progress_meter, showvalues = showvalues(progress))
+    elseif time() > progress.progress_meter.tlast + progress.progress_meter.dt
+        PM.update!(progress.progress_meter, showvalues = showvalues(progress))
+    end
+
+    nothing
+end
 update_progress!(progress::IntersectProgress, W) = nothing
+function update_progress_monodromy_witness!(progress::IntersectProgress, W)
+    progress.monodromy_solutions = degree(W)
+    progress.monodromy_tracked_loops = 0
+    progress.monodromy_generated_loops = 0
+    progress.monodromy_no_change = 0
+    PM.update!(progress.progress_meter, showvalues = showvalues(progress))
+end
 function update_progress_tasks!(progress::IntersectProgress, i::Int, m::Int)
     progress.current_task = i
     progress.ntasks = m
@@ -1928,8 +1965,8 @@ function showvalues(progress::IntersectProgress)
             push!(
                 text,
                 (
-                    "Track paths",
-                    "$(progress.ntasks) / $(progress.ntasks) (fill up points...)",
+                    "Fill up points",
+                    "$(progress.monodromy_solutions) solutions, $(progress.monodromy_tracked_loops) loops tracked ($(progress.monodromy_generated_loops) generated, $(progress.monodromy_no_change) no change)",
                 ),
             )
         elseif progress.is_membership_test

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1469,7 +1469,7 @@ This function decomposes a [`WitnessSet`](@ref) or a vector of [`WitnessSet`](@r
 * `show_progress = true`: indicate whether a progress bar should be displayed.
 * `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `decompose`.
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
-* `max_iters = 20`: maximal number of iterations for the decomposition step.
+* `max_iters = 50`: maximal number of iterations for the decomposition step.
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -1511,7 +1511,7 @@ function decompose(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
-    max_iters::Int = 20,
+    max_iters::Int = 50,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -1791,7 +1791,7 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 * `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of each substep.
 * `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed. 
 * `show_monodromy_for_decompose_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`decompose`](@ref) should be displayed.
-* `max_iters = 20`: maximal number of iterations for the decomposition step.
+* `max_iters = 50`: maximal number of iterations for the decomposition step.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).` This option is used for [`regeneration`](@ref).
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
@@ -1859,7 +1859,7 @@ function numerical_irreducible_decomposition(
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
-    max_iters::Int = 20,
+    max_iters::Int = 50,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
     warning::Bool = true,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -248,7 +248,7 @@ The implementation is based on the algorithm [u-regeneration](https://arxiv.org/
 
 ### Options
 
-* `sorted = true`: if `true`, the polynomials in F will be sorted by degree in decreasing order. 
+* `sorted = true`: if `true`, the polynomials in F will be sorted by degree in increasing order. 
 * `max_codim`: the maximal codimension until which witness supersets should be computed.
 * `show_progress = true`: indicate whether a progress bar should be displayed.
 * `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed.
@@ -346,7 +346,7 @@ function _regeneration(
 
     # sort expressions by degree
     if sorted
-        σ = sortperm(H, by = ModelKit.degree, rev = true)
+        σ = sortperm(H, by = ModelKit.degree)
         f = expressions(F)[σ]
         H = H[σ]
     else
@@ -1606,7 +1606,7 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 ### Options
 
 * `show_progress = true`: indicate whether a progress bar should be displayed.
-* `sorted = true`: the polynomials in F will be sorted by degree in decreasing order. 
+* `sorted = true`: the polynomials in F will be sorted by degree in increasing order. 
 * `max_codim`: the maximal codimension until which witness supersets should be computed.
 * `endgame_options`: [`EndgameOptions`](@ref) for the [`EndgameTracker`](@ref).
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1112,7 +1112,7 @@ function decompose_with_monodromy!(
             progress = show_monodromy_progress ? nothing : progress,
         )
         update_progress!(progress; is_monodromy = false)
-        update_progress_npts!(progress, length(indexed_solutions(res)))
+        update_progress_npts!(progress, nindexed_solutions(res))
 
         if warning && (trace(res) > options.trace_test_tol)
             @warn "Trying to decompose non-complete set of witness points for codimension $(dim(L)) (trace test failed). Will try to compute the missing points. The output will contain all components, for which the trace test was successfull."

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1859,7 +1859,7 @@ function numerical_irreducible_decomposition(
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
-    max_iters::Int = 50,
+    max_iters::Int = 20,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
     warning::Bool = true,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -300,7 +300,7 @@ The implementation is based on the algorithm [u-regeneration](https://arxiv.org/
 * `sorted = true`: if `true`, the polynomials in F will be sorted by degree in increasing order. 
 * `max_codim`: the maximal codimension until which witness supersets should be computed.
 * `show_progress = true`: indicate whether a progress bar should be displayed.
-* `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed.
+* `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `regeneration`.
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).
 * `endgame_options`: [`EndgameOptions`](@ref) for the [`EndgameTracker`](@ref).
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
@@ -1399,7 +1399,7 @@ This function decomposes a [`WitnessSet`](@ref) or a vector of [`WitnessSet`](@r
 
 ### Options
 * `show_progress = true`: indicate whether a progress bar should be displayed.
-* `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed.
+* `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `decompose`.
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
 * `max_iters = 50`: maximal number of iterations for the decomposition step.
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
@@ -1718,8 +1718,8 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).
 * `monodromy_options_for_regeneration`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref) in [`regeneration`](@ref).
 * `monodromy_options_for_decompose`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref) in [`decompose`](@ref).
-* `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`.
-* `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed.
+* `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of each substep.
+* `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed. 
 * `show_monodromy_for_decompose_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`decompose`](@ref) should be displayed.
 * `max_iters = 50`: maximal number of iterations for the decomposition step.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).` This option is used for [`regeneration`](@ref).
@@ -1986,7 +1986,7 @@ This intersects the witness sets `W` and `H`, where `H` is a hypersurface define
 ### Options
 
 * `show_progress = true`: indicate whether a progress bar should be displayed.
-* `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed.
+* `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `intersect`.
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).
 * `endgame_options`: [`EndgameOptions`](@ref) for the [`EndgameTracker`](@ref).
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1122,6 +1122,7 @@ function decompose_with_monodromy!(
         non_complete_points = indexed_solutions(res)
         d = length(non_complete_points) # the total degree (i.e., number of points on all irreducible components)
         non_complete_orbits = Vector{Set{Int}}()
+        trace_certified_all = false
 
         while !isempty(non_complete_points)
             iter += 1
@@ -1193,6 +1194,7 @@ function decompose_with_monodromy!(
 
             # Check if we are done
             if sum(degree, decomposition; init = 0) == d
+                trace_certified_all = true
                 update_progress_step!(progress)
                 break
             end
@@ -1254,6 +1256,34 @@ function decompose_with_monodromy!(
                     ),
                 )
         end
+
+        if !trace_certified_all && !isempty(non_complete_points)
+            covered_indices = Set{Int}()
+            for orbit in non_complete_orbits
+                union!(covered_indices, orbit)
+            end
+
+            orbits_to_return = copy(non_complete_orbits)
+            for i in eachindex(non_complete_points)
+                if !(i in covered_indices)
+                    push!(orbits_to_return, Set([i]))
+                end
+            end
+
+            for orbit in orbits_to_return
+                isempty(orbit) && continue
+                P_orbit = non_complete_points[sort!(collect(orbit))]
+                W_new = WitnessSet(G, L, P_orbit; is_irreducible = nothing)
+
+                push!(decomposition, W_new)
+                update_progress!(progress, W_new)
+            end
+
+            if warning
+                @warn "Some witness sets could not be certified by the trace test and are returned with is_irreducible = nothing. They will not be displayed in a numerical irreducible decomposition."
+            end
+        end
+
         update_progress_step!(progress)
         update_progress_npts!(progress, 0)
     else
@@ -1523,7 +1553,7 @@ decompose(W::WitnessSet; kwargs...) = decompose([W]; kwargs...)
 Store the witness sets in a common data structure.
 """
 struct NumericalIrreducibleDecomposition{T<:WitnessSet}
-    Witness_Sets::Dict{Int,Vector{T}}
+    witness_sets::Dict{Int,Vector{T}}
     seed::Union{Nothing,UInt32}
 end
 NumericalIrreducibleDecomposition(Ws::Vector{T}) where {T<:WitnessSet} =
@@ -1532,14 +1562,15 @@ function NumericalIrreducibleDecomposition(Ws::Vector{T}, seed) where {T<:Witnes
     D = Dict{Int,Vector{T}}()
     for W in Ws
         k = dim(W)
-        push!(get!(D, k, WitnessSet[]), W)
+        push!(get!(D, k, T[]), W)
     end
     NumericalIrreducibleDecomposition(D, seed)
 end
 
 """
     witness_sets(N::NumericalIrreducibleDecomposition;
-        dims::Union{Vector{Int},Nothing} = nothing)
+                dims::Union{Vector{Int},Nothing} = nothing,
+                only_irreducible::Bool = true)
 
 Returns the witness sets in `N`. 
 `dims` specifies the dimensions that should be considered.
@@ -1547,15 +1578,17 @@ Returns the witness sets in `N`.
 function witness_sets(
     N::NumericalIrreducibleDecomposition{T};
     dims::Union{Vector{Int},Nothing} = nothing,
+    only_irreducible::Bool = true,
 ) where {T}
-    D = N.Witness_Sets
-    if isnothing(dims)
-        out = D
-    else
-        out = Dict{Int,Vector{T}}()
-        for k in dims
-            if haskey(D, k)
-                out[k] = D[k]
+    W = N.witness_sets
+    out = Dict{Int,Vector{T}}()
+    selected_dims = isnothing(dims) ? keys(W) : dims
+
+    for k in selected_dims
+        if haskey(W, k)
+            Ws = only_irreducible ? filter(_is_irreducible, W[k]) : W[k]
+            if !isempty(Ws)
+                out[k] = Ws
             end
         end
     end
@@ -1568,7 +1601,8 @@ seed(N::NumericalIrreducibleDecomposition{T}) where {T} = N.seed
 
 """
     ncomponents(N::NumericalIrreducibleDecomposition;
-        dims::Union{Vector{Int},Nothing} = nothing)
+                dims::Union{Vector{Int},Nothing} = nothing,
+                only_irreducible::Bool = true)
 
 Returns the total number of components in `N`. 
 `dims` specifies the dimensions that should be considered.
@@ -1576,32 +1610,27 @@ Returns the total number of components in `N`.
 function ncomponents(
     N::NumericalIrreducibleDecomposition{T};
     dims::Union{Vector{Int},Nothing} = nothing,
+    only_irreducible::Bool = true,
 ) where {T}
-    D = witness_sets(N)
+    D = witness_sets(N; dims = dims, only_irreducible = only_irreducible)
     if isempty(D)
         return 0
-    elseif isnothing(dims)
-        out = sum(length(last(Ws)) for Ws in D)
     else
-        out = 0
-        for d in dims
-            if haskey(D, d)
-                out += length(D[d])
-            end
-        end
+        return sum(length(last(Ws)) for Ws in D)
     end
-
-    out
 end
 ncomponents(N::NumericalIrreducibleDecomposition{T}, dim::Int) where {T} =
     ncomponents(N; dims = [dim])
-n_components(N; dims = nothing) = ncomponents(N; dims = dims)
-n_components(N, dim) = ncomponents(N; dims = [dim])
+n_components(N; dims = nothing, only_irreducible::Bool = true) =
+    ncomponents(N; dims = dims, only_irreducible = only_irreducible)
+n_components(N, dim; only_irreducible::Bool = true) =
+    ncomponents(N; dims = [dim], only_irreducible = only_irreducible)
 
 """
 
     degrees(N::NumericalIrreducibleDecomposition;
-        dims::Union{Vector{Int},Nothing} = nothing)
+            dims::Union{Vector{Int},Nothing} = nothing,
+            only_irreducible::Bool = true)
 
 Returns the degrees of the components in `N`.
 `dims` specifies the dimensions that should be considered.
@@ -1610,22 +1639,12 @@ Returns the degrees of the components in `N`.
 function ModelKit.degrees(
     N::NumericalIrreducibleDecomposition{T};
     dims::Union{Vector{Int},Nothing} = nothing,
+    only_irreducible::Bool = true,
 ) where {T}
-    D = N.Witness_Sets
+    D = witness_sets(N; dims = dims, only_irreducible = only_irreducible)
     out = Dict{Int,Vector{Int}}()
-    if isnothing(dims)
-        for key in keys(D)
-            out[key] = degree.(D[key])
-        end
-    else
-        out = Dict{Int,Vector{Int}}()
-        if !isempty(dims)
-            for k in dims
-                if haskey(D, k)
-                    out[k] = degree.(D[k])
-                end
-            end
-        end
+    for key in keys(D)
+        out[key] = degree.(D[key])
     end
 
     out
@@ -1633,8 +1652,11 @@ end
 ModelKit.degrees(N::NumericalIrreducibleDecomposition{T}, dim::Int) where {T} =
     degrees(N; dims = [dim])
 
-function max_dim(N::NumericalIrreducibleDecomposition{T}) where {T}
-    D = witness_sets(N)
+function max_dim(
+    N::NumericalIrreducibleDecomposition{T};
+    only_irreducible::Bool = true,
+) where {T}
+    D = witness_sets(N; only_irreducible = only_irreducible)
     k = keys(D)
     if !isempty(k)
         maximum(k)
@@ -1645,20 +1667,16 @@ end
 
 function Base.show(io::IO, N::NumericalIrreducibleDecomposition{T}) where {T}
     D = witness_sets(N)
-    if !isempty(D)
-        total = sum(length(last(Ws)) for Ws in D)
-    else
-        total = 0
-    end
+    total = ncomponents(N)
     s = total == 1 ? "component" : "components"
     header = "Numerical irreducible decomposition with $total $s"
     println(io, header)
     println(io, "="^(length(header)))
     mdim = max_dim(N)
     if mdim >= 0
-        for d = max_dim(N):-1:0
+        for d = mdim:-1:0
             if haskey(D, d)
-                ℓ = length(D[d])
+                ℓ = count(_is_irreducible, D[d])
                 if ℓ > 0
                     println(io, "• $ℓ component(s) of dimension $d.")
                 end
@@ -1670,7 +1688,7 @@ function Base.show(io::IO, N::NumericalIrreducibleDecomposition{T}) where {T}
     end
 end
 function degree_table(io, N::NumericalIrreducibleDecomposition{T}) where {T}
-    D = witness_sets(N)
+    D = degrees(N)
     k = collect(keys(D))
     sort!(k, rev = true)
     n = length(k)
@@ -1680,7 +1698,7 @@ function degree_table(io, N::NumericalIrreducibleDecomposition{T}) where {T}
 
     for (i, key) in enumerate(k)
         data[i, 1] = key
-        components = [ModelKit.degree(W) for W in D[key]]
+        components = D[key]
         sort!(components, rev = true)
         if length(components) == 1
             data[i, 2] = first(components)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1102,9 +1102,10 @@ function decompose_with_monodromy!(
         update_progress!(progress; is_monodromy = true)
 
         MS = MonodromySolver(G, L; compile = false, options = options)
+        initial_points = check_start_solutions(MS, P, L)
         res = monodromy_solve(
             MS,
-            P,
+            initial_points,
             L,
             seed;
             threading = threading,
@@ -1180,11 +1181,24 @@ function decompose_with_monodromy!(
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
-                        W_new = WitnessSet(G, L, P_orbit; is_irreducible = true)
+                        P_certified = indexed_solutions(res_orbit)
+                        W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
+                        complete_orbit =
+                            length(P_certified) == length(orbit) ? orbit :
+                            Set(
+                                matching_indices(
+                                    non_complete_points,
+                                    P_certified;
+                                    norm = options.distance,
+                                    atol = something(options.unique_points_atol, 1e-14),
+                                    rtol = something(options.unique_points_rtol, 1e-8),
+                                ),
+                            )
 
                         push!(decomposition, W_new)
-                        push!(complete_orbits, orbit)
-                        k = k - length(orbit)
+                        push!(complete_orbits, complete_orbit)
+                        d += length(P_certified) - length(complete_orbit)
+                        k = k - length(complete_orbit)
 
                         update_progress!(progress, W_new)
                         update_progress_npts!(progress, k)
@@ -1357,6 +1371,24 @@ function merge_sets(sets)
         end
     end
     return collect(values(result))
+end
+
+# find indices of newly detected points
+function matching_indices(points, certified_points; norm, atol, rtol)
+    indices = Int[]
+    matched = falses(length(certified_points))
+    for (i, p) in pairs(points)
+        tol = max(atol, rtol * distance(p, zero(p), norm))
+        for (j, q) in pairs(certified_points)
+            matched[j] && continue
+            if distance(p, q, norm) ≤ tol
+                push!(indices, i)
+                matched[j] = true
+                break
+            end
+        end
+    end
+    indices
 end
 
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1610,11 +1610,13 @@ Returns the witness sets in `N`.
 function witness_sets(
     N::NumericalIrreducibleDecomposition{T};
     dims::Union{Vector{Int},Nothing} = nothing,
+    dim::Union{Int,Nothing} = nothing,
     only_irreducible::Bool = true,
 ) where {T}
     W = N.witness_sets
     out = Dict{Int,Vector{T}}()
-    selected_dims = isnothing(dims) ? keys(W) : dims
+    selected_dims = isnothing(dim) ? dims : [dim]
+    selected_dims = isnothing(selected_dims) ? keys(W) : selected_dims
 
     for k in selected_dims
         if haskey(W, k)
@@ -1627,8 +1629,11 @@ function witness_sets(
 
     out
 end
-witness_sets(N::NumericalIrreducibleDecomposition{T}, dim::Int) where {T} =
-    witness_sets(N; dims = [dim])
+witness_sets(
+    N::NumericalIrreducibleDecomposition{T},
+    dim::Int;
+    only_irreducible::Bool = true,
+) where {T} = witness_sets(N; dim = dim, only_irreducible = only_irreducible)
 seed(N::NumericalIrreducibleDecomposition{T}) where {T} = N.seed
 
 """
@@ -1642,8 +1647,10 @@ Returns the total number of components in `N`.
 function ncomponents(
     N::NumericalIrreducibleDecomposition{T};
     dims::Union{Vector{Int},Nothing} = nothing,
+    dim::Union{Int,Nothing} = nothing,
     only_irreducible::Bool = true,
 ) where {T}
+    dims = isnothing(dim) ? dims : [dim]
     D = witness_sets(N; dims = dims, only_irreducible = only_irreducible)
     if isempty(D)
         return 0
@@ -1651,12 +1658,15 @@ function ncomponents(
         return sum(length(last(Ws)) for Ws in D)
     end
 end
-ncomponents(N::NumericalIrreducibleDecomposition{T}, dim::Int) where {T} =
-    ncomponents(N; dims = [dim])
-n_components(N; dims = nothing, only_irreducible::Bool = true) =
-    ncomponents(N; dims = dims, only_irreducible = only_irreducible)
+ncomponents(
+    N::NumericalIrreducibleDecomposition{T},
+    dim::Int;
+    only_irreducible::Bool = true,
+) where {T} = ncomponents(N; dim = dim, only_irreducible = only_irreducible)
+n_components(N; dims = nothing, dim = nothing, only_irreducible::Bool = true) =
+    ncomponents(N; dims = dims, dim = dim, only_irreducible = only_irreducible)
 n_components(N, dim; only_irreducible::Bool = true) =
-    ncomponents(N; dims = [dim], only_irreducible = only_irreducible)
+    ncomponents(N; dim = dim, only_irreducible = only_irreducible)
 
 """
 
@@ -1671,8 +1681,10 @@ Returns the degrees of the components in `N`.
 function ModelKit.degrees(
     N::NumericalIrreducibleDecomposition{T};
     dims::Union{Vector{Int},Nothing} = nothing,
+    dim::Union{Int,Nothing} = nothing,
     only_irreducible::Bool = true,
 ) where {T}
+    dims = isnothing(dim) ? dims : [dim]
     D = witness_sets(N; dims = dims, only_irreducible = only_irreducible)
     out = Dict{Int,Vector{Int}}()
     for key in keys(D)
@@ -1681,8 +1693,11 @@ function ModelKit.degrees(
 
     out
 end
-ModelKit.degrees(N::NumericalIrreducibleDecomposition{T}, dim::Int) where {T} =
-    degrees(N; dims = [dim])
+ModelKit.degrees(
+    N::NumericalIrreducibleDecomposition{T},
+    dim::Int;
+    only_irreducible::Bool = true,
+) where {T} = degrees(N; dim = dim, only_irreducible = only_irreducible)
 
 function max_dim(
     N::NumericalIrreducibleDecomposition{T};

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -919,6 +919,7 @@ Base.@kwdef mutable struct DecomposeProgress
     step::Int = 0
     is_monodromy::Bool = true
     is_finished::Bool = false
+    monodromy_solutions::Int = 0
     monodromy_tracked_loops::Int = 0
     monodromy_generated_loops::Int = 0
     monodromy_no_change::Int = 0
@@ -927,6 +928,7 @@ end
 function update_progress!(progress::DecomposeProgress; is_monodromy = nothing)
     isnothing(is_monodromy) ? nothing : progress.is_monodromy = is_monodromy
     if is_monodromy === true
+        progress.monodromy_solutions = 0
         progress.monodromy_tracked_loops = 0
         progress.monodromy_generated_loops = 0
         progress.monodromy_no_change = 0
@@ -948,7 +950,7 @@ function update_progress!(
     solutions::Int,
     finish::Bool = false,
 )
-    progress.npts = solutions
+    progress.monodromy_solutions = solutions
     progress.monodromy_tracked_loops = stats.tracked_loops[]
     progress.monodromy_generated_loops = stats.generated_loops[]
     progress.monodromy_no_change = loops_no_change(stats, solutions)
@@ -1026,7 +1028,7 @@ function showstatus(progress::DecomposeProgress)
                 text,
                 (
                     "Status",
-                    "running monodromy ($(progress.monodromy_tracked_loops) loops tracked, $(progress.monodromy_generated_loops) generated, $(progress.monodromy_no_change) no change)",
+                    "running monodromy ($(progress.monodromy_solutions) solutions, $(progress.monodromy_generated_loops) loops generated, $(progress.monodromy_no_change) no change)",
                 ),
             )
         else

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -58,6 +58,7 @@ Base.@kwdef mutable struct WitnessSetsProgress
     monodromy_codim::Int = 0
     monodromy_solutions::Int = 0
     monodromy_tracked_loops::Int = 0
+    monodromy_generated_loops::Int = 0
     monodromy_no_change::Int = 0
 end
 WitnessSetsProgress(n::Int, nhypersurfaces::Int, progress_meter::PM.ProgressUnknown) =
@@ -101,6 +102,7 @@ function update_progress!(
 )
     progress.monodromy_solutions = solutions
     progress.monodromy_tracked_loops = stats.tracked_loops[]
+    progress.monodromy_generated_loops = stats.generated_loops[]
     progress.monodromy_no_change = loops_no_change(stats, solutions)
 
     if finish
@@ -124,6 +126,7 @@ function update_progress_monodromy_witness!(progress::WitnessSetsProgress, W)
     progress.monodromy_codim = codim(W)
     progress.monodromy_solutions = degree(W)
     progress.monodromy_tracked_loops = 0
+    progress.monodromy_generated_loops = 0
     progress.monodromy_no_change = 0
     PM.update!(
         progress.progress_meter,
@@ -203,7 +206,7 @@ function showvalues(progress::WitnessSetsProgress)
                     text,
                     (
                         "Fill up points",
-                        "$(progress.monodromy_tracked_loops) loops tracked, $(progress.monodromy_no_change) no change",
+                        "$(progress.monodromy_tracked_loops) loops tracked ($(progress.monodromy_generated_loops) generated, $(progress.monodromy_no_change) no change)",
                     ),
                 )
             elseif progress.is_membership_test
@@ -916,10 +919,18 @@ Base.@kwdef mutable struct DecomposeProgress
     step::Int = 0
     is_monodromy::Bool = true
     is_finished::Bool = false
+    monodromy_tracked_loops::Int = 0
+    monodromy_generated_loops::Int = 0
+    monodromy_no_change::Int = 0
 end
 
 function update_progress!(progress::DecomposeProgress; is_monodromy = nothing)
     isnothing(is_monodromy) ? nothing : progress.is_monodromy = is_monodromy
+    if is_monodromy === true
+        progress.monodromy_tracked_loops = 0
+        progress.monodromy_generated_loops = 0
+        progress.monodromy_no_change = 0
+    end
 
     if !isnothing(is_monodromy)
         PM.update!(
@@ -929,6 +940,34 @@ function update_progress!(progress::DecomposeProgress; is_monodromy = nothing)
             force = true,
         )
     end
+end
+function update_progress!(
+    progress::DecomposeProgress,
+    stats::MonodromyStatistics;
+    queued::Int,
+    solutions::Int,
+    finish::Bool = false,
+)
+    progress.npts = solutions
+    progress.monodromy_tracked_loops = stats.tracked_loops[]
+    progress.monodromy_generated_loops = stats.generated_loops[]
+    progress.monodromy_no_change = loops_no_change(stats, solutions)
+
+    if finish
+        PM.update!(
+            progress.progress_meter,
+            progress.step,
+            showvalues = showstatus(progress),
+        )
+    elseif time() > progress.progress_meter.tlast + progress.progress_meter.dt
+        PM.update!(
+            progress.progress_meter,
+            progress.step,
+            showvalues = showstatus(progress),
+        )
+    end
+
+    nothing
 end
 update_progress!(progress::Nothing, D::Vector{WitnessSet}) = nothing
 function update_progress!(progress::DecomposeProgress, W::WitnessSet)
@@ -983,7 +1022,13 @@ function showstatus(progress::DecomposeProgress)
     end
     if !progress.is_finished
         if progress.is_monodromy
-            push!(text, ("Status", "running monodromy"))
+            push!(
+                text,
+                (
+                    "Status",
+                    "running monodromy ($(progress.monodromy_tracked_loops) loops tracked ($(progress.monodromy_generated_loops) generated, $(progress.monodromy_no_change) no change)",
+                ),
+            )
         else
             push!(text, ("Status", "partitioning points"))
         end
@@ -1059,6 +1104,7 @@ function decompose_with_monodromy!(
             seed;
             threading = threading,
             show_progress = show_monodromy_progress,
+            progress = show_monodromy_progress ? nothing : progress,
         )
         update_progress!(progress; is_monodromy = false)
         update_progress_npts!(progress, nsolutions(res))
@@ -1088,6 +1134,7 @@ function decompose_with_monodromy!(
                     seed;
                     threading = threading,
                     show_progress = show_monodromy_progress,
+                    progress = show_monodromy_progress ? nothing : progress,
                 )
                 update_progress!(progress; is_monodromy = false)
             end
@@ -1118,6 +1165,7 @@ function decompose_with_monodromy!(
                     seed;
                     threading = threading,
                     show_progress = show_monodromy_progress,
+                    progress = show_monodromy_progress ? nothing : progress,
                 )
                 update_progress!(progress; is_monodromy = false)
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1469,7 +1469,7 @@ This function decomposes a [`WitnessSet`](@ref) or a vector of [`WitnessSet`](@r
 * `show_progress = true`: indicate whether a progress bar should be displayed.
 * `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `decompose`.
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
-* `max_iters = 50`: maximal number of iterations for the decomposition step.
+* `max_iters = 20`: maximal number of iterations for the decomposition step.
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -1511,7 +1511,7 @@ function decompose(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
-    max_iters::Int = 50,
+    max_iters::Int = 20,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -1776,7 +1776,7 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 * `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of each substep.
 * `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed. 
 * `show_monodromy_for_decompose_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`decompose`](@ref) should be displayed.
-* `max_iters = 50`: maximal number of iterations for the decomposition step.
+* `max_iters = 20`: maximal number of iterations for the decomposition step.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).` This option is used for [`regeneration`](@ref).
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)

--- a/src/witness_set.jl
+++ b/src/witness_set.jl
@@ -116,7 +116,7 @@ function is_irreducible(W::WitnessSet)
         W.is_irreducible
     end
 end
-
+_is_irreducible(W::WitnessSet) = W.is_irreducible === true
 
 ### Construct witness sets
 """


### PR DESCRIPTION
This PR patches a few quirks in monodromy and numerical irreducible decomposition. Most notably:

* Regeneration now sorts equations by increasing degree when `sorted = true`.

* The regeneration/intersection hypersurface step now uses a three-stage homotopy through an intermediate random linear space.

* Regeneration, decomposition, and intersection progress meters now show embedded monodromy information

* `check_startsolutions` is now actually honored by `monodromy_solve`.

* `permutations(result)` now pads incomplete permutation vectors instead of dropping them when their length differs from the final result count.

* Singular monodromy endpoints are no longer inserted as accepted monodromy solutions.

* Heuristic monodromy insertion now validates genuinely new endpoints before allowing them to become future start points.

* decompose now runs monodromy with stable start indexing by setting `check_startsolutions = false` in its monodromy options.

* Trace-certified orbits are allowed to grow during the trace-test monodromy run and are accepted using the grown certified point set.

* If trace certification does not finish, decompose now returns remaining orbit witness sets with `is_irreducible = nothing` instead of silently dropping them.

* `NumericalIrreducibleDecomposition` now stores all witness sets internally but defaults its public helpers/display to only `is_irreducible == true`.

* reduced the default value of `max_iters` in `decompose` to 20.