### PR TITLE
Nid for homogeneous systems

### DIFF
--- a/src/linear_subspaces.jl
+++ b/src/linear_subspaces.jl
@@ -11,6 +11,7 @@ export LinearSubspace,
     codim,
     ambient_dim,
     rand_subspace,
+    rand_subspace!,
     coord_change,
     geodesic_distance,
     geodesic,
@@ -473,13 +474,11 @@ function rand_subspace(
         k = n - codim
     end
     T = real ? Float64 : ComplexF64
-    A = randn(T, n - k, n)
-    if affine
-        LinearSubspace(A, randn(T, n - k))
-    else
-        LinearSubspace(A)
-    end
-
+    rand_subspace!(
+        Matrix{T}(undef, n - k, n),
+        Vector{T}(undef, n - k);
+        affine = affine,
+    )
 end
 rand_subspace(x::AbstractVector{Variable}; kwargs...) = rand_subspace(length(x); kwargs...)
 function rand_subspace(
@@ -501,15 +500,58 @@ function rand_subspace(
         k = n - codim
     end
 
+    rand_subspace!(
+        Matrix{eltype(x)}(undef, n - k, n),
+        Vector{eltype(x)}(undef, n - k),
+        x;
+        affine = affine,
+    )
+end
+function rand_subspace!(
+    A::AbstractMatrix,
+    b::AbstractVector;
+    affine::Bool = true,
+)
+    size(A, 1) == length(b) || throw(ArgumentError("Size of A and b not compatible."))
+
+    Random.randn!(A)
     if affine
-        A = randn(eltype(x), n - k, n)
-        b = A * x
-        LinearSubspace(A, b)
+        Random.randn!(b)
     else
-        N = LA.nullspace(Matrix(x'))'
-        A = randn(eltype(N), n - k, size(N, 1)) * N
-        LinearSubspace(A)
+        fill!(b, zero(eltype(b)))
     end
+
+    LinearSubspace(Matrix(A), Vector(b))
+end
+function rand_subspace!(
+    A::AbstractMatrix,
+    b::AbstractVector,
+    x::AbstractVector;
+    affine::Bool = true,
+)
+    size(A, 2) == length(x) || throw(ArgumentError("Size of A and x not compatible."))
+    size(A, 1) == length(b) || throw(ArgumentError("Size of A and b not compatible."))
+
+    if affine
+        Random.randn!(A)
+        LA.mul!(b, A, x)
+    else
+        fill!(b, zero(eltype(b)))
+        Random.randn!(A)
+        x′x = sum(abs2, x)
+        for i = 1:size(A, 1)
+            α = zero(eltype(A))
+            for j = 1:size(A, 2)
+                α += A[i, j] * x[j]
+            end
+            α /= x′x
+            for j = 1:size(A, 2)
+                A[i, j] -= α * conj(x[j])
+            end
+        end
+    end
+
+    LinearSubspace(Matrix(A), Vector(b))
 end
 
 # Coordinate changes

--- a/src/linear_subspaces.jl
+++ b/src/linear_subspaces.jl
@@ -476,11 +476,7 @@ function rand_subspace(
     T = real ? Float64 : ComplexF64
     A = zeros(T, n - k, n)
     b = zeros(T, n - k)
-    rand_subspace!(
-        A,
-        b;
-        affine = affine,
-    )
+    rand_subspace!(A, b; affine = affine)
 end
 rand_subspace(x::AbstractVector{Variable}; kwargs...) = rand_subspace(length(x); kwargs...)
 function rand_subspace(
@@ -503,18 +499,9 @@ function rand_subspace(
     end
     A = zeros(eltype(x), n - k, n)
     b = zeros(eltype(x), n - k)
-    rand_subspace!(
-        A,
-        b,
-        x;
-        affine = affine,
-    )
+    rand_subspace!(A, b, x; affine = affine)
 end
-function rand_subspace!(
-    A::AbstractMatrix,
-    b::AbstractVector;
-    affine::Bool = true,
-)
+function rand_subspace!(A::AbstractMatrix, b::AbstractVector; affine::Bool = true)
     size(A, 1) == length(b) || throw(ArgumentError("Size of A and b not compatible."))
 
     Random.randn!(A)

--- a/src/linear_subspaces.jl
+++ b/src/linear_subspaces.jl
@@ -474,9 +474,11 @@ function rand_subspace(
         k = n - codim
     end
     T = real ? Float64 : ComplexF64
+    A = zeros(T, n - k, n)
+    b = zeros(T, n - k)
     rand_subspace!(
-        Matrix{T}(undef, n - k, n),
-        Vector{T}(undef, n - k);
+        A,
+        b;
         affine = affine,
     )
 end
@@ -499,10 +501,11 @@ function rand_subspace(
         0 < codim < n || throw(ArgumentError("`codim` has to be between 0 and `n`."))
         k = n - codim
     end
-
+    A = zeros(eltype(x), n - k, n)
+    b = zeros(eltype(x), n - k)
     rand_subspace!(
-        Matrix{eltype(x)}(undef, n - k, n),
-        Vector{eltype(x)}(undef, n - k),
+        A,
+        b,
         x;
         affine = affine,
     )
@@ -538,13 +541,13 @@ function rand_subspace!(
     else
         fill!(b, zero(eltype(b)))
         Random.randn!(A)
-        x′x = sum(abs2, x)
+        nrmsq = sum(abs2, x)
         for i = 1:size(A, 1)
             α = zero(eltype(A))
             for j = 1:size(A, 2)
                 α += A[i, j] * x[j]
             end
-            α /= x′x
+            α /= nrmsq
             for j = 1:size(A, 2)
                 A[i, j] -= α * conj(x[j])
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -658,9 +658,9 @@ function initialize_hypersurfaces(
             return nothing
         end
         if projective && qᵢ == 1
-            S = map(x -> [x; 0], solutions(res, only_nonsingular = false))
+            S = map(x -> [x; 0], solution.(results(res)))
         else
-            S = solutions(res, only_nonsingular = false)
+            S = solution.(results(res))
         end
         out[i] = WitnessSet(h, L, S)
     end
@@ -725,7 +725,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
             if nsolutions(res) == 0
                 W.R = Vector{Vector{ComplexF64}}()
             else
-                W.R = solutions(res; only_nonsingular = false)
+                W.R = solution.(results(res))
             end
             update_progress!(progress, W)
         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1378,7 +1378,7 @@ function decompose_with_monodromy!(
 )
     update_progress_dim!(progress, dim(W))
 
-    P = points(W)
+    P = unique_points(points(W))
     L = linear_subspace(W)
     G = system(W)
     n = ambient_dim(L)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1391,7 +1391,7 @@ function decompose_with_monodromy!(
                 if trace(res_orbit) < options.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
-                    if length(orbit) > 1 || iter ≥ 50 || iter ≥ max_iters - 1
+                    if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         complete_orbit =

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -550,7 +550,7 @@ function initialize_hypersurfaces(
         if qᵢ != 1
             res = solve(
                 h,
-                solutions(res);
+                solution.(results(res));
                 start_subspace = L,
                 target_subspace = L,
                 show_progress = false,
@@ -560,7 +560,7 @@ function initialize_hypersurfaces(
         if isnothing(res)
             return nothing
         end
-        S = solutions(res, only_nonsingular = true)
+        S = solution.(results(res))
         out[i] = WitnessSet(h, L, S)
     end
     out
@@ -624,7 +624,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
             if nsolutions(res) == 0
                 W.R = Vector{Vector{ComplexF64}}()
             else
-                W.R = unique_points(solutions(res))
+                W.R = solution.(results(res))
             end
             update_progress!(progress, W)
         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -654,7 +654,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 Fᵢ,
                 W.R,
                 linear_subspace(W);
-                options = regeneration_monodromy_options(monodromy_options, W),
+                options = regeneration_monodromy_options(monodromy_options, W; atol = atol, rtol = rtol),
                 show_progress = show_monodromy_progress,
                 progress = show_monodromy_progress ? nothing : progress,
                 threading = threading,
@@ -676,7 +676,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
     end
 end
 
-function regeneration_monodromy_options(M::MonodromyOptions, W)
+function regeneration_monodromy_options(M::MonodromyOptions, W; atol = 1e-14, rtol = sqrt(eps()))
 
     MonodromyOptions(;
         permutations = false,
@@ -697,8 +697,10 @@ function regeneration_monodromy_options(M::MonodromyOptions, W)
         max_loops_no_progress = M.max_loops_no_progress,
         reuse_loops = M.reuse_loops,
         distance = M.distance,
-        unique_points_atol = M.unique_points_atol,
-        unique_points_rtol = M.unique_points_rtol,
+        # Forward the practical tolerances so monodromy's internal add! uses them
+        # rather than the tight per-solution uniqueness_rtol(res) based on ω.
+        unique_points_atol = something(M.unique_points_atol, atol),
+        unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
 end
 
@@ -1723,9 +1725,9 @@ function get_orbits_from_monodromy_permutations(
     orbits
 end
 
-function decompose_with_monodromy_options(M::MonodromyOptions)
+function decompose_with_monodromy_options(M::MonodromyOptions; atol = 1e-14, rtol = sqrt(eps()))
 
-    # we need two copies of the options. 
+    # we need two copies of the options.
     # one with trace test
     # one without to run monodromy populating the permutation matrix
     options_with_trace = MonodromyOptions(;
@@ -1747,8 +1749,8 @@ function decompose_with_monodromy_options(M::MonodromyOptions)
         max_loops_no_progress = M.max_loops_no_progress,
         reuse_loops = M.reuse_loops,
         distance = M.distance,
-        unique_points_atol = M.unique_points_atol,
-        unique_points_rtol = M.unique_points_rtol,
+        unique_points_atol = something(M.unique_points_atol, atol),
+        unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
     options_without_trace = MonodromyOptions(;
         permutations = true,
@@ -1769,8 +1771,8 @@ function decompose_with_monodromy_options(M::MonodromyOptions)
         max_loops_no_progress = M.max_loops_no_progress,
         reuse_loops = M.reuse_loops,
         distance = M.distance,
-        unique_points_atol = M.unique_points_atol,
-        unique_points_rtol = M.unique_points_rtol,
+        unique_points_atol = something(M.unique_points_atol, atol),
+        unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
 
     options_with_trace, options_without_trace
@@ -1830,6 +1832,8 @@ function decompose(
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
+    atol = 1e-14,
+    rtol = sqrt(eps()),
 ) where {WP<:WitnessSet}
 
     if isnothing(seed)
@@ -1838,7 +1842,7 @@ function decompose(
     Random.seed!(seed)
 
     sort!(Ws; by = dim, rev = true)
-    options = decompose_with_monodromy_options(monodromy_options)
+    options = decompose_with_monodromy_options(monodromy_options; atol = atol, rtol = rtol)
     out = Vector{WitnessSet}()
 
     if isempty(Ws)
@@ -2216,6 +2220,8 @@ function numerical_irreducible_decomposition(
         threading = threading,
         warning = warning,
         seed = seed,
+        atol = atol,
+        rtol = rtol,
         kwargs...,
     )
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -829,25 +829,24 @@ end
 function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
     l_start = length(P) * length(roots)
     P1 = Vector{Vector{ComplexF64}}(undef, l_start)
-    accepted1 = falses(l_start)
-    accepted2 = falses(l_start)
+    accepted = falses(l_start)
 
     ntrials = max(cache.max_trials_u_homotopy, 1)
     for trial = 1:ntrials
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
 
-        fill!(accepted1, false)
-        fill!(accepted2, false)
+        fill!(accepted, false)
         track_hom1!(accepted1, P1, P, roots, trackers[1], progress, threading)
-        all(accepted1) || continue
+        all(accepted) || continue
 
         # Hom1 only moves the slice. We still need to verify that its endpoints
         # are usable starts for Hom2; otherwise resample L1 and try again.
-        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
-        all(accepted2) && break
+        fill!(accepted, false)
+        check_hom2_starts!(accepted2, P1, trackers[2], progress, threading)
+        all(accepted) && break
     end
 
-    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
 
     nothing
 end
@@ -923,19 +922,19 @@ function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
     end
 end
 
-function check_hom2_starts!(accepted, P1, accepted1, tracker, progress, threading)
+function check_hom2_starts!(accepted, P1, tracker, progress, threading)
     if threading
-        threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     else
-        serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+        serial_check_hom2_starts!(accepted, P1, tracker, progress)
     end
 end
 
-function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     end
 end
 
@@ -958,12 +957,11 @@ function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
-        accepted1[i] || continue
 
         code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
         accepted[i] = is_success(code)
@@ -972,12 +970,11 @@ function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
-        accepted[i] || continue
 
         code2 = track!(tracker2, P1[i], 1)
         if is_accepted(tracker2, code2)
@@ -1036,7 +1033,7 @@ function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
 
     l_start = length(P1)
 
@@ -1060,7 +1057,6 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
-                        accepted1[idx] || continue
 
                         code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
                         accepted[idx] = is_success(code)
@@ -1073,7 +1069,7 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1098,7 +1094,6 @@ function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
-                        accepted[idx] || continue
 
                         code2 = track!(local_tracker2, P1[idx], 1)
                         if is_accepted(local_tracker2, code2)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -256,6 +256,10 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     u::Variable
     i::Int
     codim::Int
+    projective::Bool
+    variable_groups::Union{Nothing,Vector{Vector{Variable}}}
+    ℓ::Expression
+    ℓ_coeffs::Vector{ComplexF64}
 
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
@@ -263,7 +267,20 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     progress::Union{WitnessSetsProgress,Nothing}
 end
 
-function RegenerationCache(u, f, F, h, codim, EO, TO, progress)
+function RegenerationCache(
+    u,
+    f,
+    F,
+    h,
+    codim,
+    projective,
+    variable_groups,
+    ℓ,
+    ℓ_coeffs,
+    EO,
+    TO,
+    progress,
+)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -271,10 +288,32 @@ function RegenerationCache(u, f, F, h, codim, EO, TO, progress)
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    RegenerationCache(A, b, x0, y0, y, f, F, h, u, 0, codim, EO, TO, progress)
+    RegenerationCache(
+        A,
+        b,
+        x0,
+        y0,
+        y,
+        f,
+        F,
+        h,
+        u,
+        0,
+        codim,
+        projective,
+        variable_groups,
+        ℓ,
+        ℓ_coeffs,
+        EO,
+        TO,
+        progress,
+    )
 end
 function update_Fᵢ!(cache, fᵢ, vars)
-    Fᵢ = fixed(System(fᵢ, variables = vars), compile = false)
+    Fᵢ = fixed(
+        System(fᵢ, variables = vars, variable_groups = cache.variable_groups),
+        compile = false,
+    )
     cache.fᵢ = fᵢ
     cache.Fᵢ = Fᵢ
     m = length(Fᵢ)
@@ -287,6 +326,18 @@ function update_Fᵢ!(cache, fᵢ, vars)
 end
 update_hᵢ!(cache, h) = cache.h = h
 update_i!(cache, i) = cache.i = i
+
+function single_projective_variable_group(F::System)
+    is_homogeneous(F) || return nothing
+    groups = variable_groups(F)
+    if isnothing(groups)
+        return variables(F)
+    elseif length(groups) == 1
+        return only(groups)
+    else
+        error("NID for systems with multiple variable groups is not implemented yet.")
+    end
+end
 
 """
     regeneration(F::System; options...) 
@@ -348,10 +399,13 @@ function _regeneration(
     # the algorithm is u-regeneration as proposed 
     # by Duff, Leykin and Rodriguez in https://arxiv.org/abs/2206.02869
 
-    vars = variables(F)
+    xvars = variables(F)
+    projective_group = single_projective_variable_group(F)
+    projective = !isnothing(projective_group)
+    vars = copy(xvars)
     n = size(F, 2) # ambient dimension
     c = size(F, 1) # we can have witness sets of codimesion at most min(c,n)
-    expected_max_codim = min(c, n)
+    expected_max_codim = min(c, n - projective)
     if !isnothing(max_codim) && max_codim < expected_max_codim
         # if max_codim is smaller than the expected codimension we must compute witness points for one more codimension, so that we can remove spurious points
         codim = max_codim + 1
@@ -361,6 +415,9 @@ function _regeneration(
     # u-regeneration adds another variable u to F
     @unique_var u
     push!(vars, u)
+    variable_groups = projective ? [vars] : nothing
+    ℓ_coeffs = randn(ComplexF64, length(xvars))
+    ℓ = sum(ℓ_coeffs .* xvars)
 
     # progress bar
     if show_progress
@@ -381,13 +438,19 @@ function _regeneration(
     # prepare codim witness sets for the output
     # internally we represent a witness superset by WitnessPoints
     # the i-th witness superset out[i] is for codimension i
-    out = initialize_witness_sets(codim, n)
+    out = initialize_witness_sets(codim, n; projective = projective)
 
     # we compute witness (super)sets for the hypersurfaces f[1]=0,...,f[c]=0.
     # it is covenient to use the WitnessSet wrapper here, because this also keeps track of the equation
     # as a linear subspace we take the linear subspace for out[1], that sets u=0.
     update_progress!(progress; is_computing_hypersurfaces = true)
-    H = initialize_hypersurfaces(F, vars, linear_subspace(out[1]); threading = threading)
+    H = initialize_hypersurfaces(
+        F,
+        vars,
+        linear_subspace(out[1]);
+        variable_groups = variable_groups,
+        threading = threading,
+    )
     if any(isnothing, H)
         return nothing
     end
@@ -402,13 +465,20 @@ function _regeneration(
     end
 
     # Initialize a cache
-    Fᵢ = fixed(System(f[1:1], variables = vars), compile = false)
+    Fᵢ = fixed(
+        System(f[1:1], variables = vars, variable_groups = variable_groups),
+        compile = false,
+    )
     cache = RegenerationCache(
         u,
         f[1:1],
         Fᵢ,
         f[1],
         codim,
+        projective,
+        variable_groups,
+        ℓ,
+        ℓ_coeffs,
         endgame_options,
         tracker_options,
         progress,
@@ -476,7 +546,7 @@ function _regeneration(
         ws = map(out) do W
             update_progress!(progress)
             P, L = u_transform(W)
-            WitnessSet(fixed(F, compile = false), L, P)
+            WitnessSet(fixed(F, compile = false), L, P; projective = projective)
         end
     else
         return ws = Vector{WitnessSet}()
@@ -516,10 +586,53 @@ function get_flag(iter, L₀)
         L, Lᵤ
     end
 end
-function initialize_witness_sets(codim, n)
+function get_projective_flag(iter, L₀)
+    A₀ = extrinsic(L₀).A
+    r = size(A₀, 1)
+    m = size(A₀, 2)
+    Aᵤ = [A₀ zeros(r)]
+
+    map(iter) do i
+        Aᵤᵢ = i <= r ? Aᵤ[i:r, :] : zeros(eltype(Aᵤ), 0, m + 1)
+        Lᵤ = LinearSubspace(
+            ExtrinsicDescription(Aᵤᵢ, zeros(ComplexF64, size(Aᵤᵢ, 1)); orthonormal = true),
+        )
+
+        idx = i <= r ? (i:r) : ((r+1):r)
+        Aᵢ = [zeros(1, m) 1.0; A₀[idx, :] zeros(length(idx), 1)]
+        L = LinearSubspace(
+            ExtrinsicDescription(Aᵢ, zeros(ComplexF64, size(Aᵢ, 1)); orthonormal = true),
+        )
+        L, Lᵤ
+    end
+end
+
+function initial_projective_slice(n)
+    if n == 2
+        LinearSubspace(zeros(ComplexF64, 0, n))
+    else
+        rand_subspace(n; dim = 2, affine = false)
+    end
+end
+
+function projective_drop_u(L::LinearSubspace)
+    E = extrinsic(L)
+    A = E.A[2:end, 1:(end-1)]
+    b = E.b[2:end]
+    LinearSubspace(ExtrinsicDescription(A, b; orthonormal = false))
+end
+
+function linear_equations(L::LinearSubspace, vars)
+    A = extrinsic(L).A
+    map(1:size(A, 1)) do i
+        sum(A[i, j] * vars[j] for j = 1:length(vars))
+    end
+end
+
+function initialize_witness_sets(codim, n; projective::Bool = false)
     # we need a flag containing a linear space of dimension 1
-    L₀ = rand_subspace(n; dim = 1)
-    flag = get_flag(1:codim, L₀)
+    L₀ = projective ? initial_projective_slice(n) : rand_subspace(n; dim = 1)
+    flag = projective ? get_projective_flag(1:codim, L₀) : get_flag(1:codim, L₀)
 
     map(flag) do F
         L, Lᵤ = F
@@ -530,6 +643,7 @@ function initialize_hypersurfaces(
     F::System,
     vars,
     L;
+    variable_groups = nothing,
     threading::Bool = Threads.nthreads() > 1,
 )
     f = expressions(F)
@@ -537,20 +651,35 @@ function initialize_hypersurfaces(
     out = Vector{WitnessSet}(undef, c)
     for i = 1:c
         fᵢ = f[i]
-        h = fixed(System([fᵢ], variables = vars), compile = false)
-        pᵢ, qᵢ = get_num_den(fᵢ) # fᵢ = pᵢ / qᵢ
-        res = solve(
-            System([pᵢ], variables = vars),
-            target_subspace = L;
-            start_system = :total_degree,
-            show_progress = false,
-            threading = threading,
+        h = fixed(
+            System([fᵢ], variables = vars, variable_groups = variable_groups),
+            compile = false,
         )
+        pᵢ, qᵢ = get_num_den(fᵢ) # fᵢ = pᵢ / qᵢ
+        xvars = vars[1:(end-1)]
+        projective = !isnothing(variable_groups)
+        if projective
+            Lx = projective_drop_u(L)
+            res = solve(
+                System([pᵢ; linear_equations(Lx, xvars)], variables = xvars);
+                start_system = :total_degree,
+                show_progress = false,
+                threading = threading,
+            )
+        else
+            res = solve(
+                System([pᵢ], variables = vars),
+                target_subspace = L;
+                start_system = :total_degree,
+                show_progress = false,
+                threading = threading,
+            )
+        end
         # if fᵢ is rational we check which zeros of pᵢ are also zeros of fᵢ
         if qᵢ != 1
             res = solve(
                 h,
-                solutions(res);
+                projective ? map(x -> [x; 0], solutions(res)) : solutions(res);
                 start_subspace = L,
                 target_subspace = L,
                 show_progress = false,
@@ -560,7 +689,9 @@ function initialize_hypersurfaces(
         if isnothing(res)
             return nothing
         end
-        S = solutions(res, only_nonsingular = true)
+        S =
+            projective && qᵢ == 1 ? map(x -> [x; 0], solutions(res, only_nonsingular = true)) :
+            solutions(res, only_nonsingular = true)
         out[i] = WitnessSet(h, L, S)
     end
     out
@@ -695,7 +826,17 @@ function intersect_with_hypersurface!(
     # Step 2:
     # the points in P_next are used as starting points for a homotopy.
     # where u^d-1 (u is the extra variable in u-regeneration) is deformed into g 
-    Hom, d = set_up_u_homotopy(W, f, X, h, vars, u)
+    Hom, d = set_up_u_homotopy(
+        W,
+        f,
+        X,
+        h,
+        vars,
+        u;
+        projective = cache.projective,
+        variable_groups = cache.variable_groups,
+        ℓ = cache.ℓ,
+    )
 
     trackers = map(Hom) do H
         EndgameTracker(
@@ -717,9 +858,25 @@ function intersect_with_hypersurface!(
         is_monodromy = false,
     )
     if threading
-        threaded_intersection!(X, P_next, roots, trackers, progress)
+        threaded_intersection!(
+            X,
+            P_next,
+            roots,
+            trackers,
+            progress,
+            Val(cache.projective),
+            cache.ℓ_coeffs,
+        )
     else
-        serial_intersection!(X, P_next, roots, trackers, progress)
+        serial_intersection!(
+            X,
+            P_next,
+            roots,
+            trackers,
+            progress,
+            Val(cache.projective),
+            cache.ℓ_coeffs,
+        )
     end
     nothing
 end
@@ -750,30 +907,36 @@ function track_intersection_path(egtrackers, p)
     q
 end
 
-function serial_intersection!(X, P, roots, egtrackers, progress)
-    start = Iterators.product(P, roots)
-    l_start = length(P) * length(roots)
+start_values(p, roots, ::Val{false}, ℓ_coeffs) = roots
+start_values(p, roots, ::Val{true}, ℓ_coeffs) =
+    roots .* sum(ℓ_coeffs[j] * p[j] for j = 1:length(ℓ_coeffs))
 
-    for (i, s) in enumerate(start)
-        update_progress_paths!(progress, i, l_start)
+function serial_intersection!(X, P, roots, egtrackers, progress, projective::Val, ℓ_coeffs)
+    l_start = sum(length(start_values(p, roots, projective, ℓ_coeffs)) for p in P)
 
-        p = s[1]
-        p[end] = s[2] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
+    i = 0
+    for p₀ in P
+        for r in start_values(p₀, roots, projective, ℓ_coeffs)
+            i += 1
+            update_progress_paths!(progress, i, l_start)
 
-        q = track_intersection_path(egtrackers, p)
-        if !isnothing(q)
-            push!(X, q)
+            p = copy(p₀)
+            p[end] = r
+
+            q = track_intersection_path(egtrackers, p)
+            if !isnothing(q)
+                push!(X, q)
+            end
         end
     end
 
     nothing
 end
 
-function threaded_intersection!(X, P, roots, trackers, progress)
+function threaded_intersection!(X, P, roots, trackers, progress, projective::Val, ℓ_coeffs)
 
-    l_P = length(P)
-    l_roots = length(roots)
-    l_start = l_P * l_roots
+    starts = [(p, r) for p in P for r in start_values(p, roots, projective, ℓ_coeffs)]
+    l_start = length(starts)
 
     # Pre-allocate one tracker per thread
     nthr = Threads.nthreads()
@@ -798,10 +961,8 @@ function threaded_intersection!(X, P, roots, trackers, progress)
                             update_progress_paths!(progress, idx, l_start)
                         end
 
-                        p_idx = rem(idx - 1, l_P) + 1
-                        r_idx = div(idx - 1, l_P) + 1
-                        p = copy(P[p_idx])
-                        p[end] = roots[r_idx] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
+                        p = copy(starts[idx][1])
+                        p[end] = starts[idx][2]
 
                         q = track_intersection_path(local_egtrackers, p)
                         if !isnothing(q)
@@ -818,23 +979,34 @@ function threaded_intersection!(X, P, roots, trackers, progress)
     nothing
 end
 
-function set_up_u_homotopy(W, f, X, h, vars, u)
+function set_up_u_homotopy(
+    W,
+    f,
+    X,
+    h,
+    vars,
+    u;
+    projective::Bool = false,
+    variable_groups = nothing,
+    ℓ = 1,
+)
 
     P, Q = get_num_den(h)
     d = degree(P)
-    h0 = (u^d - 1) / Q
+    h0 = projective ? (u^d - ℓ^d) / Q : (u^d - 1) / Q
 
     # we start with the linear space L which does not use pose conditions on u, so that u^d=1
     # we end with the linear space L2 with u=c.
     L = linear_subspace_u(W)
-    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
+    L1 = rand_subspace(ambient_dim(L); dim = dim(L), affine = !projective)
     L2 = linear_subspace(X)
 
-    F = fixed(System([f; h0], variables = vars); compile = false)
-    G = fixed(System([f; h], variables = vars); compile = false)
+    F = fixed(System([f; h0], variables = vars, variable_groups = variable_groups); compile = false)
+    G = fixed(System([f; h], variables = vars, variable_groups = variable_groups); compile = false)
 
     Hom1 = linear_subspace_homotopy(F, L, L1)
     Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
+    projective && (Hom2 = on_affine_chart(Hom2))
     Hom3 = linear_subspace_homotopy(G, L1, L2)
 
     return (Hom1, Hom2, Hom3), d
@@ -859,12 +1031,33 @@ function is_contained(X::WitnessPoints, Y::WitnessSet, F, cache; kwargs...)
     end
 
     set_up_linear_spaces!(cache, LX, LY)
-    out = is_contained(points(X), Y::WitnessSet, F, cache; kwargs...)
+    out =
+        cache.projective ? is_contained_projective(points(X), Y, F, cache; kwargs...) :
+        is_contained(points(X), Y::WitnessSet, F, cache; kwargs...)
 
     out
 end
 function is_contained(V::WitnessPoints, W::WitnessSet, cache; kwargs...)
     is_contained(V, W, system(W), cache; kwargs...)
+end
+
+function is_contained_projective(
+    P::Vector{Vector{T}},
+    Y::WitnessSet,
+    F,
+    cache;
+    threading::Bool = Threads.nthreads() > 1,
+    kwargs...,
+) where {T<:Number}
+    Hom = linear_subspace_homotopy(on_affine_chart(F), linear_subspace(Y), linear_subspace(Y))
+    tracker = EndgameTracker(
+        Hom;
+        tracker_options = cache.tracker_options,
+        options = cache.endgame_options,
+    )
+
+    threading ? threaded_x_in_Y(P, Y, F, tracker, cache; kwargs...) :
+    serial_x_in_Y(P, Y, F, tracker, cache; kwargs...)
 end
 
 function set_up_linear_spaces!(cache, LX, LY)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -752,6 +752,7 @@ function intersect_with_hypersurface!(
     else
         serial_intersection!(X, P_next, roots, trackers, u_data, cache, progress)
     end
+
     nothing
 end
 
@@ -1405,6 +1406,7 @@ function decompose_with_monodromy!(
             )
             update_progress!(progress; is_monodromy = false)
 
+            prev_count = length(non_complete_points)
             updated_points = indexed_solutions(res)
             d += length(updated_points) - length(non_complete_points) # update total degree in case we found new points.
             non_complete_points = updated_points
@@ -1412,7 +1414,13 @@ function decompose_with_monodromy!(
             k = length(non_complete_points) # and once for counting progress
             update_progress_npts!(progress, k)
 
-            # Get orbits from monodromy result            
+            # If monodromy deduplicated starting solutions, the cached orbit indices are
+            # stale (they reference the old count). Reset to avoid a BoundsError.
+            if length(non_complete_points) < prev_count
+                non_complete_orbits = Vector{Set{Int}}()
+            end
+
+            # Get orbits from monodromy result
             orbits = get_orbits_from_monodromy_permutations(
                 res;
                 initial_orbits = non_complete_orbits,
@@ -1442,7 +1450,12 @@ function decompose_with_monodromy!(
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         complete_orbit =
-                            length(P_certified) == length(orbit) ? orbit :
+                            # matching_indices is only needed when P_certified found more
+                            # witness points than orbit contained. When P_certified has
+                            # fewer points (inner monodromy deduplicated some starts), the
+                            # full orbit is still complete — collapsed elements were just
+                            # numerical duplicates on the same component.
+                            length(P_certified) > length(orbit) ?
                             Set(
                                 matching_indices(
                                     non_complete_points,
@@ -1451,7 +1464,8 @@ function decompose_with_monodromy!(
                                     atol = something(options.unique_points_atol, 1e-14),
                                     rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
-                            )
+                            ) :
+                            orbit
 
                         push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1694,7 +1694,7 @@ This function decomposes a [`WitnessSet`](@ref) or a vector of [`WitnessSet`](@r
 * `show_progress = true`: indicate whether a progress bar should be displayed.
 * `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `decompose`.
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
-* `max_iters = 50`: maximal number of iterations for the decomposition step.
+* `max_iters = 200`: maximal number of iterations for the decomposition step.
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -1736,7 +1736,7 @@ function decompose(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
-    max_iters::Int = 50,
+    max_iters::Int = 200,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -2016,7 +2016,7 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 * `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of each substep.
 * `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed. 
 * `show_monodromy_for_decompose_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`decompose`](@ref) should be displayed.
-* `max_iters = 50`: maximal number of iterations for the decomposition step.
+* `max_iters = 200`: maximal number of iterations for the decomposition step.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).` This option is used for [`regeneration`](@ref).
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
@@ -2084,7 +2084,7 @@ function numerical_irreducible_decomposition(
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
-    max_iters::Int = 50,
+    max_iters::Int = 200,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
     max_trials_u_homotopy::Int = 5,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1494,8 +1494,6 @@ function decompose_with_monodromy!(
             complete_orbits = Vector{Set{Int}}()
 
             for orbit in orbits
-                success = true # this checks if this run was successful
-
                 update_progress!(progress; is_monodromy = true)
 
                 # Strip phantom indices from the orbit before running inner monodromy.
@@ -1535,42 +1533,39 @@ function decompose_with_monodromy!(
 
                         if length(P_certified) > length(clean_orbit)
                             # Inner monodromy found new points beyond the starting orbit.
-                            # First match them against non_complete_points.
+                            # Match them against non_complete_points to detect orbit merging
+                            # and path-jumping phantoms.
                             matched = setdiff(
                                 Set(
                                     matching_indices(
                                         non_complete_points,
                                         P_certified;
                                         atol = atol,
-                                        rtol = something(options.unique_points_rtol, 1e-8),
+                                        rtol = rtol,
                                     ),
                                 ),
                                 phantom_indices,
                             )
-                            # Only check certified_up when matching_indices left points unaccounted for.
-                            # Unmatched points are either genuine new discoveries or path-jumping phantoms.
+                            # If not all P_certified points are accounted for in non_complete_points,
+                            # the result is unreliable (phantom or genuine new point) — skip.
                             if length(matched) < length(P_certified)
-                                success = false
-                            else
-                                complete_orbit = matched
+                                continue
                             end
+                            complete_orbit = matched
                         else
                             complete_orbit = clean_orbit
                         end
 
-                        # postprocessing
-                        if success
-                            push!(complete_orbits, complete_orbit)
-                            k -= length(complete_orbit)
-                            update_progress_npts!(progress, k)
+                        push!(complete_orbits, complete_orbit)
+                        k -= length(complete_orbit)
+                        update_progress_npts!(progress, k)
 
-                            push!(decomposition, W_new)
-                            for p in solutions(W_new)
-                                add!(certified_up, p, 1; atol = atol, rtol = rtol)
-                            end
-                            d += length(P_certified) - length(complete_orbit)
-                            update_progress!(progress, W_new)
+                        push!(decomposition, W_new)
+                        for p in solutions(W_new)
+                            add!(certified_up, p, 1; atol = atol, rtol = rtol)
                         end
+                        d += length(P_certified) - length(complete_orbit)
+                        update_progress!(progress, W_new)
                     end
                 end
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -829,22 +829,25 @@ end
 function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
     l_start = length(P) * length(roots)
     P1 = Vector{Vector{ComplexF64}}(undef, l_start)
-    accepted = falses(l_start)
+    accepted1 = falses(l_start)
+    accepted2 = falses(l_start)
 
     ntrials = max(cache.max_trials_u_homotopy, 1)
     for trial = 1:ntrials
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
-        
-        fill!(accepted, false)
-        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
-        all(accepted) && break
 
-        fill!(accepted, false)
-        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
-        all(accepted) && break
+        fill!(accepted1, false)
+        fill!(accepted2, false)
+        track_hom1!(accepted1, P1, P, roots, trackers[1], progress, threading)
+        all(accepted1) || continue
+
+        # Hom1 only moves the slice. We still need to verify that its endpoints
+        # are usable starts for Hom2; otherwise resample L1 and try again.
+        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
+        all(accepted2) && break
     end
 
-    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
 
     nothing
 end
@@ -920,19 +923,19 @@ function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
     end
 end
 
-function check_hom2_starts!(accepted, P1, tracker, progress, threading)
+function check_hom2_starts!(accepted, P1, accepted1, tracker, progress, threading)
     if threading
-        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
+        threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     else
-        serial_check_hom2_starts!(accepted, P1, tracker, progress)
+        serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     end
 end
 
-function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     end
 end
 
@@ -955,11 +958,12 @@ function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function serial_check_hom2_starts!(accepted, P1, tracker, progress)
+function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
+        accepted1[i] || continue
 
         code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
         accepted[i] = is_success(code)
@@ -968,11 +972,12 @@ function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
+        accepted[i] || continue
 
         code2 = track!(tracker2, P1[i], 1)
         if is_accepted(tracker2, code2)
@@ -1031,7 +1036,7 @@ function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
+function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
 
     l_start = length(P1)
 
@@ -1055,6 +1060,7 @@ function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
+                        accepted1[idx] || continue
 
                         code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
                         accepted[idx] = is_success(code)
@@ -1067,7 +1073,7 @@ function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1092,6 +1098,7 @@ function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
+                        accepted[idx] || continue
 
                         code2 = track!(local_tracker2, P1[idx], 1)
                         if is_accepted(local_tracker2, code2)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -49,6 +49,7 @@ Base.@kwdef mutable struct WitnessSetsProgress
     is_membership_test::Bool = false
     is_monodromy::Bool = false
     is_finished::Bool = false
+    path_label::String = "Computing start solutions" # this is the initial stage of the u-homotopy
     current_path::Int = 0
     npaths::Int = 0
     current_task::Int = 0
@@ -163,6 +164,15 @@ function update_progress_paths!(progress::WitnessSetsProgress, i::Int, m::Int)
         showvalues = showvalues(progress),
     )
 end
+update_progress_path_label!(progress::Nothing, label::String) = nothing
+function update_progress_path_label!(progress::WitnessSetsProgress, label::String)
+    progress.path_label = label
+    PM.update!(
+        progress.progress_meter,
+        progress.current_hypersurface,
+        showvalues = showvalues(progress),
+    )
+end
 update_progress!(progress::Nothing, W::Union{WitnessPoints,WitnessSet}) = nothing
 function update_progress!(progress::WitnessSetsProgress, W::Union{WitnessPoints,WitnessSet})
     progress.degrees[codim(W)] = degree(W)
@@ -199,7 +209,7 @@ function showvalues(progress::WitnessSetsProgress)
             if progress.is_solving
                 push!(
                     text,
-                    ("Track paths", "$(progress.current_path) / $(progress.npaths)"),
+                    (progress.path_label, "$(progress.current_path) / $(progress.npaths)"),
                 )
             elseif progress.is_monodromy
                 push!(
@@ -840,6 +850,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         # is nothing left to resample, so we finish the sweep and keep the
         # starts that did pass the check.
         fail_fast = trial < ntrials
+        update_progress_path_label!(progress, "Computing start solutions")
         track_hom1_and_check_hom2_starts!(
             accepted,
             P1,
@@ -857,6 +868,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
     # `accepted` guards against undefined or rejected P1 entries. This matters
     # both after failed trials and when the final trial only validates a subset
     # of the starts.
+    update_progress_path_label!(progress, "Track paths")
     track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -972,10 +972,10 @@ function set_up_u_homotopy(
     F = fixed(System([f; h0], variables = vars, variable_groups = variable_groups); compile = false)
     G = fixed(System([f; h], variables = vars, variable_groups = variable_groups); compile = false)
 
-    Hom1 = linear_subspace_homotopy(F, L, L1)
+    Hom1 = linear_subspace_homotopy(F, L, L1; homogeneous = projective)
     Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
     projective && (Hom2 = on_affine_chart(Hom2))
-    Hom3 = linear_subspace_homotopy(G, L1, L2)
+    Hom3 = linear_subspace_homotopy(G, L1, L2; homogeneous = projective)
 
     return (Hom1, Hom2, Hom3), d
 end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2205,6 +2205,10 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     Fᵢ::Sys
     h::Expression
     u::Variable
+    projective::Bool
+    variable_groups::Union{Nothing,Vector{Vector{Variable}}}
+    ℓ::Expression
+    ℓ_coeffs::Vector{ComplexF64}
 
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
@@ -2212,7 +2216,7 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     progress::Union{IntersectProgress,Nothing}
 end
 
-function IntersectCache(u, f, F, h, EO, TO, progress)
+function IntersectCache(u, f, F, h, projective, variable_groups, ℓ, ℓ_coeffs, EO, TO, progress)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -2220,7 +2224,24 @@ function IntersectCache(u, f, F, h, EO, TO, progress)
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    IntersectCache(A, b, x0, y0, y, f, F, h, u, EO, TO, progress)
+    IntersectCache(
+        A,
+        b,
+        x0,
+        y0,
+        y,
+        f,
+        F,
+        h,
+        u,
+        projective,
+        variable_groups,
+        ℓ,
+        ℓ_coeffs,
+        EO,
+        TO,
+        progress,
+    )
 end
 
 
@@ -2290,6 +2311,7 @@ function _intersect(
 )
     @assert size(system(H), 1) == 1 "The second argument must be defined by a single polynomial."
     @assert size(system(W), 2) == size(system(H), 2) "Witness sets must be in the same ambient space."
+    W.projective == H.projective || throw(ArgumentError("Witness sets must both be affine or projective."))
 
     # progress bar
     if show_progress
@@ -2310,10 +2332,34 @@ function _intersect(
     n = ambient_dim(W.L)
     @unique_var u
     @unique_var vars[1:n]
-    W₁, W₂, Hᵤ, f, F, h, vars_u = prepare_for_u_homotopy(H, W, vars, u)
+    vars_u = [vars; u]
+    projective = W.projective
+    variable_groups = projective ? [vars_u] : nothing
+    ℓ_coeffs = randn(ComplexF64, n)
+    ℓ = sum(ℓ_coeffs .* vars)
+    W₁, W₂, Hᵤ, f, F, h = prepare_for_u_homotopy(
+        H,
+        W,
+        vars,
+        vars_u,
+        variable_groups,
+        projective,
+    )
 
     # cache
-    cache = IntersectCache(u, f, F, h, endgame_options, tracker_options, progress)
+    cache = IntersectCache(
+        u,
+        f,
+        F,
+        h,
+        projective,
+        variable_groups,
+        ℓ,
+        ℓ_coeffs,
+        endgame_options,
+        tracker_options,
+        progress,
+    )
 
     # intersect
     intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, kwargs...)
@@ -2321,12 +2367,15 @@ function _intersect(
     fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading)
 
     # return data 
-    G = fixed(System([f; h], variables = vars); compile = false)
+    G = fixed(
+        System([f; h], variables = vars, variable_groups = projective ? [vars] : nothing);
+        compile = false,
+    )
     P1, L1 = u_transform(W₁)
-    out = [WitnessSet(G, L1, P1)]
+    out = [WitnessSet(G, L1, P1; projective = projective)]
     if !isnothing(W₂)
         P2, L2 = u_transform(W₂)
-        push!(out, WitnessSet(G, L2, P2))
+        push!(out, WitnessSet(G, L2, P2; projective = projective))
 
     end
     filter!(X -> degree(X) > 0, out)
@@ -2337,15 +2386,14 @@ end
 
 
 
-function prepare_for_u_homotopy(H, W, vars, u)
+function prepare_for_u_homotopy(H, W, vars, vars_u, variable_groups, projective)
     # prepare polynomials 
     FH0 = deepcopy(System(system(H)))
     FW0 = deepcopy(System(system(W)))
     h = subs(expressions(FH0), variables(FH0) => vars)
     f = subs(expressions(FW0), variables(FW0) => vars)
-    vars_u = [vars; u]
-    FH = System(h, variables = vars_u)
-    FW = System(f, variables = vars_u)
+    FH = System(h, variables = vars_u, variable_groups = variable_groups)
+    FW = System(f, variables = vars_u, variable_groups = variable_groups)
 
     # prepare flags
     LW = linear_subspace(W)
@@ -2363,8 +2411,13 @@ function prepare_for_u_homotopy(H, W, vars, u)
         W₂ = WitnessPoints(flagW[2][1], flagW[2][2], Vector{Vector{ComplexF64}}())
     end
     Hᵤ =
-        WitnessSet(fixed(FH; compile = false), flagH[1][1], map(x -> [x; cH], solutions(H)))
+        WitnessSet(
+            fixed(FH; compile = false),
+            flagH[1][1],
+            map(x -> [x; cH], solutions(H));
+            projective = projective,
+        )
 
-    W₁, W₂, Hᵤ, f, fixed(FW; compile = false), first(h), vars_u
+    W₁, W₂, Hᵤ, f, fixed(FW; compile = false), first(h)
 end
 get_c(flag) = extrinsic((flag[1][1])).b[1] # the first entry of b is the right-hand side of "u=c"

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2227,6 +2227,7 @@ Base.@kwdef mutable struct IntersectProgress
     is_membership_test::Bool = false
     is_monodromy::Bool = false
     is_finished::Bool = false
+    path_label::String = "Track paths"
     current_task::Int = 0
     ntasks::Int = 0
     current_path::Int = 0
@@ -2294,6 +2295,12 @@ function update_progress_paths!(progress::IntersectProgress, i::Int, m::Int)
     progress.npaths = m
     PM.update!(progress.progress_meter, showvalues = showvalues(progress))
 end
+function start_progress_paths!(progress::IntersectProgress, label::String, m::Int)
+    progress.path_label = label
+    progress.current_path = 0
+    progress.npaths = m
+    PM.update!(progress.progress_meter, showvalues = showvalues(progress))
+end
 function finish_progress!(progress::IntersectProgress)
     progress.is_solving = false
     progress.is_membership_test = false
@@ -2305,8 +2312,11 @@ function showvalues(progress::IntersectProgress)
 
     if !progress.is_finished
         text = [("Status", "")]
-        if progress.is_solving
-            push!(text, ("Track paths", "$(progress.current_task)/$(progress.ntasks)"))
+        if progress.is_solving && progress.npaths > 0
+            push!(
+                text,
+                (progress.path_label, "$(progress.current_path) / $(progress.npaths)"),
+            )
         elseif progress.is_monodromy
             push!(
                 text,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -963,7 +963,7 @@ function set_up_u_homotopy(
 
     P, Q = get_num_den(h)
     d = degree(P)
-    if projective 
+    if projective
         h0 = u^d - ℓ^d
     else
         h0 = u^d - 1
@@ -977,8 +977,14 @@ function set_up_u_homotopy(
     L1 = rand_subspace(ambient_dim(L); dim = dim(L), affine = !projective)
     L2 = linear_subspace(X)
 
-    F = fixed(System([f; h0], variables = vars, variable_groups = variable_groups); compile = false)
-    G = fixed(System([f; h], variables = vars, variable_groups = variable_groups); compile = false)
+    F = fixed(
+        System([f; h0], variables = vars, variable_groups = variable_groups);
+        compile = false,
+    )
+    G = fixed(
+        System([f; h], variables = vars, variable_groups = variable_groups);
+        compile = false,
+    )
 
     Hom1 = linear_subspace_homotopy(F, L, L1; homogeneous = projective)
     Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
@@ -1330,8 +1336,7 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
-                        W_new = WitnessSet(G, L, P_certified; 
-                                                is_irreducible = true)
+                        W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         if length(P_certified) == length(orbit)
                             complete_orbit = orbit
                         else
@@ -1345,7 +1350,7 @@ function decompose_with_monodromy!(
                                 ),
                             )
                         end
-                        
+
                         push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)
                         d += length(P_certified) - length(complete_orbit)
@@ -2227,7 +2232,19 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     progress::Union{IntersectProgress,Nothing}
 end
 
-function IntersectCache(u, f, F, h, projective, variable_groups, ℓ, ℓ_coeffs, EO, TO, progress)
+function IntersectCache(
+    u,
+    f,
+    F,
+    h,
+    projective,
+    variable_groups,
+    ℓ,
+    ℓ_coeffs,
+    EO,
+    TO,
+    progress,
+)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -2322,7 +2339,8 @@ function _intersect(
 )
     @assert size(system(H), 1) == 1 "The second argument must be defined by a single polynomial."
     @assert size(system(W), 2) == size(system(H), 2) "Witness sets must be in the same ambient space."
-    W.projective == H.projective || throw(ArgumentError("Witness sets must both be affine or projective."))
+    W.projective == H.projective ||
+        throw(ArgumentError("Witness sets must both be affine or projective."))
 
     # progress bar
     if show_progress
@@ -2348,14 +2366,8 @@ function _intersect(
     variable_groups = projective ? [vars_u] : nothing
     ℓ_coeffs = randn(ComplexF64, n)
     ℓ = sum(ℓ_coeffs .* vars)
-    W₁, W₂, Hᵤ, f, F, h = prepare_for_u_homotopy(
-        H,
-        W,
-        vars,
-        vars_u,
-        variable_groups,
-        projective,
-    )
+    W₁, W₂, Hᵤ, f, F, h =
+        prepare_for_u_homotopy(H, W, vars, vars_u, variable_groups, projective)
 
     # cache
     cache = IntersectCache(
@@ -2421,13 +2433,12 @@ function prepare_for_u_homotopy(H, W, vars, vars_u, variable_groups, projective)
     else
         W₂ = WitnessPoints(flagW[2][1], flagW[2][2], Vector{Vector{ComplexF64}}())
     end
-    Hᵤ =
-        WitnessSet(
-            fixed(FH; compile = false),
-            flagH[1][1],
-            map(x -> [x; cH], solutions(H));
-            projective = projective,
-        )
+    Hᵤ = WitnessSet(
+        fixed(FH; compile = false),
+        flagH[1][1],
+        map(x -> [x; cH], solutions(H));
+        projective = projective,
+    )
 
     W₁, W₂, Hᵤ, f, fixed(FW; compile = false), first(h)
 end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -682,7 +682,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 threading = threading,
                 warning = false,
             )
-            # check if solutions remain, and if yes, take unique_points
+            # check if solutions remain
             if nsolutions(res) == 0
                 W.R = Vector{Vector{ComplexF64}}()
             else

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -844,7 +844,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         all(accepted) && break
     end
 
-    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
 
     nothing
 end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1293,7 +1293,7 @@ The core function for decomposing a witness set into irreducible components.
 function decompose_with_monodromy!(
     W,
     show_monodromy_progress,
-    options,
+    _options,
     max_iters,
     warning,
     progress,
@@ -1312,13 +1312,13 @@ function decompose_with_monodromy!(
     if dim(L) < n
         update_progress!(progress; is_monodromy = true)
 
-        options_with_trace, options_without_trace = options
-        MS_with_trace = MonodromySolver(G, L; compile = false, options = options_with_trace)
+        options, options_without_trace = _options
+        MS = MonodromySolver(G, L; compile = false, options = options)
         MS_without_trace =
             MonodromySolver(G, L; compile = false, options = options_without_trace)
-        initial_points = check_start_solutions(MS_with_trace, P, L)
+        initial_points = check_start_solutions(MS, P, L)
         res = monodromy_solve(
-            MS_with_trace,
+            MS,
             solution.(initial_points),
             L,
             seed;
@@ -1329,7 +1329,7 @@ function decompose_with_monodromy!(
         update_progress!(progress; is_monodromy = false)
         update_progress_npts!(progress, nindexed_solutions(res))
 
-        if warning && (trace(res) > options_with_trace.trace_test_tol)
+        if warning && (trace(res) > options.trace_test_tol)
             @warn "Trying to decompose non-complete set of witness points for codimension $(dim(L)) (trace test failed). Will try to compute the missing points. The output will contain all components, for which the trace test was successfull."
         end
 
@@ -1378,7 +1378,7 @@ function decompose_with_monodromy!(
 
                 P_orbit = non_complete_points[collect(orbit)]
                 res_orbit = monodromy_solve(
-                    MS_with_trace,
+                    MS,
                     P_orbit,
                     L,
                     seed;
@@ -1388,7 +1388,7 @@ function decompose_with_monodromy!(
                 )
                 update_progress!(progress; is_monodromy = false)
 
-                if trace(res_orbit) < options_with_trace.trace_test_tol
+                if trace(res_orbit) < options.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
@@ -1400,9 +1400,9 @@ function decompose_with_monodromy!(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
-                                    norm = options_with_trace.distance,
-                                    atol = something(options_with_trace.unique_points_atol, 1e-14),
-                                    rtol = something(options_with_trace.unique_points_rtol, 1e-8),
+                                    norm = options.distance,
+                                    atol = something(options.unique_points_atol, 1e-14),
+                                    rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
                             )
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -808,7 +808,7 @@ end
 # Hom1 moves the linear equation u = c to a random linear space L1 involving (x,u), where x are the variables of F.
 # Hom2 moves u^d - 1 to the new polynomial fᵢ with deg(fᵢ) = d.
 # Hom3 moves the linear space L1 to the linear space given by the initial witness sets. 
-# We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resampel L1. Only then track Hom2 and Hom3. 
+# We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resample L1. Only then track Hom2 and Hom3. 
 
 const HOM2_START_CHECK_TARGET = 0.95
 
@@ -834,19 +834,29 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
 
         fill!(accepted, false)
-        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
-        if !all(accepted)
-            fill!(accepted, false)
-            continue
-        end
-
-        # Hom1 only moves the slice. We still need to verify that its endpoints
-        # are usable starts for Hom2; otherwise resample L1 and try again.
-        fill!(accepted, false)
-        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
+        # Hom1 and the cheap Hom2 start check are paired: as soon as an
+        # intermediate slice produces a start that Hom2 cannot consume, the
+        # slice is considered bad and we resample it. On the final trial there
+        # is nothing left to resample, so we finish the sweep and keep the
+        # starts that did pass the check.
+        fail_fast = trial < ntrials
+        track_hom1_and_check_hom2_starts!(
+            accepted,
+            P1,
+            P,
+            roots,
+            trackers[1],
+            trackers[2],
+            progress,
+            threading,
+            fail_fast,
+        )
         all(accepted) && break
     end
 
+    # `accepted` guards against undefined or rejected P1 entries. This matters
+    # both after failed trials and when the final trial only validates a subset
+    # of the starts.
     track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing
@@ -915,19 +925,39 @@ function set_up_u_homotopy(W, f, X, h, vars, u)
 end
 
 
-function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
+function track_hom1_and_check_hom2_starts!(
+    accepted,
+    P1,
+    P,
+    roots,
+    tracker1,
+    tracker2,
+    progress,
+    threading,
+    fail_fast,
+)
     if threading
-        threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
+        threaded_track_hom1_and_check_hom2_starts!(
+            accepted,
+            P1,
+            P,
+            roots,
+            tracker1,
+            tracker2,
+            progress,
+            fail_fast,
+        )
     else
-        serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
-    end
-end
-
-function check_hom2_starts!(accepted, P1, tracker, progress, threading)
-    if threading
-        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
-    else
-        serial_check_hom2_starts!(accepted, P1, tracker, progress)
+        serial_track_hom1_and_check_hom2_starts!(
+            accepted,
+            P1,
+            P,
+            roots,
+            tracker1,
+            tracker2,
+            progress,
+            fail_fast,
+        )
     end
 end
 
@@ -939,33 +969,39 @@ function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threadi
     end
 end
 
-function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
+function serial_track_hom1_and_check_hom2_starts!(
+    accepted,
+    P1,
+    P,
+    roots,
+    tracker1,
+    tracker2,
+    progress,
+    fail_fast,
+)
     l_start = length(P) * length(roots)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
 
         p = start_solution(P, roots, i)
-        code = track!(tracker, p, 1)
-        if is_accepted(tracker, code)
-            accepted[i] = true
-            P1[i] = solution(tracker)
-        else
+        code1 = track!(tracker1, p, 1)
+        if !is_accepted(tracker1, code1)
             accepted[i] = false
+            fail_fast && break
+            continue
         end
-    end
 
-    nothing
-end
+        p1 = solution(tracker1)
+        code2 = track!(tracker2.tracker, p1, 1, HOM2_START_CHECK_TARGET)
+        if !is_success(code2)
+            accepted[i] = false
+            fail_fast && break
+            continue
+        end
 
-function serial_check_hom2_starts!(accepted, P1, tracker, progress)
-    l_start = length(P1)
-
-    for i = 1:l_start
-        update_progress_paths!(progress, i, l_start)
-
-        code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
-        accepted[i] = is_success(code)
+        accepted[i] = true
+        P1[i] = p1
     end
 
     nothing
@@ -991,23 +1027,35 @@ function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     nothing
 end
 
-function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
+function threaded_track_hom1_and_check_hom2_starts!(
+    accepted,
+    P1,
+    P,
+    roots,
+    tracker1,
+    tracker2,
+    progress,
+    fail_fast,
+)
 
     l_P = length(P)
     l_roots = length(roots)
     l_start = l_P * l_roots
 
     nthr = Threads.nthreads()
-    trackers = [deepcopy(tracker) for _ = 1:nthr]
+    trackers1 = [deepcopy(tracker1) for _ = 1:nthr]
+    trackers2 = [deepcopy(tracker2.tracker) for _ = 1:nthr]
 
     progress_lock = ReentrantLock()
 
     next_idx = Threads.Atomic{Int}(1)
+    failed = Threads.Atomic{Bool}(false)
     Threads.@sync begin
         for tid = 1:nthr
-            let local_tracker = trackers[tid]
+            let local_tracker1 = trackers1[tid], local_tracker2 = trackers2[tid]
                 Threads.@spawn begin
                     while true
+                        fail_fast && failed[] && break
 
                         idx = Threads.atomic_add!(next_idx, 1)
                         if idx > l_start
@@ -1019,49 +1067,26 @@ function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
                         end
 
                         p = start_solution(P, roots, idx)
-                        code = track!(local_tracker, p, 1)
-                        if is_accepted(local_tracker, code)
-                            accepted[idx] = true
-                            P1[idx] = solution(local_tracker)
+                        code1 = track!(local_tracker1, p, 1)
+                        if is_accepted(local_tracker1, code1)
+                            p1 = solution(local_tracker1)
+                            code2 = track!(
+                                local_tracker2,
+                                p1,
+                                1,
+                                HOM2_START_CHECK_TARGET,
+                            )
+                            if is_success(code2)
+                                accepted[idx] = true
+                                P1[idx] = p1
+                            else
+                                accepted[idx] = false
+                                fail_fast && (failed[] = true)
+                            end
                         else
                             accepted[idx] = false
+                            fail_fast && (failed[] = true)
                         end
-                    end
-                end
-            end
-        end
-    end
-
-    nothing
-end
-
-function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
-
-    l_start = length(P1)
-
-    nthr = Threads.nthreads()
-    trackers = [deepcopy(tracker.tracker) for _ = 1:nthr]
-
-    progress_lock = ReentrantLock()
-
-    next_idx = Threads.Atomic{Int}(1)
-    Threads.@sync begin
-        for tid = 1:nthr
-            let local_tracker = trackers[tid]
-                Threads.@spawn begin
-                    while true
-
-                        idx = Threads.atomic_add!(next_idx, 1)
-                        if idx > l_start
-                            break
-                        end
-
-                        lock(progress_lock) do
-                            update_progress_paths!(progress, idx, l_start)
-                        end
-
-                        code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
-                        accepted[idx] = is_success(code)
                     end
                 end
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -657,9 +657,11 @@ function initialize_hypersurfaces(
         if isnothing(res)
             return nothing
         end
-        S =
-            projective && qᵢ == 1 ? map(x -> [x; 0], solutions(res, only_nonsingular = true)) :
-            solutions(res, only_nonsingular = true)
+        if projective && qᵢ == 1
+            S = map(x -> [x; 0], solutions(res, only_nonsingular = false))
+        else
+            S = solutions(res, only_nonsingular = false)
+        end
         out[i] = WitnessSet(h, L, S)
     end
     out
@@ -723,7 +725,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
             if nsolutions(res) == 0
                 W.R = Vector{Vector{ComplexF64}}()
             else
-                W.R = unique_points(solutions(res))
+                W.R = solutions(res; only_nonsingular = false)
             end
             update_progress!(progress, W)
         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1820,7 +1820,7 @@ This function decomposes a [`WitnessSet`](@ref) or a vector of [`WitnessSet`](@r
 * `show_progress = true`: indicate whether a progress bar should be displayed.
 * `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `decompose`.
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
-* `max_iters = 200`: maximal number of iterations for the decomposition step.
+* `max_iters = 500`: maximal number of iterations for the decomposition step.
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -1860,7 +1860,7 @@ function decompose(
     show_progress::Bool = true,
     show_monodromy_progress::Bool = false,
     monodromy_options::MonodromyOptions = MonodromyOptions(),
-    max_iters::Int = 200,
+    max_iters::Int = 500,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -2142,7 +2142,7 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 * `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of each substep.
 * `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed. 
 * `show_monodromy_for_decompose_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`decompose`](@ref) should be displayed.
-* `max_iters = 200`: maximal number of iterations for the decomposition step.
+* `max_iters = 500`: maximal number of iterations for the decomposition step.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).` This option is used for [`regeneration`](@ref).
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
@@ -2206,7 +2206,7 @@ function numerical_irreducible_decomposition(
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
-    max_iters::Int = 200,
+    max_iters::Int = 500,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
     max_trials_u_homotopy::Int = 5,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -829,19 +829,19 @@ end
 function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
     l_start = length(P) * length(roots)
     P1 = Vector{Vector{ComplexF64}}(undef, l_start)
-    accepted1 = falses(l_start)
-    accepted2 = falses(l_start)
+    accepted = falses(l_start)
 
     ntrials = max(cache.max_trials_u_homotopy, 1)
     for trial = 1:ntrials
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
-        fill!(accepted1, false)
-        fill!(accepted2, false)
+        
+        fill!(accepted, false)
+        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
+        all(accepted) && break
 
-        track_hom1!(P1, accepted1, P, roots, trackers[1], progress, threading)
-        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
-
-        all(accepted2) && break
+        fill!(accepted, false)
+        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
+        all(accepted) && break
     end
 
     track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
@@ -912,31 +912,31 @@ function set_up_u_homotopy(W, f, X, h, vars, u)
 end
 
 
-function track_hom1!(P1, accepted1, P, roots, tracker, progress, threading)
+function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
     if threading
-        threaded_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+        threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
     else
-        serial_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+        serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     end
 end
 
-function check_hom2_starts!(accepted2, P1, accepted1, tracker, progress, threading)
+function check_hom2_starts!(accepted, P1, tracker, progress, threading)
     if threading
-        threaded_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     else
-        serial_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+        serial_check_hom2_starts!(accepted, P1, tracker, progress)
     end
 end
 
-function track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     end
 end
 
-function serial_track_hom1!(P1, accepted, P, roots, tracker, progress)
+function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     l_start = length(P) * length(roots)
 
     for i = 1:l_start
@@ -955,37 +955,31 @@ function serial_track_hom1!(P1, accepted, P, roots, tracker, progress)
     nothing
 end
 
-function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
 
-        if accepted1[i]
-            code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
-            accepted[i] = is_success(code)
-        else
-            accepted[i] = false
-        end
+        code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
+        accepted[i] = is_success(code)
     end
 
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
 
-        if accepted2[i]
-            code2 = track!(tracker2, P1[i], 1)
-            if is_accepted(tracker2, code2)
-                p2 = solution(tracker2)
-                code3 = track!(tracker3, p2, 1)
-                if is_accepted(tracker3, code3)
-                    push!(X, solution(tracker3))
-                end
+        code2 = track!(tracker2, P1[i], 1)
+        if is_accepted(tracker2, code2)
+            p2 = solution(tracker2)
+            code3 = track!(tracker3, p2, 1)
+            if is_accepted(tracker3, code3)
+                push!(X, solution(tracker3))
             end
         end
     end
@@ -993,7 +987,7 @@ function serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
     nothing
 end
 
-function threaded_track_hom1!(P1, accepted, P, roots, tracker, progress)
+function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
 
     l_P = length(P)
     l_roots = length(roots)
@@ -1037,7 +1031,7 @@ function threaded_track_hom1!(P1, accepted, P, roots, tracker, progress)
     nothing
 end
 
-function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
 
     l_start = length(P1)
 
@@ -1062,13 +1056,8 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
                             update_progress_paths!(progress, idx, l_start)
                         end
 
-                        if accepted1[idx]
-                            code =
-                                track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
-                            accepted[idx] = is_success(code)
-                        else
-                            accepted[idx] = false
-                        end
+                        code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
+                        accepted[idx] = is_success(code)
                     end
                 end
             end
@@ -1078,7 +1067,7 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1104,16 +1093,14 @@ function threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progres
                             update_progress_paths!(progress, idx, l_start)
                         end
 
-                        if accepted2[idx]
-                            code2 = track!(local_tracker2, P1[idx], 1)
-                            if is_accepted(local_tracker2, code2)
-                                p2 = solution(local_tracker2)
-                                code3 = track!(local_tracker3, p2, 1)
-                                if is_accepted(local_tracker3, code3)
-                                    q = solution(local_tracker3)
-                                    lock(progress_lock) do
-                                        push!(X, q)
-                                    end
+                        code2 = track!(local_tracker2, P1[idx], 1)
+                        if is_accepted(local_tracker2, code2)
+                            p2 = solution(local_tracker2)
+                            code3 = track!(local_tracker3, p2, 1)
+                            if is_accepted(local_tracker3, code3)
+                                q = solution(local_tracker3)
+                                lock(progress_lock) do
+                                    push!(X, q)
                                 end
                             end
                         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1526,33 +1526,35 @@ function decompose_with_monodromy!(
                        allow_degree1_iter ≥ 5 ||
                        iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
-
-                        # Check whether inner monodromy jumped into an already-certified component.
-                        # If so, the trace test result is unreliable — skip this orbit.
-                        if any(
-                            p -> !isnothing(search_in_radius(certified_up, p, atol)),
-                            P_certified,
-                        )
-                            continue
-                        end
-
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
                         if length(P_certified) > length(clean_orbit)
-                            # Genuine new points found — compute their indices in non_complete_points,
-                            # excluding any phantom indices that might have matched numerically.
-                            complete_orbit = setdiff(
+                            # Inner monodromy found new points beyond the starting orbit.
+                            # First match them against non_complete_points.
+                            matched = setdiff(
                                 Set(
                                     matching_indices(
                                         non_complete_points,
                                         P_certified;
                                         atol = atol,
-                                        rtol = rtol,
+                                        rtol = something(options.unique_points_rtol, 1e-8),
                                     ),
                                 ),
                                 phantom_indices,
                             )
-                            allow_degree1_iter = 0
+                            # Only check certified_up when matching_indices left points unaccounted for.
+                            # Unmatched points are either genuine new discoveries or path-jumping phantoms.
+                            diff = length(P_certified) - length(matched)
+                            if diff > 0 && any(
+                                p -> !isnothing(search_in_radius(certified_up, p, atol)),
+                                P_certified,
+                            )
+                                continue
+                            end
+                            complete_orbit = matched
+                            if diff == 1
+                                allow_degree1_iter = 0
+                            end
                         else
                             complete_orbit = clean_orbit
                         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -438,7 +438,7 @@ function _regeneration(
     # prepare codim witness sets for the output
     # internally we represent a witness superset by WitnessPoints
     # the i-th witness superset out[i] is for codimension i
-    out = initialize_witness_sets(codim, n; projective = projective)
+    out = initialize_witness_sets(codim, n; affine = !projective)
 
     # we compute witness (super)sets for the hypersurfaces f[1]=0,...,f[c]=0.
     # it is covenient to use the WitnessSet wrapper here, because this also keeps track of the equation
@@ -570,69 +570,32 @@ function get_flag(iter, L₀)
     # type 1 does not use u, so we set the last column to zero
     Aᵤ = [A₀ zeros(n - 1)]
     bᵤ = b₀
-    # type 2 sets the linear equation u=c. We add this as the first equation
-    c = randn(ComplexF64)
+    # type 2 sets the linear equation u=c. If L₀ is linear, keep the augmented
+    # subspaces linear as well.
+    c = is_linear(L₀) ? zero(ComplexF64) : randn(ComplexF64)
     A = [zeros(1, m) 1.0; A₀ zeros(n - 1)]
     b = [c; b₀]
 
     map(iter) do i
-        j = i + 1
         # type 1 linear equation for out[i] takes the last i rows of Aᵤ
-        Eᵤ = ExtrinsicDescription(Aᵤ[i:end, :], bᵤ[i:end]; orthonormal = true)
+        idx = i <= n - 1 ? (i:n-1) : (n:n-1)
+        Eᵤ = ExtrinsicDescription(Aᵤ[idx, :], bᵤ[idx]; orthonormal = true)
         Lᵤ = LinearSubspace(Eᵤ)
         # type 2 linear equation for out[i] takes the last i-1 rows and the first row of A
-        E = ExtrinsicDescription(A[[1; j:n], :], b[[1; j:n]]; orthonormal = true)
+        rows = [1; idx .+ 1]
+        E = ExtrinsicDescription(A[rows, :], b[rows]; orthonormal = true)
         L = LinearSubspace(E)
         L, Lᵤ
     end
 end
-function get_projective_flag(iter, L₀)
-    A₀ = extrinsic(L₀).A
-    r = size(A₀, 1)
-    m = size(A₀, 2)
-    Aᵤ = [A₀ zeros(r)]
 
-    map(iter) do i
-        Aᵤᵢ = i <= r ? Aᵤ[i:r, :] : zeros(eltype(Aᵤ), 0, m + 1)
-        Lᵤ = LinearSubspace(
-            ExtrinsicDescription(Aᵤᵢ, zeros(ComplexF64, size(Aᵤᵢ, 1)); orthonormal = true),
-        )
-
-        idx = i <= r ? (i:r) : ((r+1):r)
-        Aᵢ = [zeros(1, m) 1.0; A₀[idx, :] zeros(length(idx), 1)]
-        L = LinearSubspace(
-            ExtrinsicDescription(Aᵢ, zeros(ComplexF64, size(Aᵢ, 1)); orthonormal = true),
-        )
-        L, Lᵤ
-    end
-end
-
-function initial_projective_slice(n)
-    if n == 2
-        LinearSubspace(zeros(ComplexF64, 0, n))
-    else
-        rand_subspace(n; dim = 2, affine = false)
-    end
-end
-
-function projective_drop_u(L::LinearSubspace)
-    E = extrinsic(L)
-    A = E.A[2:end, 1:(end-1)]
-    b = E.b[2:end]
-    LinearSubspace(ExtrinsicDescription(A, b; orthonormal = false))
-end
-
-function linear_equations(L::LinearSubspace, vars)
-    A = extrinsic(L).A
-    map(1:size(A, 1)) do i
-        sum(A[i, j] * vars[j] for j = 1:length(vars))
-    end
-end
-
-function initialize_witness_sets(codim, n; projective::Bool = false)
-    # we need a flag containing a linear space of dimension 1
-    L₀ = projective ? initial_projective_slice(n) : rand_subspace(n; dim = 1)
-    flag = projective ? get_projective_flag(1:codim, L₀) : get_flag(1:codim, L₀)
+function initialize_witness_sets(codim, n; affine::Bool = true)
+    # we need an initial slice from which the u-regeneration flag is derived
+    dim = affine ? 1 : 2
+    L₀ =
+        dim == n ? LinearSubspace(zeros(ComplexF64, 0, n)) :
+        rand_subspace(n; dim = dim, affine = affine)
+    flag = get_flag(1:codim, L₀)
 
     map(flag) do F
         L, Lᵤ = F
@@ -659,9 +622,14 @@ function initialize_hypersurfaces(
         xvars = vars[1:(end-1)]
         projective = !isnothing(variable_groups)
         if projective
-            Lx = projective_drop_u(L)
+            E = extrinsic(L)
+            A = E.A[2:end, 1:(end-1)]
+            b = E.b[2:end]
+            L_eqs = map(1:size(A, 1)) do i
+                sum(A[i, j] * xvars[j] for j = 1:length(xvars)) - b[i]
+            end
             res = solve(
-                System([pᵢ; linear_equations(Lx, xvars)], variables = xvars);
+                System([pᵢ; L_eqs], variables = xvars);
                 start_system = :total_degree,
                 show_progress = false,
                 threading = threading,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1454,7 +1454,9 @@ function decompose_with_monodromy!(
                 initial_orbits = non_complete_orbits,
             )
 
-            # increase the degree1 check only if there are other orbits
+            # update the degree1 check only if there are no orbits of degree > 1
+            # we want to check degree 1 component 
+            # only if there is nothing else to classify
             if all(o -> length(o) == 1, orbits)
                 allow_degree1_iter += 1
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1442,9 +1442,11 @@ function decompose_with_monodromy!(
             update_progress_npts!(progress, k)
 
             # If monodromy deduplicated starting solutions, the cached orbit indices are
-            # stale (they reference the old count). Reset to avoid a BoundsError.
+            # stale (they reference the old count). Reset to avoid a BoundsError
+            # also reset the degree 1 counter in this case
             if length(non_complete_points) < prev_count
                 non_complete_orbits = Vector{Set{Int}}()
+                allow_degree1_iter = 0
             end
 
             # Get orbits from monodromy result

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1476,19 +1476,8 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
-                        # Near-singular solutions tracked in monodromy loops can have
-                        # poor accuracy (~1e-10 error). If they evade monodromy's 
-                        # internal deduplication tolerance, 
-                        # remove near-duplicates here before
-                        # computing the degree of the certified component.
-                        if length(P_certified) > 1
-                            P_certified = unique_points(
-                                P_certified;
-                                atol = something(options.unique_points_atol, 1e-14),
-                                rtol = something(options.unique_points_rtol, sqrt(eps())),
-                            )
-                        end
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
+                        
                         # matching_indices is only needed when P_certified found more
                         # witness points than orbit contained. When P_certified has
                         # fewer points (inner monodromy deduplicated some starts), the

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1415,7 +1415,6 @@ function decompose_with_monodromy!(
 
         while !isempty(non_complete_points)
             iter += 1
-            allow_degree1_iter += 1
             if iter > max_iters
                 break
             end
@@ -1455,6 +1454,10 @@ function decompose_with_monodromy!(
                 initial_orbits = non_complete_orbits,
             )
 
+            # increase the degree1 check only if there are other orbits
+            if all(o -> length(o) == 1, orbits)
+                allow_degree1_iter += 1
+            end
             complete_orbits = Vector{Set{Int}}()
 
             for orbit in orbits
@@ -1477,7 +1480,7 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 10. 
                     # Single orobits tend to have small trace, even if their points are on a irreducible component of degree > 1.
                     # allow_degree1_iter is reset once we we find new points 
-                    if length(orbit) > 1 || allow_degree1_iter ≥ 10 || iter ≥ max_iters - 1
+                    if length(orbit) > 1 || allow_degree1_iter ≥ 5 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -287,7 +287,20 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     progress::Union{WitnessSetsProgress,Nothing}
 end
 
-function RegenerationCache(u, f, F, h, codim, projective, ℓ, ℓ_coeffs, max_trials_u_homotopy, EO, TO, progress)
+function RegenerationCache(
+    u,
+    f,
+    F,
+    h,
+    codim,
+    projective,
+    ℓ,
+    ℓ_coeffs,
+    max_trials_u_homotopy,
+    EO,
+    TO,
+    progress,
+)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -808,7 +821,8 @@ function intersect_with_hypersurface!(
     # Step 2:
     # the points in P_next are used as starting points for a homotopy.
     # where u^d-1 (u is the extra variable in u-regeneration) is deformed into g 
-    u_data, d = set_up_u_homotopy(W, f, X, h, vars, u; projective = cache.projective, ℓ = cache.ℓ)
+    u_data, d =
+        set_up_u_homotopy(W, f, X, h, vars, u; projective = cache.projective, ℓ = cache.ℓ)
     trackers = initialize_u_homotopy_trackers(u_data, cache)
 
 
@@ -911,7 +925,8 @@ const HOM2_START_CHECK_TARGET = 0.95
 is_accepted(T::EndgameTracker, code) = is_success(code) && !T.state.singular
 
 function scaling(p, ℓ_coeffs)
-    isnothing(ℓ_coeffs) ? one(ComplexF64) : sum(ℓ_coeffs[j] * p[j] for j = 1:length(ℓ_coeffs))
+    isnothing(ℓ_coeffs) ? one(ComplexF64) :
+    sum(ℓ_coeffs[j] * p[j] for j = 1:length(ℓ_coeffs))
 end
 
 function start_solution(P, roots, idx, ℓ_coeffs = nothing)
@@ -1430,7 +1445,7 @@ The core function for decomposing a witness set into irreducible components.
 function decompose_with_monodromy!(
     W,
     show_monodromy_progress,
-    _options,
+    options,
     max_iters,
     warning,
     progress,
@@ -1449,10 +1464,7 @@ function decompose_with_monodromy!(
     if dim(L) < n
         update_progress!(progress; is_monodromy = true)
 
-        options, options_without_trace = _options
         MS = MonodromySolver(G, L; compile = false, options = options)
-        MS_without_trace =
-            MonodromySolver(G, L; compile = false, options = options_without_trace)
         initial_points = check_start_solutions(MS, P, L)
         res = monodromy_solve(
             MS,
@@ -1463,6 +1475,7 @@ function decompose_with_monodromy!(
             show_progress = show_monodromy_progress,
             progress = show_monodromy_progress ? nothing : progress,
         )
+
         update_progress!(progress; is_monodromy = false)
         update_progress_npts!(progress, nindexed_solutions(res))
 
@@ -1485,7 +1498,7 @@ function decompose_with_monodromy!(
 
             update_progress!(progress; is_monodromy = true)
             res = monodromy_solve(
-                MS_without_trace, # without trace to populate the permutation matrix
+                MS,
                 non_complete_points,
                 L,
                 seed;
@@ -1803,7 +1816,7 @@ function decompose_with_monodromy_options(
     # we need two copies of the options.
     # one with trace test
     # one without to run monodromy populating the permutation matrix
-    options_with_trace = MonodromyOptions(;
+    options = MonodromyOptions(;
         permutations = true,
         trace_test = true,
         single_loop_per_start_solution = true,
@@ -1825,30 +1838,8 @@ function decompose_with_monodromy_options(
         unique_points_atol = something(M.unique_points_atol, atol),
         unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
-    options_without_trace = MonodromyOptions(;
-        permutations = true,
-        trace_test = false,
-        single_loop_per_start_solution = true,
-        check_startsolutions = false,
-        group_actions = M.group_actions,
-        loop_finished_callback = M.loop_finished_callback,
-        parameter_sampler = M.parameter_sampler,
-        equivalence_classes = M.equivalence_classes,
-        duplicate_check = M.duplicate_check,
-        certification_max_precision = M.certification_max_precision,
-        certification_refine_solution = M.certification_refine_solution,
-        trace_test_tol = M.trace_test_tol,
-        target_solutions_count = M.target_solutions_count,
-        timeout = M.timeout,
-        min_solutions = M.min_solutions,
-        max_loops_no_progress = M.max_loops_no_progress,
-        reuse_loops = M.reuse_loops,
-        distance = M.distance,
-        unique_points_atol = something(M.unique_points_atol, atol),
-        unique_points_rtol = something(M.unique_points_rtol, rtol),
-    )
 
-    options_with_trace, options_without_trace
+    options
 end
 
 
@@ -2479,7 +2470,19 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     progress::Union{IntersectProgress,Nothing}
 end
 
-function IntersectCache(u, f, F, h, projective, ℓ, ℓ_coeffs, max_trials_u_homotopy, EO, TO, progress)
+function IntersectCache(
+    u,
+    f,
+    F,
+    h,
+    projective,
+    ℓ,
+    ℓ_coeffs,
+    max_trials_u_homotopy,
+    EO,
+    TO,
+    progress,
+)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -2487,7 +2490,24 @@ function IntersectCache(u, f, F, h, projective, ℓ, ℓ_coeffs, max_trials_u_ho
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    IntersectCache(A, b, x0, y0, y, f, F, h, u, projective, ℓ, ℓ_coeffs, max_trials_u_homotopy, EO, TO, progress)
+    IntersectCache(
+        A,
+        b,
+        x0,
+        y0,
+        y,
+        f,
+        F,
+        h,
+        u,
+        projective,
+        ℓ,
+        ℓ_coeffs,
+        max_trials_u_homotopy,
+        EO,
+        TO,
+        progress,
+    )
 end
 
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -49,7 +49,7 @@ Base.@kwdef mutable struct WitnessSetsProgress
     is_membership_test::Bool = false
     is_monodromy::Bool = false
     is_finished::Bool = false
-    path_label::String = "Computing start solutions" # this is the initial stage of the u-homotopy
+    path_label::String = "Track paths"
     current_path::Int = 0
     npaths::Int = 0
     current_task::Int = 0
@@ -138,6 +138,9 @@ end
 update_progress_hypersurface!(progress::Nothing, i::Int) = nothing
 function update_progress_hypersurface!(progress::WitnessSetsProgress, i::Int)
     progress.current_hypersurface = i
+    progress.current_path = 0
+    progress.npaths = 0
+    progress.path_label = "Track paths"
     PM.update!(
         progress.progress_meter,
         progress.current_hypersurface,
@@ -167,6 +170,13 @@ end
 update_progress_path_label!(progress::Nothing, label::String) = nothing
 function update_progress_path_label!(progress::WitnessSetsProgress, label::String)
     progress.path_label = label
+    nothing
+end
+start_progress_paths!(progress::Nothing, label::String, m::Int) = nothing
+function start_progress_paths!(progress::WitnessSetsProgress, label::String, m::Int)
+    progress.path_label = label
+    progress.current_path = 0
+    progress.npaths = m
     PM.update!(
         progress.progress_meter,
         progress.current_hypersurface,
@@ -206,7 +216,7 @@ function showvalues(progress::WitnessSetsProgress)
                     "$(progress.current_hypersurface) / $(progress.nhypersurfaces)",
                 ),
             )
-            if progress.is_solving
+            if progress.is_solving && progress.npaths > 0
                 push!(
                     text,
                     (progress.path_label, "$(progress.current_path) / $(progress.npaths)"),
@@ -850,7 +860,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         # is nothing left to resample, so we finish the sweep and keep the
         # starts that did pass the check.
         fail_fast = trial < ntrials
-        update_progress_path_label!(progress, "Computing start solutions")
+        start_progress_paths!(progress, "Computing start solutions", l_start)
         track_hom1_and_check_hom2_starts!(
             accepted,
             P1,
@@ -868,7 +878,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
     # `accepted` guards against undefined or rejected P1 entries. This matters
     # both after failed trials and when the final trial only validates a subset
     # of the starts.
-    update_progress_path_label!(progress, "Track paths")
+    start_progress_paths!(progress, "Track paths", l_start)
     track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing
@@ -1082,12 +1092,7 @@ function threaded_track_hom1_and_check_hom2_starts!(
                         code1 = track!(local_tracker1, p, 1)
                         if is_accepted(local_tracker1, code1)
                             p1 = solution(local_tracker1)
-                            code2 = track!(
-                                local_tracker2,
-                                p1,
-                                1,
-                                HOM2_START_CHECK_TARGET,
-                            )
+                            code2 = track!(local_tracker2, p1, 1, HOM2_START_CHECK_TARGET)
                             if is_success(code2)
                                 accepted[idx] = true
                                 P1[idx] = p1

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -493,7 +493,9 @@ function _regeneration(
                         monodromy_options,
                         cache,
                         show_monodromy_progress,
-                        threading,
+                        threading;
+                        atol = atol,
+                        rtol = rtol,
                     )
 
                     update_progress!(progress)
@@ -635,7 +637,7 @@ function intersect_all!(out, H, cache; kwargs...)
     end
 end
 
-function fill_up!(out, monodromy_options, cache, show_monodromy_progress, threading)
+function fill_up!(out, monodromy_options, cache, show_monodromy_progress, threading; atol = 1e-14, rtol = sqrt(eps()))
     progress = cache.progress
     Fᵢ = cache.Fᵢ
 
@@ -662,7 +664,12 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
             if nsolutions(res) == 0
                 W.R = Vector{Vector{ComplexF64}}()
             else
-                W.R = solution.(results(res))
+                sols = solution.(results(res))
+                # Near-singular solutions tracked in monodromy loops can have poor
+                # accuracy (~1e-10 error), which is too large for monodromy's internal
+                # add! tolerance (1e-14 * norm). Deduplicate here with the wider
+                # regeneration tolerances to catch such near-duplicates.
+                W.R = length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
             end
             update_progress!(progress, W)
         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1479,32 +1479,54 @@ function decompose_with_monodromy!(
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
-                        # matching_indices is only needed when P_certified found more
-                        # witness points than orbit contained. When P_certified has
-                        # fewer points (inner monodromy deduplicated some starts), the
-                        # full orbit is still complete — collapsed elements were just
+                        # when P_certified found more witness points than orbit contained,
+                        # there can be two reasons
+                        # (1) path jumping
+                        # (2) we found genuine new points 
+                        # we first check path jumping using has_point_in_decomposition
+                        # if this returns false, run matching_indices to find the correct indices
+                        # of the points in P_certified
+                        # if P_certified has fewer points (inner monodromy deduplicated some starts), the full orbit is still complete — collapsed elements were just
                         # numerical duplicates on the same component.
                         if length(P_certified) > length(orbit)
-                            complete_orbit = Set(
-                                matching_indices(
-                                    non_complete_points,
-                                    P_certified;
-                                    atol = something(options.unique_points_atol, 1e-14),
-                                    rtol = something(options.unique_points_rtol, 1e-8),
-                                ),
+                            # check if the extra points in P_certified came from path 
+                            # jumping by comparing them to the points in the completed decompositions
+                            has_duplicate = has_point_in_decomposition(
+                                P_certified,
+                                decomposition;
+                                atol = something(options.unique_points_atol, 1e-14),
+                                rtol = something(options.unique_points_rtol, 1e-8),
                             )
-                            allow_degree1_iter = 0
+
+                            if !has_duplicate
+                                # if we have genuine new points find their indices
+                                complete_orbit = Set(
+                                    matching_indices(
+                                        non_complete_points,
+                                        P_certified;
+                                        atol = something(options.unique_points_atol, 1e-14),
+                                        rtol = something(options.unique_points_rtol, 1e-8),
+                                    ),
+                                )
+                                # if we have genuine new points restart the degree 1 check 
+                                allow_degree1_iter = 0
+                            end
                         else
+                            has_duplicate = false
                             complete_orbit = orbit
                         end
 
-                        push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)
-                        d += length(P_certified) - length(complete_orbit)
                         k = k - length(complete_orbit)
-
-                        update_progress!(progress, W_new)
                         update_progress_npts!(progress, k)
+
+                        # put a new witness set into decomposition
+                        # only if has_duplicate == false
+                        if !has_duplicate
+                            push!(decomposition, W_new)
+                            d += length(P_certified) - length(complete_orbit)
+                            update_progress!(progress, W_new)
+                        end
                     end
                 end
             end
@@ -1672,6 +1694,16 @@ function merge_sets(sets)
         end
     end
     return collect(values(result))
+end
+
+# check if we have found points that are already classifiedxw
+function has_point_in_decomposition(P, decomposition; atol, rtol)
+    any(P) do p
+        rad = max(atol, norm(p, Inf) * rtol)
+        any(decomposition) do W
+            any(q -> distance(p, q, InfNorm()) ≤ rad, points(W))
+        end
+    end
 end
 
 # find indices of newly detected points

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1477,7 +1477,7 @@ function decompose_with_monodromy!(
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
-                        
+
                         # matching_indices is only needed when P_certified found more
                         # witness points than orbit contained. When P_certified has
                         # fewer points (inner monodromy deduplicated some starts), the

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -637,7 +637,15 @@ function intersect_all!(out, H, cache; kwargs...)
     end
 end
 
-function fill_up!(out, monodromy_options, cache, show_monodromy_progress, threading; atol = 1e-14, rtol = sqrt(eps()))
+function fill_up!(
+    out,
+    monodromy_options,
+    cache,
+    show_monodromy_progress,
+    threading;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
     progress = cache.progress
     Fᵢ = cache.Fᵢ
 
@@ -654,7 +662,12 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 Fᵢ,
                 W.R,
                 linear_subspace(W);
-                options = regeneration_monodromy_options(monodromy_options, W; atol = atol, rtol = rtol),
+                options = regeneration_monodromy_options(
+                    monodromy_options,
+                    W;
+                    atol = atol,
+                    rtol = rtol,
+                ),
                 show_progress = show_monodromy_progress,
                 progress = show_monodromy_progress ? nothing : progress,
                 threading = threading,
@@ -669,14 +682,20 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 # poor accuracy (~1e-10 error). If they evade monodromy's 
                 # internal deduplication tolerance, 
                 # remove near-duplicates here before continuing
-                W.R = length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
+                W.R =
+                    length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
             end
             update_progress!(progress, W)
         end
     end
 end
 
-function regeneration_monodromy_options(M::MonodromyOptions, W; atol = 1e-14, rtol = sqrt(eps()))
+function regeneration_monodromy_options(
+    M::MonodromyOptions,
+    W;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
 
     MonodromyOptions(;
         permutations = false,
@@ -1725,7 +1744,11 @@ function get_orbits_from_monodromy_permutations(
     orbits
 end
 
-function decompose_with_monodromy_options(M::MonodromyOptions; atol = 1e-14, rtol = sqrt(eps()))
+function decompose_with_monodromy_options(
+    M::MonodromyOptions;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
 
     # we need two copies of the options.
     # one with trace test
@@ -2518,9 +2541,26 @@ function _intersect(
     )
 
     # intersect
-    intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, atol = atol, rtol = rtol, kwargs...)
+    intersect_with_hypersurface!(
+        W₁,
+        Hᵤ,
+        W₂,
+        cache;
+        threading = threading,
+        atol = atol,
+        rtol = rtol,
+        kwargs...,
+    )
     update_Fᵢ!(cache, [f; h], vars_u)
-    fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading; atol = atol, rtol = rtol)
+    fill_up!(
+        [W₁; W₂],
+        monodromy_options,
+        cache,
+        show_monodromy_progress,
+        threading;
+        atol = atol,
+        rtol = rtol,
+    )
 
     # return data 
     G = fixed(System([f; h], variables = vars); compile = false)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1457,6 +1457,9 @@ function decompose_with_monodromy!(
             # Only check when new points were found and certified_up is non-empty.
             phantom_indices = Set{Int}()
             if length(updated_points) > prev_count && !isempty(certified_up)
+                # reset degree1 check if we found new points 
+                allow_degree1_iter = 0
+                # now compute phantom points
                 for (i, p) in pairs(updated_points)
                     if !isnothing(search_in_radius(certified_up, p, atol))
                         push!(phantom_indices, i)
@@ -1491,6 +1494,8 @@ function decompose_with_monodromy!(
             complete_orbits = Vector{Set{Int}}()
 
             for orbit in orbits
+                success = true # this checks if this run was successful
+
                 update_progress!(progress; is_monodromy = true)
 
                 # Strip phantom indices from the orbit before running inner monodromy.
@@ -1544,32 +1549,28 @@ function decompose_with_monodromy!(
                             )
                             # Only check certified_up when matching_indices left points unaccounted for.
                             # Unmatched points are either genuine new discoveries or path-jumping phantoms.
-                            diff = length(P_certified) - length(matched)
-                            if diff > 0 && any(
-                                p -> !isnothing(search_in_radius(certified_up, p, atol)),
-                                P_certified,
-                            )
-                                continue
-                            end
-                            complete_orbit = matched
-                            if diff == 1
-                                allow_degree1_iter = 0
+                            if length(matched) < length(P_certified)
+                                success = false
+                            else
+                                complete_orbit = matched
                             end
                         else
                             complete_orbit = clean_orbit
                         end
 
                         # postprocessing
-                        push!(complete_orbits, complete_orbit)
-                        k -= length(complete_orbit)
-                        update_progress_npts!(progress, k)
+                        if success
+                            push!(complete_orbits, complete_orbit)
+                            k -= length(complete_orbit)
+                            update_progress_npts!(progress, k)
 
-                        push!(decomposition, W_new)
-                        for p in solutions(W_new)
-                            add!(certified_up, p, 1, atol)
+                            push!(decomposition, W_new)
+                            for p in solutions(W_new)
+                                add!(certified_up, p, 1, atol)
+                            end
+                            d += length(P_certified) - length(complete_orbit)
+                            update_progress!(progress, W_new)
                         end
-                        d += length(P_certified) - length(complete_orbit)
-                        update_progress!(progress, W_new)
                     end
                 end
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -256,6 +256,7 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     u::Variable
     i::Int
     codim::Int
+    max_trials_u_homotopy::Int
 
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
@@ -263,7 +264,7 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     progress::Union{WitnessSetsProgress,Nothing}
 end
 
-function RegenerationCache(u, f, F, h, codim, EO, TO, progress)
+function RegenerationCache(u, f, F, h, codim, max_trials_u_homotopy, EO, TO, progress)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -271,7 +272,23 @@ function RegenerationCache(u, f, F, h, codim, EO, TO, progress)
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    RegenerationCache(A, b, x0, y0, y, f, F, h, u, 0, codim, EO, TO, progress)
+    RegenerationCache(
+        A,
+        b,
+        x0,
+        y0,
+        y,
+        f,
+        F,
+        h,
+        u,
+        0,
+        codim,
+        max_trials_u_homotopy,
+        EO,
+        TO,
+        progress,
+    )
 end
 function update_Fᵢ!(cache, fᵢ, vars)
     Fᵢ = fixed(System(fᵢ, variables = vars), compile = false)
@@ -304,6 +321,7 @@ The implementation is based on the algorithm [u-regeneration](https://arxiv.org/
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).
 * `endgame_options`: [`EndgameOptions`](@ref) for the [`EndgameTracker`](@ref).
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
+* `max_trials_u_homotopy = 5`: maximal number of random subspaces tried until an intermediate u-regeneration intersection step succeeds.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).`
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -336,6 +354,7 @@ function _regeneration(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
+    max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -409,6 +428,7 @@ function _regeneration(
         Fᵢ,
         f[1],
         codim,
+        max_trials_u_homotopy,
         endgame_options,
         tracker_options,
         progress,
@@ -695,15 +715,8 @@ function intersect_with_hypersurface!(
     # Step 2:
     # the points in P_next are used as starting points for a homotopy.
     # where u^d-1 (u is the extra variable in u-regeneration) is deformed into g 
-    Hom, d = set_up_u_homotopy(W, f, X, h, vars, u)
-
-    trackers = map(Hom) do H
-        EndgameTracker(
-            H;
-            tracker_options = cache.tracker_options,
-            options = cache.endgame_options,
-        )
-    end
+    u_data, d = set_up_u_homotopy(W, f, X, h, vars, u)
+    trackers = initialize_u_homotopy_trackers(u_data, cache)
 
 
     # the start solutions are the Cartesian product between P_next and the d-th roots of unity.
@@ -717,9 +730,9 @@ function intersect_with_hypersurface!(
         is_monodromy = false,
     )
     if threading
-        threaded_intersection!(X, P_next, roots, trackers, progress)
+        threaded_intersection!(X, P_next, roots, trackers, u_data, cache, progress)
     else
-        serial_intersection!(X, P_next, roots, trackers, progress)
+        serial_intersection!(X, P_next, roots, trackers, u_data, cache, progress)
     end
     nothing
 end
@@ -729,117 +742,6 @@ function manage_initial_points!(P, m)
     deleteat!(P, m)
     return P_next
 end
-
-function track_intersection_path(egtrackers, p)
-    # Stage 1: L -> random linear space L1
-    res1 = track(egtrackers[1], p, 1)
-    is_success(res1) && is_finite(res1) && is_nonsingular(res1) || return nothing
-
-    # Stage 2: replace u^d - 1 by hypersurface equation
-    p1 = solution(egtrackers[1])
-    res2 = track(egtrackers[2], p1, 1)
-    is_success(res2) && is_finite(res2) && is_nonsingular(res2) || return nothing
-
-    # Stage 3: L1 -> {u = c}
-    p2 = solution(egtrackers[2])
-    res3 = track(egtrackers[3], p2, 1)
-    is_success(res3) && is_finite(res3) && is_nonsingular(res3) || return nothing
-
-    q = copy(solution(egtrackers[3]))
-
-    q
-end
-
-function serial_intersection!(X, P, roots, egtrackers, progress)
-    start = Iterators.product(P, roots)
-    l_start = length(P) * length(roots)
-
-    for (i, s) in enumerate(start)
-        update_progress_paths!(progress, i, l_start)
-
-        p = s[1]
-        p[end] = s[2] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
-
-        q = track_intersection_path(egtrackers, p)
-        if !isnothing(q)
-            push!(X, q)
-        end
-    end
-
-    nothing
-end
-
-function threaded_intersection!(X, P, roots, trackers, progress)
-
-    l_P = length(P)
-    l_roots = length(roots)
-    l_start = l_P * l_roots
-
-    # Pre-allocate one tracker per thread
-    nthr = Threads.nthreads()
-    trackers_per_thread = [deepcopy(trackers) for _ = 1:nthr]
-
-    # Use a lock for thread-safe operations on X and progress
-    progress_lock = ReentrantLock()
-
-    next_idx = Threads.Atomic{Int}(1)
-    Threads.@sync begin
-        for tid = 1:nthr
-            let local_egtrackers = trackers_per_thread[tid]
-                Threads.@spawn begin
-                    while true
-
-                        idx = Threads.atomic_add!(next_idx, 1)
-                        if idx > l_start
-                            break
-                        end
-
-                        lock(progress_lock) do
-                            update_progress_paths!(progress, idx, l_start)
-                        end
-
-                        p_idx = rem(idx - 1, l_P) + 1
-                        r_idx = div(idx - 1, l_P) + 1
-                        p = copy(P[p_idx])
-                        p[end] = roots[r_idx] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
-
-                        q = track_intersection_path(local_egtrackers, p)
-                        if !isnothing(q)
-                            lock(progress_lock) do
-                                push!(X, q)
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-
-    nothing
-end
-
-function set_up_u_homotopy(W, f, X, h, vars, u)
-
-    P, Q = get_num_den(h)
-    d = degree(P)
-    h0 = (u^d - 1) / Q
-
-    # we start with the linear space L which does not use pose conditions on u, so that u^d=1
-    # we end with the linear space L2 with u=c.
-    L = linear_subspace_u(W)
-    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
-    L2 = linear_subspace(X)
-
-    F = fixed(System([f; h0], variables = vars); compile = false)
-    G = fixed(System([f; h], variables = vars); compile = false)
-
-    Hom1 = linear_subspace_homotopy(F, L, L1)
-    Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
-    Hom3 = linear_subspace_homotopy(G, L1, L2)
-
-    return (Hom1, Hom2, Hom3), d
-end
-
 
 
 function is_contained(X::WitnessPoints, Y::WitnessSet, F, cache; kwargs...)
@@ -900,6 +802,329 @@ function set_up_linear_spaces!(cache, LX, LY)
         end
         b[ℓ] = bX[i]
     end
+end
+
+
+# The following piece of the code implements the core part of u-regeneration
+# It consists of three subhomotopies: Hom1, Hom2, Hom3.
+# Hom1 moves the linear equation u = c to a random linear space L1 involving (x,u), where x are the variables of F.
+# Hom2 moves u^d - 1 to the new polynomial fᵢ with deg(fᵢ) = d.
+# Hom3 moves the linear space L1 to the linear space given by the initial witness sets. 
+# We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resampel L1. Only then track Hom2 and Hom3. 
+
+const HOM2_START_CHECK_TARGET = 0.95
+
+is_accepted(T::EndgameTracker, code) =
+    is_success(code) && !T.state.singular && !T.state.at_infinity
+
+function start_solution(P, roots, idx)
+    l_P = length(P)
+    p_idx = rem(idx - 1, l_P) + 1
+    r_idx = div(idx - 1, l_P) + 1
+    p = copy(P[p_idx])
+    p[end] = roots[r_idx]
+
+    p
+end
+
+function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
+    l_start = length(P) * length(roots)
+    P1 = Vector{Vector{ComplexF64}}(undef, l_start)
+    accepted1 = falses(l_start)
+    accepted2 = falses(l_start)
+
+    ntrials = max(cache.max_trials_u_homotopy, 1)
+    for trial = 1:ntrials
+        trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
+        fill!(accepted1, false)
+        fill!(accepted2, false)
+
+        track_hom1!(P1, accepted1, P, roots, trackers[1], progress, threading)
+        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
+
+        all(accepted2) && break
+    end
+
+    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
+
+    nothing
+end
+
+function serial_intersection!(X, P, roots, trackers, u_data, cache, progress)
+    track_intersection!(X, P, roots, trackers, u_data, cache, progress, false)
+end
+
+function threaded_intersection!(X, P, roots, trackers, u_data, cache, progress)
+    track_intersection!(X, P, roots, trackers, u_data, cache, progress, true)
+end
+
+function u_homotopy_tracker(H, cache)
+    EndgameTracker(
+        H;
+        tracker_options = cache.tracker_options,
+        options = cache.endgame_options,
+    )
+end
+
+function initialize_u_homotopy_trackers(u_data, cache)
+    F, G, L, L2 = u_data
+    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
+
+    Hom1 = linear_subspace_homotopy(F, L, L1)
+    Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
+    Hom3 = linear_subspace_homotopy(G, L1, L2)
+
+    [
+        u_homotopy_tracker(Hom1, cache),
+        u_homotopy_tracker(Hom2, cache),
+        u_homotopy_tracker(Hom3, cache),
+    ]
+end
+
+function reset_u_homotopy_trackers!(trackers, u_data, cache)
+    F, G, L, L2 = u_data
+    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
+
+    target_parameters!(trackers[1], L1)
+    trackers[2] = u_homotopy_tracker(
+        StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand())),
+        cache,
+    )
+    start_parameters!(trackers[3], L1)
+
+    trackers
+end
+
+function set_up_u_homotopy(W, f, X, h, vars, u)
+
+    P, Q = get_num_den(h)
+    d = degree(P)
+    h0 = (u^d - 1) / Q
+
+    # we start with the linear space L which does not use pose conditions on u, so that u^d=1
+    # we end with the linear space L2 with u=c.
+    L = linear_subspace_u(W)
+    L2 = linear_subspace(X)
+
+    F = fixed(System([f; h0], variables = vars); compile = false)
+    G = fixed(System([f; h], variables = vars); compile = false)
+
+    return (F, G, L, L2), d
+end
+
+
+function track_hom1!(P1, accepted1, P, roots, tracker, progress, threading)
+    if threading
+        threaded_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+    else
+        serial_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+    end
+end
+
+function check_hom2_starts!(accepted2, P1, accepted1, tracker, progress, threading)
+    if threading
+        threaded_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+    else
+        serial_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+    end
+end
+
+function track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress, threading)
+    if threading
+        threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+    else
+        serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+    end
+end
+
+function serial_track_hom1!(P1, accepted, P, roots, tracker, progress)
+    l_start = length(P) * length(roots)
+
+    for i = 1:l_start
+        update_progress_paths!(progress, i, l_start)
+
+        p = start_solution(P, roots, i)
+        code = track!(tracker, p, 1)
+        if is_accepted(tracker, code)
+            accepted[i] = true
+            P1[i] = solution(tracker)
+        else
+            accepted[i] = false
+        end
+    end
+
+    nothing
+end
+
+function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+    l_start = length(P1)
+
+    for i = 1:l_start
+        update_progress_paths!(progress, i, l_start)
+
+        if accepted1[i]
+            code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
+            accepted[i] = is_success(code)
+        else
+            accepted[i] = false
+        end
+    end
+
+    nothing
+end
+
+function serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+    l_start = length(P1)
+
+    for i = 1:l_start
+        update_progress_paths!(progress, i, l_start)
+
+        if accepted2[i]
+            code2 = track!(tracker2, P1[i], 1)
+            if is_accepted(tracker2, code2)
+                p2 = solution(tracker2)
+                code3 = track!(tracker3, p2, 1)
+                if is_accepted(tracker3, code3)
+                    push!(X, solution(tracker3))
+                end
+            end
+        end
+    end
+
+    nothing
+end
+
+function threaded_track_hom1!(P1, accepted, P, roots, tracker, progress)
+
+    l_P = length(P)
+    l_roots = length(roots)
+    l_start = l_P * l_roots
+
+    nthr = Threads.nthreads()
+    trackers = [deepcopy(tracker) for _ = 1:nthr]
+
+    progress_lock = ReentrantLock()
+
+    next_idx = Threads.Atomic{Int}(1)
+    Threads.@sync begin
+        for tid = 1:nthr
+            let local_tracker = trackers[tid]
+                Threads.@spawn begin
+                    while true
+
+                        idx = Threads.atomic_add!(next_idx, 1)
+                        if idx > l_start
+                            break
+                        end
+
+                        lock(progress_lock) do
+                            update_progress_paths!(progress, idx, l_start)
+                        end
+
+                        p = start_solution(P, roots, idx)
+                        code = track!(local_tracker, p, 1)
+                        if is_accepted(local_tracker, code)
+                            accepted[idx] = true
+                            P1[idx] = solution(local_tracker)
+                        else
+                            accepted[idx] = false
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    nothing
+end
+
+function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+
+    l_start = length(P1)
+
+    nthr = Threads.nthreads()
+    trackers = [deepcopy(tracker.tracker) for _ = 1:nthr]
+
+    progress_lock = ReentrantLock()
+
+    next_idx = Threads.Atomic{Int}(1)
+    Threads.@sync begin
+        for tid = 1:nthr
+            let local_tracker = trackers[tid]
+                Threads.@spawn begin
+                    while true
+
+                        idx = Threads.atomic_add!(next_idx, 1)
+                        if idx > l_start
+                            break
+                        end
+
+                        lock(progress_lock) do
+                            update_progress_paths!(progress, idx, l_start)
+                        end
+
+                        if accepted1[idx]
+                            code =
+                                track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
+                            accepted[idx] = is_success(code)
+                        else
+                            accepted[idx] = false
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    nothing
+end
+
+function threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+
+    l_start = length(P1)
+
+    nthr = Threads.nthreads()
+    trackers2 = [deepcopy(tracker2) for _ = 1:nthr]
+    trackers3 = [deepcopy(tracker3) for _ = 1:nthr]
+
+    progress_lock = ReentrantLock()
+
+    next_idx = Threads.Atomic{Int}(1)
+    Threads.@sync begin
+        for tid = 1:nthr
+            let local_tracker2 = trackers2[tid], local_tracker3 = trackers3[tid]
+                Threads.@spawn begin
+                    while true
+
+                        idx = Threads.atomic_add!(next_idx, 1)
+                        if idx > l_start
+                            break
+                        end
+
+                        lock(progress_lock) do
+                            update_progress_paths!(progress, idx, l_start)
+                        end
+
+                        if accepted2[idx]
+                            code2 = track!(local_tracker2, P1[idx], 1)
+                            if is_accepted(local_tracker2, code2)
+                                p2 = solution(local_tracker2)
+                                code3 = track!(local_tracker3, p2, 1)
+                                if is_accepted(local_tracker3, code3)
+                                    q = solution(local_tracker3)
+                                    lock(progress_lock) do
+                                        push!(X, q)
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    nothing
 end
 
 
@@ -1862,6 +2087,7 @@ function numerical_irreducible_decomposition(
     max_iters::Int = 50,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
+    max_trials_u_homotopy::Int = 5,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -1884,6 +2110,7 @@ function numerical_irreducible_decomposition(
         tracker_options = tracker_options,
         endgame_options = endgame_options,
         monodromy_options = monodromy_options_for_regeneration,
+        max_trials_u_homotopy = max_trials_u_homotopy,
         show_monodromy_progress = show_monodromy_for_regeneration_progress,
         threading = threading,
         seed = nothing,
@@ -2066,13 +2293,15 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     h::Expression
     u::Variable
 
+    max_trials_u_homotopy::Int
+
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
 
     progress::Union{IntersectProgress,Nothing}
 end
 
-function IntersectCache(u, f, F, h, EO, TO, progress)
+function IntersectCache(u, f, F, h, EO, TO, progress; max_trials_u_homotopy::Int = 5)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -2080,7 +2309,7 @@ function IntersectCache(u, f, F, h, EO, TO, progress)
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    IntersectCache(A, b, x0, y0, y, f, F, h, u, EO, TO, progress)
+    IntersectCache(A, b, x0, y0, y, f, F, h, u, max_trials_u_homotopy, EO, TO, progress)
 end
 
 
@@ -2096,6 +2325,7 @@ This intersects the witness sets `W` and `H`, where `H` is a hypersurface define
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).
 * `endgame_options`: [`EndgameOptions`](@ref) for the [`EndgameTracker`](@ref).
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
+* `max_trials_u_homotopy = 5`: maximal number of random subspaces tried until an intermediate u-regeneration intersection step succeeds.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).`
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 
@@ -2144,6 +2374,7 @@ function _intersect(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
+    max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading = Threads.nthreads() > 1,
     kwargs...,
@@ -2173,7 +2404,16 @@ function _intersect(
     W₁, W₂, Hᵤ, f, F, h, vars_u = prepare_for_u_homotopy(H, W, vars, u)
 
     # cache
-    cache = IntersectCache(u, f, F, h, endgame_options, tracker_options, progress)
+    cache = IntersectCache(
+        u,
+        f,
+        F,
+        h,
+        endgame_options,
+        tracker_options,
+        progress;
+        max_trials_u_homotopy = max_trials_u_homotopy,
+    )
 
     # intersect
     intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, kwargs...)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1407,6 +1407,7 @@ function decompose_with_monodromy!(
         end
 
         iter = 0
+        allow_degree1_iter = 0
         non_complete_points = indexed_solutions(res)
         d = length(non_complete_points) # the total degree (i.e., number of points on all irreducible components)
         non_complete_orbits = Vector{Set{Int}}()
@@ -1414,6 +1415,7 @@ function decompose_with_monodromy!(
 
         while !isempty(non_complete_points)
             iter += 1
+            allow_degree1_iter += 1
             if iter > max_iters
                 break
             end
@@ -1470,8 +1472,10 @@ function decompose_with_monodromy!(
 
                 if trace(res_orbit) < options.trace_test_tol
 
-                    # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
-                    if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
+                    # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 10. 
+                    # Single orobits tend to have small trace, even if their points are on a irreducible component of degree > 1.
+                    # allow_degree1_iter is reset once we we find new points 
+                    if length(orbit) > 1 || allow_degree1_iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
@@ -1485,11 +1489,11 @@ function decompose_with_monodromy!(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
-                                    norm = options.distance,
                                     atol = something(options.unique_points_atol, 1e-14),
                                     rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
                             )
+                            allow_degree1_iter = 0
                         else
                             complete_orbit = orbit
                         end
@@ -1671,14 +1675,14 @@ function merge_sets(sets)
 end
 
 # find indices of newly detected points
-function matching_indices(points, certified_points; norm, atol, rtol)
+function matching_indices(points, certified_points; atol, rtol)
     indices = Int[]
     matched = falses(length(certified_points))
     for (i, p) in pairs(points)
-        tol = max(atol, rtol * distance(p, zero(p), norm))
+        rad = max(atol, norm(p, Inf) * rtol)
         for (j, q) in pairs(certified_points)
             matched[j] && continue
-            if distance(p, q, norm) ≤ tol
+            if distance(p, q, InfNorm()) ≤ rad
                 push!(indices, i)
                 matched[j] = true
                 break

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1456,7 +1456,7 @@ function decompose_with_monodromy!(
             # Identify phantom points: new points that jumped into an already-certified component.
             # Only check when new points were found and certified_up is non-empty.
             phantom_indices = Set{Int}()
-            if length(updated_points) > prev_count && !isempty(certified_up)
+            if length(updated_points) > prev_count && length(certified_up) > 0
                 # reset degree1 check if we found new points 
                 allow_degree1_iter = 0
                 # now compute phantom points

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1369,7 +1369,7 @@ The core function for decomposing a witness set into irreducible components.
 function decompose_with_monodromy!(
     W,
     show_monodromy_progress,
-    _options,
+    options,
     max_iters,
     warning,
     progress,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -814,8 +814,7 @@ end
 
 const HOM2_START_CHECK_TARGET = 0.95
 
-is_accepted(T::EndgameTracker, code) =
-    is_success(code) && !T.state.singular && !T.state.at_infinity
+is_accepted(T::EndgameTracker, code) = is_success(code) && !T.state.singular
 
 function start_solution(P, roots, idx)
     l_P = length(P)
@@ -1326,10 +1325,13 @@ function decompose_with_monodromy!(
     if dim(L) < n
         update_progress!(progress; is_monodromy = true)
 
-        MS = MonodromySolver(G, L; compile = false, options = options)
-        initial_points = check_start_solutions(MS, P, L)
+        options_with_trace, options_without_trace = options
+        MS_with_trace = MonodromySolver(G, L; compile = false, options = options_with_trace)
+        MS_without_trace =
+            MonodromySolver(G, L; compile = false, options = options_without_trace)
+        initial_points = check_start_solutions(MS_with_trace, P, L)
         res = monodromy_solve(
-            MS,
+            MS_with_trace,
             solution.(initial_points),
             L,
             seed;
@@ -1340,7 +1342,7 @@ function decompose_with_monodromy!(
         update_progress!(progress; is_monodromy = false)
         update_progress_npts!(progress, nindexed_solutions(res))
 
-        if warning && (trace(res) > options.trace_test_tol)
+        if warning && (trace(res) > options_with_trace.trace_test_tol)
             @warn "Trying to decompose non-complete set of witness points for codimension $(dim(L)) (trace test failed). Will try to compute the missing points. The output will contain all components, for which the trace test was successfull."
         end
 
@@ -1356,20 +1358,18 @@ function decompose_with_monodromy!(
                 break
             end
 
-            if iter > 1
-                # for safety an additional monodromy when iter > 1
-                update_progress!(progress; is_monodromy = true)
-                res = monodromy_solve(
-                    MS,
-                    non_complete_points,
-                    L,
-                    seed;
-                    threading = threading,
-                    show_progress = show_monodromy_progress,
-                    progress = show_monodromy_progress ? nothing : progress,
-                )
-                update_progress!(progress; is_monodromy = false)
-            end
+
+            update_progress!(progress; is_monodromy = true)
+            res = monodromy_solve(
+                MS_without_trace, # without trace to populate the permutation matrix
+                non_complete_points,
+                L,
+                seed;
+                threading = threading,
+                show_progress = show_monodromy_progress,
+                progress = show_monodromy_progress ? nothing : progress,
+            )
+            update_progress!(progress; is_monodromy = false)
 
             updated_points = indexed_solutions(res)
             d += length(updated_points) - length(non_complete_points) # update total degree in case we found new points.
@@ -1377,7 +1377,6 @@ function decompose_with_monodromy!(
             ℓ = length(non_complete_points) # once for a later check
             k = length(non_complete_points) # and once for counting progress
             update_progress_npts!(progress, k)
-
 
             # Get orbits from monodromy result            
             orbits = get_orbits_from_monodromy_permutations(
@@ -1392,7 +1391,7 @@ function decompose_with_monodromy!(
 
                 P_orbit = non_complete_points[collect(orbit)]
                 res_orbit = monodromy_solve(
-                    MS,
+                    MS_with_trace,
                     P_orbit,
                     L,
                     seed;
@@ -1402,7 +1401,7 @@ function decompose_with_monodromy!(
                 )
                 update_progress!(progress; is_monodromy = false)
 
-                if trace(res_orbit) < options.trace_test_tol
+                if trace(res_orbit) < options_with_trace.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
@@ -1539,8 +1538,6 @@ function decompose_with_monodromy!(
     decomposition
 end
 
-
-
 # Helper function to merge two sets
 function merge_sets_find(parent, i)
     root = i
@@ -1660,7 +1657,10 @@ end
 
 function decompose_with_monodromy_options(M::MonodromyOptions)
 
-    MonodromyOptions(;
+    # we need two copies of the options. 
+    # one with trace test
+    # one without to run monodromy populating the permutation matrix
+    options_with_trace = MonodromyOptions(;
         permutations = true,
         trace_test = true,
         single_loop_per_start_solution = true,
@@ -1682,6 +1682,30 @@ function decompose_with_monodromy_options(M::MonodromyOptions)
         unique_points_atol = M.unique_points_atol,
         unique_points_rtol = M.unique_points_rtol,
     )
+    options_without_trace = MonodromyOptions(;
+        permutations = true,
+        trace_test = false,
+        single_loop_per_start_solution = true,
+        check_startsolutions = false,
+        group_actions = M.group_actions,
+        loop_finished_callback = M.loop_finished_callback,
+        parameter_sampler = M.parameter_sampler,
+        equivalence_classes = M.equivalence_classes,
+        duplicate_check = M.duplicate_check,
+        certification_max_precision = M.certification_max_precision,
+        certification_refine_solution = M.certification_refine_solution,
+        trace_test_tol = M.trace_test_tol,
+        target_solutions_count = M.target_solutions_count,
+        timeout = M.timeout,
+        min_solutions = M.min_solutions,
+        max_loops_no_progress = M.max_loops_no_progress,
+        reuse_loops = M.reuse_loops,
+        distance = M.distance,
+        unique_points_atol = M.unique_points_atol,
+        unique_points_rtol = M.unique_points_rtol,
+    )
+
+    options_with_trace, options_without_trace
 end
 
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -665,10 +665,10 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 W.R = Vector{Vector{ComplexF64}}()
             else
                 sols = solution.(results(res))
-                # Near-singular solutions tracked in monodromy loops can have poor
-                # accuracy (~1e-10 error), which is too large for monodromy's internal
-                # add! tolerance (1e-14 * norm). Deduplicate here with the wider
-                # regeneration tolerances to catch such near-duplicates.
+                # Near-singular solutions tracked in monodromy loops can have
+                # poor accuracy (~1e-10 error). If they evade monodromy's 
+                # internal deduplication tolerance, 
+                # remove near-duplicates here before continuing
                 W.R = length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
             end
             update_progress!(progress, W)
@@ -1455,6 +1455,18 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
+                        # Near-singular solutions tracked in monodromy loops can have
+                        # poor accuracy (~1e-10 error). If they evade monodromy's 
+                        # internal deduplication tolerance, 
+                        # remove near-duplicates here before
+                        # computing the degree of the certified component.
+                        if length(P_certified) > 1
+                            P_certified = unique_points(
+                                P_certified;
+                                atol = something(options.unique_points_atol, 1e-14),
+                                rtol = something(options.unique_points_rtol, sqrt(eps())),
+                            )
+                        end
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         # matching_indices is only needed when P_certified found more
                         # witness points than orbit contained. When P_certified has

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -963,8 +963,14 @@ function set_up_u_homotopy(
 
     P, Q = get_num_den(h)
     d = degree(P)
-    h0 = projective ? (u^d - ℓ^d) / Q : (u^d - 1) / Q
-
+    if projective 
+        h0 = u^d - ℓ^d
+    else
+        h0 = u^d - 1
+    end
+    if degree(Q) > 0
+        h0 = h0 / Q
+    end
     # we start with the linear space L which does not use pose conditions on u, so that u^d=1
     # we end with the linear space L2 with u=c.
     L = linear_subspace_u(W)
@@ -1324,10 +1330,12 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
-                        W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
-                        complete_orbit =
-                            length(P_certified) == length(orbit) ? orbit :
-                            Set(
+                        W_new = WitnessSet(G, L, P_certified; 
+                                                is_irreducible = true)
+                        if length(P_certified) == length(orbit)
+                            complete_orbit = orbit
+                        else
+                            complete_orbit = Set(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
@@ -1336,7 +1344,8 @@ function decompose_with_monodromy!(
                                     rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
                             )
-
+                        end
+                        
                         push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)
                         d += length(P_certified) - length(complete_orbit)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -859,7 +859,7 @@ end
 # Hom3 moves the linear space L1 to the linear space given by the initial witness sets. 
 # We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resample L1. Only then track Hom2 and Hom3. 
 
-const HOM2_START_CHECK_TARGET = 0.95
+const HOM2_START_CHECK_TARGET = 0.99
 
 is_accepted(T::EndgameTracker, code) = is_success(code) && !T.state.singular
 
@@ -889,7 +889,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         # is nothing left to resample, so we finish the sweep and keep the
         # starts that did pass the check.
         fail_fast = trial < ntrials
-        start_progress_paths!(progress, "Computing start solutions", l_start)
+        start_progress_paths!(progress, "Compute start solutions", l_start)
         track_hom1_and_check_hom2_starts!(
             accepted,
             P1,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -920,7 +920,7 @@ end
 # Hom3 moves the linear space L1 to the linear space given by the initial witness sets.
 # We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resample L1. Only then track Hom2 and Hom3.
 
-const HOM2_START_CHECK_TARGET = 0.95
+const HOM2_START_CHECK_TARGET = 0.99
 
 is_accepted(T::EndgameTracker, code) = is_success(code) && !T.state.singular
 
@@ -954,7 +954,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         # is nothing left to resample, so we finish the sweep and keep the
         # starts that did pass the check.
         fail_fast = trial < ntrials
-        start_progress_paths!(progress, "Computing start solutions", l_start)
+        start_progress_paths!(progress, "Compute start solutions", l_start)
         track_hom1_and_check_hom2_starts!(
             accepted,
             P1,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1400,9 +1400,9 @@ function decompose_with_monodromy!(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
-                                    norm = options.distance,
-                                    atol = something(options.unique_points_atol, 1e-14),
-                                    rtol = something(options.unique_points_rtol, 1e-8),
+                                    norm = options_with_trace.distance,
+                                    atol = something(options_with_trace.unique_points_atol, 1e-14),
+                                    rtol = something(options_with_trace.unique_points_rtol, 1e-8),
                                 ),
                             )
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1031,33 +1031,12 @@ function is_contained(X::WitnessPoints, Y::WitnessSet, F, cache; kwargs...)
     end
 
     set_up_linear_spaces!(cache, LX, LY)
-    out =
-        cache.projective ? is_contained_projective(points(X), Y, F, cache; kwargs...) :
-        is_contained(points(X), Y::WitnessSet, F, cache; kwargs...)
+    out = is_contained(points(X), Y::WitnessSet, F, cache; kwargs...)
 
     out
 end
 function is_contained(V::WitnessPoints, W::WitnessSet, cache; kwargs...)
     is_contained(V, W, system(W), cache; kwargs...)
-end
-
-function is_contained_projective(
-    P::Vector{Vector{T}},
-    Y::WitnessSet,
-    F,
-    cache;
-    threading::Bool = Threads.nthreads() > 1,
-    kwargs...,
-) where {T<:Number}
-    Hom = linear_subspace_homotopy(on_affine_chart(F), linear_subspace(Y), linear_subspace(Y))
-    tracker = EndgameTracker(
-        Hom;
-        tracker_options = cache.tracker_options,
-        options = cache.endgame_options,
-    )
-
-    threading ? threaded_x_in_Y(P, Y, F, tracker, cache; kwargs...) :
-    serial_x_in_Y(P, Y, F, tracker, cache; kwargs...)
 end
 
 function set_up_linear_spaces!(cache, LX, LY)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -708,7 +708,7 @@ function regeneration_monodromy_options(M::MonodromyOptions, W)
         certification_max_precision = M.certification_max_precision,
         certification_refine_solution = M.certification_refine_solution,
         trace_test_tol = M.trace_test_tol,
-        target_solutions_count = Int(floor(1.5 * degree(W))), # in case a singular solution slips through
+        target_solutions_count = Int(floor(1.5 * degree(W))), # in case we miss solutions
         timeout = M.timeout,
         min_solutions = M.min_solutions,
         max_loops_no_progress = M.max_loops_no_progress,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1389,8 +1389,7 @@ function decompose_with_monodromy!(
 
     # first check that all points in P are unique
     id = 1
-    certified_up =
-        UniquePoints(first(P₀), 1; distance = InfNorm())
+    certified_up = UniquePoints(first(P₀), 1; distance = InfNorm())
     P = Vector{eltype(P₀)}()
     for (i, pᵢ) in enumerate(P₀)
         _, new_point = add!(certified_up, pᵢ, i; atol = atol, rtol = rtol)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1449,14 +1449,13 @@ function decompose_with_monodromy!(
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
-                        complete_orbit =
-                            # matching_indices is only needed when P_certified found more
-                            # witness points than orbit contained. When P_certified has
-                            # fewer points (inner monodromy deduplicated some starts), the
-                            # full orbit is still complete — collapsed elements were just
-                            # numerical duplicates on the same component.
-                            length(P_certified) > length(orbit) ?
-                            Set(
+                        # matching_indices is only needed when P_certified found more
+                        # witness points than orbit contained. When P_certified has
+                        # fewer points (inner monodromy deduplicated some starts), the
+                        # full orbit is still complete — collapsed elements were just
+                        # numerical duplicates on the same component.
+                        if length(P_certified) > length(orbit)
+                            complete_orbit = Set(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
@@ -1464,8 +1463,10 @@ function decompose_with_monodromy!(
                                     atol = something(options.unique_points_atol, 1e-14),
                                     rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
-                            ) :
-                            orbit
+                            )
+                        else
+                            complete_orbit = orbit
+                        end
 
                         push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -836,13 +836,13 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
 
         fill!(accepted, false)
-        track_hom1!(accepted1, P1, P, roots, trackers[1], progress, threading)
+        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
         all(accepted) || continue
 
         # Hom1 only moves the slice. We still need to verify that its endpoints
         # are usable starts for Hom2; otherwise resample L1 and try again.
         fill!(accepted, false)
-        check_hom2_starts!(accepted2, P1, trackers[2], progress, threading)
+        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
         all(accepted) && break
     end
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -351,9 +351,7 @@ function _regeneration(
         max_endgame_extended_steps = 100,
         sing_cond = 1e12,
     ),
-    monodromy_options::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options::MonodromyOptions = MonodromyOptions(),
     max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading::Bool = Threads.nthreads() > 1,
@@ -1746,9 +1744,7 @@ function decompose(
     Ws::Vector{WP};
     show_progress::Bool = true,
     show_monodromy_progress::Bool = false,
-    monodromy_options::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options::MonodromyOptions = MonodromyOptions(),
     max_iters::Int = 200,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
@@ -2088,12 +2084,8 @@ function numerical_irreducible_decomposition(
         max_endgame_extended_steps = 100,
         sing_accuracy = 1e-10,
     ),
-    monodromy_options_for_regeneration = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
-    monodromy_options_for_decompose::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options_for_regeneration = MonodromyOptions(),
+    monodromy_options_for_decompose::MonodromyOptions = MonodromyOptions(),
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
@@ -2384,9 +2376,7 @@ function _intersect(
         max_endgame_extended_steps = 100,
         sing_cond = 1e12,
     ),
-    monodromy_options::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options::MonodromyOptions = MonodromyOptions(),
     max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading = Threads.nthreads() > 1,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1526,7 +1526,7 @@ function decompose_with_monodromy!(
                     # Single orbits tend to have small trace, even if their points are on an irreducible component of degree > 1.
                     # allow_degree1_iter is reset once we find new points.
                     if length(clean_orbit) > 1 ||
-                       allow_degree1_iter ≥ 5 ||
+                       allow_degree1_iter ≥ 10 ||
                        iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1566,7 +1566,7 @@ function decompose_with_monodromy!(
 
                             push!(decomposition, W_new)
                             for p in solutions(W_new)
-                                add!(certified_up, p, 1, atol)
+                                add!(certified_up, p, 1; atol = atol, rtol = rtol)
                             end
                             d += length(P_certified) - length(complete_orbit)
                             update_progress!(progress, W_new)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1378,10 +1378,27 @@ function decompose_with_monodromy!(
 )
     update_progress_dim!(progress, dim(W))
 
-    P = unique_points(points(W))
+    P₀ = points(W)
     L = linear_subspace(W)
     G = system(W)
     n = ambient_dim(L)
+
+    # tolerances for comparing points
+    atol = something(options.unique_points_atol, 1e-14)
+    rtol = something(options.unique_points_rtol, 1e-8)
+
+    # first check that all points in P are unique
+    id = 1
+    certified_up =
+        UniquePoints(first(P₀), 1; distance = InfNorm())
+    P = Vector{eltype(P₀)}()
+    for (i, pᵢ) in enumerate(P₀)
+        _, new_point = add!(certified_up, pᵢ, i; atol = atol, rtol = rtol)
+        if new_point
+            push!(P, pᵢ)
+        end
+    end
+    empty!(certified_up) # we reuse this later
 
     decomposition = Vector{WitnessSet}()
 
@@ -1436,6 +1453,18 @@ function decompose_with_monodromy!(
             updated_points = indexed_solutions(res)
             d += length(updated_points) - length(non_complete_points) # update total degree in case we found new points.
             non_complete_points = updated_points
+
+            # Identify phantom points: new points that jumped into an already-certified component.
+            # Only check when new points were found and certified_up is non-empty.
+            phantom_indices = Set{Int}()
+            if length(updated_points) > prev_count && !isempty(certified_up)
+                for (i, p) in pairs(updated_points)
+                    if !isnothing(search_in_radius(certified_up, p, atol))
+                        push!(phantom_indices, i)
+                    end
+                end
+                d -= length(phantom_indices)
+            end
             ℓ = length(non_complete_points) # once for a later check
             k = length(non_complete_points) # and once for counting progress
             update_progress_npts!(progress, k)
@@ -1465,7 +1494,18 @@ function decompose_with_monodromy!(
             for orbit in orbits
                 update_progress!(progress; is_monodromy = true)
 
-                P_orbit = non_complete_points[collect(orbit)]
+                # Strip phantom indices from the orbit before running inner monodromy.
+                clean_orbit =
+                    isempty(phantom_indices) ? orbit : setdiff(orbit, phantom_indices)
+                if isempty(clean_orbit)
+                    push!(complete_orbits, orbit)
+                    k -= length(orbit)
+                    update_progress_npts!(progress, k)
+                    update_progress!(progress; is_monodromy = false)
+                    continue
+                end
+
+                P_orbit = non_complete_points[sort!(collect(clean_orbit))]
                 res_orbit = monodromy_solve(
                     MS,
                     P_orbit,
@@ -1477,63 +1517,58 @@ function decompose_with_monodromy!(
                 )
                 update_progress!(progress; is_monodromy = false)
 
+                # only continue when trace test succeeds
                 if trace(res_orbit) < options.trace_test_tol
 
-                    # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 10. 
-                    # Single orobits tend to have small trace, even if their points are on a irreducible component of degree > 1.
-                    # allow_degree1_iter is reset once we we find new points 
-                    if length(orbit) > 1 || allow_degree1_iter ≥ 5 || iter ≥ max_iters - 1
+                    # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 5.
+                    # Single orbits tend to have small trace, even if their points are on an irreducible component of degree > 1.
+                    # allow_degree1_iter is reset once we find new points.
+                    if length(clean_orbit) > 1 ||
+                       allow_degree1_iter ≥ 5 ||
+                       iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
+
+                        # Check whether inner monodromy jumped into an already-certified component.
+                        # If so, the trace test result is unreliable — skip this orbit.
+                        if any(
+                            p -> !isnothing(search_in_radius(certified_up, p, atol)),
+                            P_certified,
+                        )
+                            continue
+                        end
+
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
-                        # when P_certified found more witness points than orbit contained,
-                        # there can be two reasons
-                        # (1) path jumping
-                        # (2) we found genuine new points 
-                        # we first check path jumping using has_point_in_decomposition
-                        # if this returns false, run matching_indices to find the correct indices
-                        # of the points in P_certified
-                        # if P_certified has fewer points (inner monodromy deduplicated some starts), the full orbit is still complete — collapsed elements were just
-                        # numerical duplicates on the same component.
-                        if length(P_certified) > length(orbit)
-                            # check if the extra points in P_certified came from path 
-                            # jumping by comparing them to the points in the completed decompositions
-                            has_duplicate = has_point_in_decomposition(
-                                P_certified,
-                                decomposition;
-                                atol = something(options.unique_points_atol, 1e-14),
-                                rtol = something(options.unique_points_rtol, 1e-8),
-                            )
-
-                            if !has_duplicate
-                                # if we have genuine new points find their indices
-                                complete_orbit = Set(
+                        if length(P_certified) > length(clean_orbit)
+                            # Genuine new points found — compute their indices in non_complete_points,
+                            # excluding any phantom indices that might have matched numerically.
+                            complete_orbit = setdiff(
+                                Set(
                                     matching_indices(
                                         non_complete_points,
                                         P_certified;
-                                        atol = something(options.unique_points_atol, 1e-14),
-                                        rtol = something(options.unique_points_rtol, 1e-8),
+                                        atol = atol,
+                                        rtol = rtol,
                                     ),
-                                )
-                                # if we have genuine new points restart the degree 1 check 
-                                allow_degree1_iter = 0
-                            end
+                                ),
+                                phantom_indices,
+                            )
+                            allow_degree1_iter = 0
                         else
-                            has_duplicate = false
-                            complete_orbit = orbit
+                            complete_orbit = clean_orbit
                         end
 
+                        # postprocessing
                         push!(complete_orbits, complete_orbit)
-                        k = k - length(complete_orbit)
+                        k -= length(complete_orbit)
                         update_progress_npts!(progress, k)
 
-                        # put a new witness set into decomposition
-                        # only if has_duplicate == false
-                        if !has_duplicate
-                            push!(decomposition, W_new)
-                            d += length(P_certified) - length(complete_orbit)
-                            update_progress!(progress, W_new)
+                        push!(decomposition, W_new)
+                        for p in solutions(W_new)
+                            add!(certified_up, p, 1, atol)
                         end
+                        d += length(P_certified) - length(complete_orbit)
+                        update_progress!(progress, W_new)
                     end
                 end
             end
@@ -1564,7 +1599,9 @@ function decompose_with_monodromy!(
             for orbit in complete_orbits
                 append!(complete_orbit_indices, orbit)
             end
+            append!(complete_orbit_indices, phantom_indices)
             sort!(complete_orbit_indices)
+            unique!(complete_orbit_indices)
 
             deleteat!(non_complete_points, complete_orbit_indices)
 
@@ -1587,15 +1624,18 @@ function decompose_with_monodromy!(
                 i += 1
             end
 
-            shift_orbit(orbit) = Set(orbit_indices_mapping[i] for i in orbit)
+            # Skip phantom indices when shifting — they have been removed from non_complete_points.
+            shift_orbit(orbit) =
+                Set(orbit_indices_mapping[i] for i in orbit if i ∉ phantom_indices)
             # 1. shift existing non complete orbits to new mapping
             non_complete_orbits =
                 shift_orbit.(
                     merge_sets(
                         [
-                            # Remove all orbits that are contained in a complete orbit
+                            # Remove all orbits that overlap with a complete orbit or phantom indices
                             filter(non_complete_orbits) do o
-                                all(co -> isdisjoint(co, o), complete_orbits)
+                                all(co -> isdisjoint(co, o), complete_orbits) &&
+                                    isdisjoint(o, phantom_indices)
                             end
                             setdiff(orbits, complete_orbits)
                         ],
@@ -1704,15 +1744,6 @@ function merge_sets(sets)
 end
 
 # check if we have found points that are already classifiedxw
-function has_point_in_decomposition(P, decomposition; atol, rtol)
-    any(P) do p
-        rad = max(atol, norm(p, Inf) * rtol)
-        any(decomposition) do W
-            any(q -> distance(p, q, InfNorm()) ≤ rad, points(W))
-        end
-    end
-end
-
 # find indices of newly detected points
 function matching_indices(points, certified_points; atol, rtol)
     indices = Int[]

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -257,9 +257,8 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     i::Int
     codim::Int
     projective::Bool
-    variable_groups::Union{Nothing,Vector{Vector{Variable}}}
-    ℓ::Expression
-    ℓ_coeffs::Vector{ComplexF64}
+    ℓ::Union{Nothing,Expression}
+    ℓ_coeffs::Union{Nothing,Vector{ComplexF64}}
 
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
@@ -267,20 +266,7 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     progress::Union{WitnessSetsProgress,Nothing}
 end
 
-function RegenerationCache(
-    u,
-    f,
-    F,
-    h,
-    codim,
-    projective,
-    variable_groups,
-    ℓ,
-    ℓ_coeffs,
-    EO,
-    TO,
-    progress,
-)
+function RegenerationCache(u, f, F, h, codim, projective, ℓ, ℓ_coeffs, EO, TO, progress)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -301,7 +287,6 @@ function RegenerationCache(
         0,
         codim,
         projective,
-        variable_groups,
         ℓ,
         ℓ_coeffs,
         EO,
@@ -310,10 +295,7 @@ function RegenerationCache(
     )
 end
 function update_Fᵢ!(cache, fᵢ, vars)
-    Fᵢ = fixed(
-        System(fᵢ, variables = vars, variable_groups = cache.variable_groups),
-        compile = false,
-    )
+    Fᵢ = fixed(System(fᵢ, variables = vars), compile = false)
     cache.fᵢ = fᵢ
     cache.Fᵢ = Fᵢ
     m = length(Fᵢ)
@@ -327,17 +309,6 @@ end
 update_hᵢ!(cache, h) = cache.h = h
 update_i!(cache, i) = cache.i = i
 
-function single_projective_variable_group(F::System)
-    is_homogeneous(F) || return nothing
-    groups = variable_groups(F)
-    if isnothing(groups)
-        return variables(F)
-    elseif length(groups) == 1
-        return only(groups)
-    else
-        error("NID for systems with multiple variable groups is not implemented yet.")
-    end
-end
 
 """
     regeneration(F::System; options...) 
@@ -400,8 +371,7 @@ function _regeneration(
     # by Duff, Leykin and Rodriguez in https://arxiv.org/abs/2206.02869
 
     xvars = variables(F)
-    projective_group = single_projective_variable_group(F)
-    projective = !isnothing(projective_group)
+    projective = is_homogeneous(F)
     vars = copy(xvars)
     n = size(F, 2) # ambient dimension
     c = size(F, 1) # we can have witness sets of codimesion at most min(c,n)
@@ -415,9 +385,6 @@ function _regeneration(
     # u-regeneration adds another variable u to F
     @unique_var u
     push!(vars, u)
-    variable_groups = projective ? [vars] : nothing
-    ℓ_coeffs = randn(ComplexF64, length(xvars))
-    ℓ = sum(ℓ_coeffs .* xvars)
 
     # progress bar
     if show_progress
@@ -447,8 +414,8 @@ function _regeneration(
     H = initialize_hypersurfaces(
         F,
         vars,
-        linear_subspace(out[1]);
-        variable_groups = variable_groups,
+        linear_subspace(out[1]),
+        projective;
         threading = threading,
     )
     if any(isnothing, H)
@@ -465,10 +432,9 @@ function _regeneration(
     end
 
     # Initialize a cache
-    Fᵢ = fixed(
-        System(f[1:1], variables = vars, variable_groups = variable_groups),
-        compile = false,
-    )
+    Fᵢ = fixed(System(f[1:1], variables = vars), compile = false)
+    ℓ_coeffs = projective ? randn(ComplexF64, length(xvars)) : nothing
+    ℓ = projective ? sum(ℓ_coeffs .* xvars) : nothing
     cache = RegenerationCache(
         u,
         f[1:1],
@@ -476,7 +442,6 @@ function _regeneration(
         f[1],
         codim,
         projective,
-        variable_groups,
         ℓ,
         ℓ_coeffs,
         endgame_options,
@@ -605,8 +570,8 @@ end
 function initialize_hypersurfaces(
     F::System,
     vars,
-    L;
-    variable_groups = nothing,
+    L,
+    projective;
     threading::Bool = Threads.nthreads() > 1,
 )
     f = expressions(F)
@@ -614,13 +579,9 @@ function initialize_hypersurfaces(
     out = Vector{WitnessSet}(undef, c)
     for i = 1:c
         fᵢ = f[i]
-        h = fixed(
-            System([fᵢ], variables = vars, variable_groups = variable_groups),
-            compile = false,
-        )
+        h = fixed(System([fᵢ], variables = vars), compile = false)
         pᵢ, qᵢ = get_num_den(fᵢ) # fᵢ = pᵢ / qᵢ
         xvars = vars[1:(end-1)]
-        projective = !isnothing(variable_groups)
         if projective
             E = extrinsic(L)
             A = E.A[2:end, 1:(end-1)]
@@ -796,17 +757,8 @@ function intersect_with_hypersurface!(
     # Step 2:
     # the points in P_next are used as starting points for a homotopy.
     # where u^d-1 (u is the extra variable in u-regeneration) is deformed into g 
-    Hom, d = set_up_u_homotopy(
-        W,
-        f,
-        X,
-        h,
-        vars,
-        u;
-        projective = cache.projective,
-        variable_groups = cache.variable_groups,
-        ℓ = cache.ℓ,
-    )
+    Hom, d =
+        set_up_u_homotopy(W, f, X, h, vars, u; projective = cache.projective, ℓ = cache.ℓ)
 
     trackers = map(Hom) do H
         EndgameTracker(
@@ -828,25 +780,9 @@ function intersect_with_hypersurface!(
         is_monodromy = false,
     )
     if threading
-        threaded_intersection!(
-            X,
-            P_next,
-            roots,
-            trackers,
-            progress,
-            Val(cache.projective),
-            cache.ℓ_coeffs,
-        )
+        threaded_intersection!(X, P_next, roots, trackers, cache.ℓ_coeffs, progress)
     else
-        serial_intersection!(
-            X,
-            P_next,
-            roots,
-            trackers,
-            progress,
-            Val(cache.projective),
-            cache.ℓ_coeffs,
-        )
+        serial_intersection!(X, P_next, roots, trackers, cache.ℓ_coeffs, progress)
     end
     nothing
 end
@@ -877,21 +813,27 @@ function track_intersection_path(egtrackers, p)
     q
 end
 
-start_values(p, roots, ::Val{false}, ℓ_coeffs) = roots
-start_values(p, roots, ::Val{true}, ℓ_coeffs) =
-    roots .* sum(ℓ_coeffs[j] * p[j] for j = 1:length(ℓ_coeffs))
+function scaling(p, ℓ_coeffs)
+    if !isnothing(ℓ_coeffs) # this is the projective case
+        return sum(ℓ_coeffs[j] * p[j] for j = 1:length(ℓ_coeffs))
+    else
+        return 1.0
+    end
+end
 
-function serial_intersection!(X, P, roots, egtrackers, progress, projective::Val, ℓ_coeffs)
-    l_start = sum(length(start_values(p, roots, projective, ℓ_coeffs)) for p in P)
+
+function serial_intersection!(X, P, roots, egtrackers, ℓ_coeffs, progress)
+    l_start = length(roots) * length(P)
 
     i = 0
     for p₀ in P
-        for r in start_values(p₀, roots, projective, ℓ_coeffs)
+        λ = scaling(p₀, ℓ_coeffs)
+        for r in roots
             i += 1
             update_progress_paths!(progress, i, l_start)
 
             p = copy(p₀)
-            p[end] = r
+            p[end] = λ * r
 
             q = track_intersection_path(egtrackers, p)
             if !isnothing(q)
@@ -903,10 +845,18 @@ function serial_intersection!(X, P, roots, egtrackers, progress, projective::Val
     nothing
 end
 
-function threaded_intersection!(X, P, roots, trackers, progress, projective::Val, ℓ_coeffs)
+function threaded_intersection!(X, P, roots, trackers, ℓ_coeffs, progress)
 
-    starts = [(p, r) for p in P for r in start_values(p, roots, projective, ℓ_coeffs)]
-    l_start = length(starts)
+    if !isnothing(ℓ_coeffs) # this is the projective case
+        starts = flatten(map(P) do p₀
+            λ = scaling(p₀, ℓ_coeffs)
+            map(r -> (p₀, λ * r), roots)
+        end)
+    else
+        starts = [(p, r) for p in P for r in roots]
+    end
+
+
 
     # Pre-allocate one tracker per thread
     nthr = Threads.nthreads()
@@ -949,17 +899,7 @@ function threaded_intersection!(X, P, roots, trackers, progress, projective::Val
     nothing
 end
 
-function set_up_u_homotopy(
-    W,
-    f,
-    X,
-    h,
-    vars,
-    u;
-    projective::Bool = false,
-    variable_groups = nothing,
-    ℓ = 1,
-)
+function set_up_u_homotopy(W, f, X, h, vars, u; projective::Bool = false, ℓ = 1)
 
     P, Q = get_num_den(h)
     d = degree(P)
@@ -977,14 +917,8 @@ function set_up_u_homotopy(
     L1 = rand_subspace(ambient_dim(L); dim = dim(L), affine = !projective)
     L2 = linear_subspace(X)
 
-    F = fixed(
-        System([f; h0], variables = vars, variable_groups = variable_groups);
-        compile = false,
-    )
-    G = fixed(
-        System([f; h], variables = vars, variable_groups = variable_groups);
-        compile = false,
-    )
+    F = fixed(System([f; h0], variables = vars); compile = false)
+    G = fixed(System([f; h], variables = vars); compile = false)
 
     Hom1 = linear_subspace_homotopy(F, L, L1; homogeneous = projective)
     Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
@@ -2222,9 +2156,8 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     h::Expression
     u::Variable
     projective::Bool
-    variable_groups::Union{Nothing,Vector{Vector{Variable}}}
-    ℓ::Expression
-    ℓ_coeffs::Vector{ComplexF64}
+    ℓ::Union{Nothing,Expression}
+    ℓ_coeffs::Union{Nothing,Vector{ComplexF64}}
 
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
@@ -2232,19 +2165,7 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     progress::Union{IntersectProgress,Nothing}
 end
 
-function IntersectCache(
-    u,
-    f,
-    F,
-    h,
-    projective,
-    variable_groups,
-    ℓ,
-    ℓ_coeffs,
-    EO,
-    TO,
-    progress,
-)
+function IntersectCache(u, f, F, h, projective, ℓ, ℓ_coeffs, EO, TO, progress)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -2252,24 +2173,7 @@ function IntersectCache(
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    IntersectCache(
-        A,
-        b,
-        x0,
-        y0,
-        y,
-        f,
-        F,
-        h,
-        u,
-        projective,
-        variable_groups,
-        ℓ,
-        ℓ_coeffs,
-        EO,
-        TO,
-        progress,
-    )
+    IntersectCache(A, b, x0, y0, y, f, F, h, u, projective, ℓ, ℓ_coeffs, EO, TO, progress)
 end
 
 
@@ -2363,20 +2267,18 @@ function _intersect(
     @unique_var vars[1:n]
     vars_u = [vars; u]
     projective = W.projective
-    variable_groups = projective ? [vars_u] : nothing
-    ℓ_coeffs = randn(ComplexF64, n)
-    ℓ = sum(ℓ_coeffs .* vars)
-    W₁, W₂, Hᵤ, f, F, h =
-        prepare_for_u_homotopy(H, W, vars, vars_u, variable_groups, projective)
+    W₁, W₂, Hᵤ, f, F, h = prepare_for_u_homotopy(H, W, vars, vars_u, projective)
+
 
     # cache
+    ℓ_coeffs = projective ? randn(ComplexF64, n) : nothing
+    ℓ = projective ? sum(ℓ_coeffs .* vars) : nothing
     cache = IntersectCache(
         u,
         f,
         F,
         h,
         projective,
-        variable_groups,
         ℓ,
         ℓ_coeffs,
         endgame_options,
@@ -2390,10 +2292,7 @@ function _intersect(
     fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading)
 
     # return data 
-    G = fixed(
-        System([f; h], variables = vars, variable_groups = projective ? [vars] : nothing);
-        compile = false,
-    )
+    G = fixed(System([f; h], variables = vars); compile = false)
     P1, L1 = u_transform(W₁)
     out = [WitnessSet(G, L1, P1; projective = projective)]
     if !isnothing(W₂)
@@ -2409,14 +2308,14 @@ end
 
 
 
-function prepare_for_u_homotopy(H, W, vars, vars_u, variable_groups, projective)
+function prepare_for_u_homotopy(H, W, vars, vars_u, projective)
     # prepare polynomials 
     FH0 = deepcopy(System(system(H)))
     FW0 = deepcopy(System(system(W)))
     h = subs(expressions(FH0), variables(FH0) => vars)
     f = subs(expressions(FW0), variables(FW0) => vars)
-    FH = System(h, variables = vars_u, variable_groups = variable_groups)
-    FW = System(f, variables = vars_u, variable_groups = variable_groups)
+    FH = System(h, variables = vars_u)
+    FW = System(f, variables = vars_u)
 
     # prepare flags
     LW = linear_subspace(W)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2477,6 +2477,8 @@ function _intersect(
     max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading = Threads.nthreads() > 1,
+    atol = 1e-14,
+    rtol = sqrt(eps()),
     kwargs...,
 )
     @assert size(system(H), 1) == 1 "The second argument must be defined by a single polynomial."
@@ -2516,9 +2518,9 @@ function _intersect(
     )
 
     # intersect
-    intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, kwargs...)
+    intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, atol = atol, rtol = rtol, kwargs...)
     update_Fᵢ!(cache, [f; h], vars_u)
-    fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading)
+    fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading; atol = atol, rtol = rtol)
 
     # return data 
     G = fixed(System([f; h], variables = vars); compile = false)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1391,7 +1391,7 @@ function decompose_with_monodromy!(
                 if trace(res_orbit) < options.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
-                    if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
+                    if length(orbit) > 1 || iter ≥ 50 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         complete_orbit =

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1765,6 +1765,8 @@ function get_orbits_from_monodromy_permutations(
             end
         end
     end
+    sort!(orbits; by = length, rev = true)
+
     orbits
 end
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1388,10 +1388,7 @@ function decompose_with_monodromy!(
     if dim(L) < n
         update_progress!(progress; is_monodromy = true)
 
-        options, options_without_trace = _options
         MS = MonodromySolver(G, L; compile = false, options = options)
-        MS_without_trace =
-            MonodromySolver(G, L; compile = false, options = options_without_trace)
         initial_points = check_start_solutions(MS, P, L)
         res = monodromy_solve(
             MS,
@@ -1424,7 +1421,7 @@ function decompose_with_monodromy!(
 
             update_progress!(progress; is_monodromy = true)
             res = monodromy_solve(
-                MS_without_trace, # without trace to populate the permutation matrix
+                MS,
                 non_complete_points,
                 L,
                 seed;
@@ -1742,7 +1739,7 @@ function decompose_with_monodromy_options(
     # we need two copies of the options.
     # one with trace test
     # one without to run monodromy populating the permutation matrix
-    options_with_trace = MonodromyOptions(;
+    options = MonodromyOptions(;
         permutations = true,
         trace_test = true,
         single_loop_per_start_solution = true,
@@ -1764,30 +1761,8 @@ function decompose_with_monodromy_options(
         unique_points_atol = something(M.unique_points_atol, atol),
         unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
-    options_without_trace = MonodromyOptions(;
-        permutations = true,
-        trace_test = false,
-        single_loop_per_start_solution = true,
-        check_startsolutions = false,
-        group_actions = M.group_actions,
-        loop_finished_callback = M.loop_finished_callback,
-        parameter_sampler = M.parameter_sampler,
-        equivalence_classes = M.equivalence_classes,
-        duplicate_check = M.duplicate_check,
-        certification_max_precision = M.certification_max_precision,
-        certification_refine_solution = M.certification_refine_solution,
-        trace_test_tol = M.trace_test_tol,
-        target_solutions_count = M.target_solutions_count,
-        timeout = M.timeout,
-        min_solutions = M.min_solutions,
-        max_loops_no_progress = M.max_loops_no_progress,
-        reuse_loops = M.reuse_loops,
-        distance = M.distance,
-        unique_points_atol = something(M.unique_points_atol, atol),
-        unique_points_rtol = something(M.unique_points_rtol, rtol),
-    )
 
-    options_with_trace, options_without_trace
+    options
 end
 
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -835,7 +835,10 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
 
         fill!(accepted, false)
         track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
-        all(accepted) || continue
+        if !all(accepted)
+            fill!(accepted, false)
+            continue
+        end
 
         # Hom1 only moves the slice. We still need to verify that its endpoints
         # are usable starts for Hom2; otherwise resample L1 and try again.
@@ -844,7 +847,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         all(accepted) && break
     end
 
-    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing
 end
@@ -928,11 +931,11 @@ function check_hom2_starts!(accepted, P1, tracker, progress, threading)
     end
 end
 
-function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     end
 end
 
@@ -968,11 +971,12 @@ function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
+        accepted[i] || continue
 
         code2 = track!(tracker2, P1[i], 1)
         if is_accepted(tracker2, code2)
@@ -1067,7 +1071,7 @@ function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1092,6 +1096,7 @@ function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
+                        accepted[idx] || continue
 
                         code2 = track!(local_tracker2, P1[idx], 1)
                         if is_accepted(local_tracker2, code2)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -278,13 +278,10 @@ function linear_subspace_homotopy(
     gamma = cis(2 * pi * randn()),
 )
 
-
-    use_intrinsic = isnothing(intrinsic) ? dim(V) <= codim(V) : intrinsic
-
-    if use_intrinsic
+    if dim(V) <= codim(V) || something(intrinsic, false)
         if is_linear(V) && is_linear(W) && is_homogeneous(System(F))
             IntrinsicSubspaceHomotopy(
-                F isa System ? on_affine_chart(F; compile = compile) : on_affine_chart(F),
+                on_affine_chart(F; compile = compile),
                 V,
                 W;
                 gamma = gamma,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -275,11 +275,14 @@ function linear_subspace_homotopy(
     W::LinearSubspace;
     compile::Union{Bool,Symbol} = COMPILE_DEFAULT[],
     intrinsic = nothing,
+    homogeneous::Union{Nothing,Bool} = nothing,
     gamma = cis(2 * pi * randn()),
 )
 
+    is_hom = isnothing(homogeneous) ? is_homogeneous(System(F)) : homogeneous
+
     if dim(V) <= codim(V) || something(intrinsic, false)
-        if is_linear(V) && is_linear(W) && is_homogeneous(System(F))
+        if is_linear(V) && is_linear(W) && is_hom
             IntrinsicSubspaceHomotopy(
                 on_affine_chart(F; compile = compile),
                 V,
@@ -291,7 +294,7 @@ function linear_subspace_homotopy(
         end
     else
         H = ExtrinsicSubspaceHomotopy(F, V, W; compile = compile, gamma = gamma)
-        if is_linear(V) && is_linear(W) && is_homogeneous(System(F))
+        if is_linear(V) && is_linear(W) && is_hom
             on_affine_chart(H)
         else
             H

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -279,10 +279,12 @@ function linear_subspace_homotopy(
 )
 
 
-    if dim(V) <= codim(V) || something(intrinsic, false)
+    use_intrinsic = isnothing(intrinsic) ? dim(V) <= codim(V) : intrinsic
+
+    if use_intrinsic
         if is_linear(V) && is_linear(W) && is_homogeneous(System(F))
             IntrinsicSubspaceHomotopy(
-                on_affine_chart(F; compile = compile),
+                F isa System ? on_affine_chart(F; compile = compile) : on_affine_chart(F),
                 V,
                 W;
                 gamma = gamma,

--- a/src/systems/affine_chart_system.jl
+++ b/src/systems/affine_chart_system.jl
@@ -30,7 +30,7 @@ on_affine_chart(
 ) = on_affine_chart(fixed(F; compile = compile), dims)
 function on_affine_chart(
     F::AbstractSystem,
-    dims = nothing,
+    dims = nothing;
     compile::Union{Bool,Symbol} = true,
 )
     vargroups = variable_groups(F)

--- a/src/witness_set.jl
+++ b/src/witness_set.jl
@@ -365,16 +365,6 @@ function is_contained(
 
     out
 end
-membership_representative(x, tracker, ::Val{false}) = x
-function membership_representative(x, tracker, ::Val{true})
-    x_chart = copy(x)
-    membership_representative!(x_chart, tracker.tracker.homotopy, x)
-    x_chart
-end
-membership_representative!(x_chart, H, x) = set_solution!(x_chart, H, x, 1)
-membership_representative!(x_chart, H::IntrinsicSubspaceHomotopy, x) =
-    set_solution!(x_chart, H.system, x)
-
 function serial_x_in_Y(
     P,
     Y,
@@ -421,7 +411,13 @@ function serial_x_in_Y(
         end
         # set L as the target for homotopy continuation
         target_parameters!(tracker, L)
-        x_target = membership_representative(x, tracker, projective)
+        if projective isa Val{true}
+            H = tracker.tracker.homotopy
+            set_solution!(tracker.tracker.state.x, H, x, 0)
+            x_target = get_solution(H, tracker.tracker.state.x, 0)
+        else
+            x_target = x
+        end
 
         rad = max(atol, norm(x_target, Inf) * rtol)
 
@@ -520,8 +516,13 @@ function threaded_x_in_Y(
                             end
                             # set L as the target for homotopy continuation
                             target_parameters!(local_tracker, L)
-                            x_target =
-                                membership_representative(x, local_tracker, projective)
+                            if projective isa Val{true}
+                                H = local_tracker.tracker.homotopy
+                                set_solution!(local_tracker.tracker.state.x, H, x, 0)
+                                x_target = get_solution(H, local_tracker.tracker.state.x, 0)
+                            else
+                                x_target = x
+                            end
 
                             rad = max(atol, norm(x_target, Inf) * rtol)
 

--- a/src/witness_set.jl
+++ b/src/witness_set.jl
@@ -352,7 +352,7 @@ function is_contained(
     endgame_options = cache.endgame_options
     projective = Y.projective
     LY = linear_subspace(Y)
-    Hom = linear_subspace_homotopy(F, LY, LY; intrinsic = false)
+    Hom = linear_subspace_homotopy(F, LY, LY)
     tracker =
         EndgameTracker(Hom; tracker_options = tracker_options, options = endgame_options)
 
@@ -365,69 +365,15 @@ function is_contained(
 
     out
 end
-function target_subspace_through(A, b, x, ::Val{false})
-    LA.mul!(b, A, x)
-    LinearSubspace(ExtrinsicDescription(copy(A), copy(b); orthonormal = true))
-end
-function target_subspace_through(A, b, x, ::Val{true})
-    r, n = size(A)
-    Aₓ = zeros(ComplexF64, r, n)
-    bₓ = zeros(ComplexF64, r)
-    x′x = sum(abs2, x)
-    z = conj.(x)
-
-    nrows = 0
-    for i = 1:r
-        nrows += add_projective_row!(Aₓ, nrows, view(A, i, :), x, z, x′x)
-    end
-    while nrows < r
-        nrows += add_projective_row!(Aₓ, nrows, randn(ComplexF64, n), x, z, x′x)
-    end
-
-    LinearSubspace(ExtrinsicDescription(Aₓ, bₓ; orthonormal = true))
-end
-function add_projective_row!(A, nrows, row, x, z, x′x)
-    candidate = Vector{ComplexF64}(undef, length(x))
-    α = zero(ComplexF64)
-    for j = 1:length(x)
-        α += row[j] * x[j]
-    end
-    α /= x′x
-    for j = 1:length(x)
-        candidate[j] = row[j] - α * z[j]
-    end
-
-    if LA.norm(candidate) < 1e-12
-        return 0
-    end
-    if nrows > 0
-        B = A[1:nrows, :]
-        for i = 1:nrows
-            β = zero(ComplexF64)
-            for j = 1:length(candidate)
-                β += candidate[j] * conj(B[i, j])
-            end
-            for j = 1:length(candidate)
-                candidate[j] -= β * B[i, j]
-            end
-        end
-    end
-
-    norm_candidate = LA.norm(candidate)
-    if norm_candidate < 1e-12
-        return 0
-    end
-    for j = 1:length(candidate)
-        A[nrows+1, j] = candidate[j] / norm_candidate
-    end
-    1
-end
 membership_representative(x, tracker, ::Val{false}) = x
 function membership_representative(x, tracker, ::Val{true})
     x_chart = copy(x)
-    set_solution!(x_chart, tracker.tracker.homotopy, x, 1)
+    membership_representative!(x_chart, tracker.tracker.homotopy, x)
     x_chart
 end
+membership_representative!(x_chart, H, x) = set_solution!(x_chart, H, x, 1)
+membership_representative!(x_chart, H::IntrinsicSubspaceHomotopy, x) =
+    set_solution!(x_chart, H.system, x)
 
 function serial_x_in_Y(
     P,
@@ -467,7 +413,12 @@ function serial_x_in_Y(
         end
 
         # second check
-        L = target_subspace_through(A, b, x, projective)
+        if projective isa Val{true}
+            L = rand_subspace!(A, b, x; affine = false)
+        else
+            LA.mul!(b, A, x)
+            L = LinearSubspace(ExtrinsicDescription(copy(A), copy(b); orthonormal = true))
+        end
         # set L as the target for homotopy continuation
         target_parameters!(tracker, L)
         x_target = membership_representative(x, tracker, projective)
@@ -519,6 +470,7 @@ function threaded_x_in_Y(
     trackers = [deepcopy(tracker) for _ = 1:nthr]
     y0_bufs = [zeros(ComplexF64, length(cache.y0)) for _ = 1:nthr]
     y_bufs = [zeros(ComplexF64, length(cache.y)) for _ = 1:nthr]
+    A_bufs = [copy(A) for _ = 1:nthr]
     b_bufs = [deepcopy(b) for _ = 1:nthr]
     F_bufs = [deepcopy(F) for _ = 1:nthr]
 
@@ -530,6 +482,7 @@ function threaded_x_in_Y(
             let local_tracker = trackers[tid],
                 local_y0 = y0_bufs[tid],
                 local_y = y_bufs[tid],
+                local_A = A_bufs[tid],
                 local_b = b_bufs[tid]
 
                 local_F = F_bufs[tid]
@@ -553,7 +506,18 @@ function threaded_x_in_Y(
                         result = false
                         if norm(local_y, Inf) <= 1e-2 * norm(local_y0, Inf)
                             # second check
-                            L = target_subspace_through(A, local_b, x, projective)
+                            if projective isa Val{true}
+                                L = rand_subspace!(local_A, local_b, x; affine = false)
+                            else
+                                LA.mul!(local_b, A, x)
+                                L = LinearSubspace(
+                                    ExtrinsicDescription(
+                                        copy(A),
+                                        copy(local_b);
+                                        orthonormal = true,
+                                    ),
+                                )
+                            end
                             # set L as the target for homotopy continuation
                             target_parameters!(local_tracker, L)
                             x_target =

--- a/src/witness_set.jl
+++ b/src/witness_set.jl
@@ -350,21 +350,95 @@ function is_contained(
     # set up homotopy
     tracker_options = cache.tracker_options
     endgame_options = cache.endgame_options
+    projective = Y.projective
     LY = linear_subspace(Y)
-    Hom = linear_subspace_homotopy(F, LY, LY)
+    Hom = linear_subspace_homotopy(F, LY, LY; intrinsic = false)
     tracker =
         EndgameTracker(Hom; tracker_options = tracker_options, options = endgame_options)
 
     # tracking
     if threading
-        out = threaded_x_in_Y(P, Y, F, tracker, cache; kwargs...)
+        out = threaded_x_in_Y(P, Y, F, tracker, cache, Val(projective); kwargs...)
     else
-        out = serial_x_in_Y(P, Y, F, tracker, cache; kwargs...)
+        out = serial_x_in_Y(P, Y, F, tracker, cache, Val(projective); kwargs...)
     end
 
     out
 end
-function serial_x_in_Y(P, Y, F, tracker, cache; atol = 1e-14, rtol = sqrt(eps()))
+function target_subspace_through(A, b, x, ::Val{false})
+    LA.mul!(b, A, x)
+    LinearSubspace(ExtrinsicDescription(copy(A), copy(b); orthonormal = true))
+end
+function target_subspace_through(A, b, x, ::Val{true})
+    r, n = size(A)
+    Aₓ = zeros(ComplexF64, r, n)
+    bₓ = zeros(ComplexF64, r)
+    x′x = sum(abs2, x)
+    z = conj.(x)
+
+    nrows = 0
+    for i = 1:r
+        nrows += add_projective_row!(Aₓ, nrows, view(A, i, :), x, z, x′x)
+    end
+    while nrows < r
+        nrows += add_projective_row!(Aₓ, nrows, randn(ComplexF64, n), x, z, x′x)
+    end
+
+    LinearSubspace(ExtrinsicDescription(Aₓ, bₓ; orthonormal = true))
+end
+function add_projective_row!(A, nrows, row, x, z, x′x)
+    candidate = Vector{ComplexF64}(undef, length(x))
+    α = zero(ComplexF64)
+    for j = 1:length(x)
+        α += row[j] * x[j]
+    end
+    α /= x′x
+    for j = 1:length(x)
+        candidate[j] = row[j] - α * z[j]
+    end
+
+    if LA.norm(candidate) < 1e-12
+        return 0
+    end
+    if nrows > 0
+        B = A[1:nrows, :]
+        for i = 1:nrows
+            β = zero(ComplexF64)
+            for j = 1:length(candidate)
+                β += candidate[j] * conj(B[i, j])
+            end
+            for j = 1:length(candidate)
+                candidate[j] -= β * B[i, j]
+            end
+        end
+    end
+
+    norm_candidate = LA.norm(candidate)
+    if norm_candidate < 1e-12
+        return 0
+    end
+    for j = 1:length(candidate)
+        A[nrows+1, j] = candidate[j] / norm_candidate
+    end
+    1
+end
+membership_representative(x, tracker, ::Val{false}) = x
+function membership_representative(x, tracker, ::Val{true})
+    x_chart = copy(x)
+    set_solution!(x_chart, tracker.tracker.homotopy, x, 1)
+    x_chart
+end
+
+function serial_x_in_Y(
+    P,
+    Y,
+    F,
+    tracker,
+    cache,
+    projective::Val;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
 
     progress = cache.progress
     x0 = cache.x0
@@ -373,7 +447,9 @@ function serial_x_in_Y(P, Y, F, tracker, cache; atol = 1e-14, rtol = sqrt(eps())
     y = cache.y
     l_X = length(P)
 
-    A, b = cache.A, cache.b
+    cY = codim(linear_subspace(Y))
+    A = view(cache.A, 1:cY, :)
+    b = view(cache.b, 1:cY)
 
     # Pre-allocate output
     out = Vector{Bool}(undef, l_X)
@@ -391,20 +467,18 @@ function serial_x_in_Y(P, Y, F, tracker, cache; atol = 1e-14, rtol = sqrt(eps())
         end
 
         # second check
-        LA.mul!(b, A, x)
-        # set up the corresponding LinearSubspace L
-        E = ExtrinsicDescription(A, b; orthonormal = true)
-        L = LinearSubspace(E)
+        L = target_subspace_through(A, b, x, projective)
         # set L as the target for homotopy continuation
         target_parameters!(tracker, L)
+        x_target = membership_representative(x, tracker, projective)
 
-        rad = max(atol, norm(x, Inf) * rtol)
+        rad = max(atol, norm(x_target, Inf) * rtol)
 
         # add the points in Y to U after we have moved them towards L 
         for p in points(Y)
             track!(tracker, p, 1)
             q = solution(tracker)
-            d = distance(q, x, InfNorm())
+            d = distance(q, x_target, InfNorm())
             if d < rad
                 return true
             end
@@ -415,7 +489,16 @@ function serial_x_in_Y(P, Y, F, tracker, cache; atol = 1e-14, rtol = sqrt(eps())
 
     out
 end
-function threaded_x_in_Y(P, Y, F, tracker, cache; atol = 1e-14, rtol = sqrt(eps()))
+function threaded_x_in_Y(
+    P,
+    Y,
+    F,
+    tracker,
+    cache,
+    projective::Val;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
 
     progress = cache.progress
     x0 = cache.x0
@@ -424,7 +507,9 @@ function threaded_x_in_Y(P, Y, F, tracker, cache; atol = 1e-14, rtol = sqrt(eps(
     y = cache.y
     l_X = length(P)
 
-    A, b = cache.A, cache.b
+    cY = codim(linear_subspace(Y))
+    A = view(cache.A, 1:cY, :)
+    b = view(cache.b, 1:cY)
 
     # Pre-allocate output
     out = Vector{Bool}(undef, l_X)
@@ -468,20 +553,19 @@ function threaded_x_in_Y(P, Y, F, tracker, cache; atol = 1e-14, rtol = sqrt(eps(
                         result = false
                         if norm(local_y, Inf) <= 1e-2 * norm(local_y0, Inf)
                             # second check
-                            LA.mul!(local_b, A, x)
-                            # set up the corresponding LinearSubspace L
-                            E = ExtrinsicDescription(A, local_b; orthonormal = true)
-                            L = LinearSubspace(E)
+                            L = target_subspace_through(A, local_b, x, projective)
                             # set L as the target for homotopy continuation
                             target_parameters!(local_tracker, L)
+                            x_target =
+                                membership_representative(x, local_tracker, projective)
 
-                            rad = max(atol, norm(x, Inf) * rtol)
+                            rad = max(atol, norm(x_target, Inf) * rtol)
 
                             # add the points in Y to U after we have moved them towards L 
                             for p in points(Y)
                                 track!(local_tracker, p, 1)
                                 q = solution(local_tracker)
-                                if distance(q, x, InfNorm()) < rad
+                                if distance(q, x_target, InfNorm()) < rad
                                     result = true
                                     break
                                 end

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -135,6 +135,7 @@
         @test dim.(W_Quadric) == [2]
         @test all(W -> W.projective, W_Quadric)
         @test all(W -> is_linear(linear_subspace(W)), W_Quadric)
+        @test membership(solutions(only(W_Quadric))[1], only(W_Quadric); show_progress = false)
 
         W_GroupedQuadric = regeneration(
             System(expressions(Quadric), variable_groups = [x]);
@@ -164,6 +165,14 @@
         @test dim.(W_CI) == [1]
         @test all(W -> W.projective, W_CI)
         @test all(W -> is_linear(linear_subspace(W)), W_CI)
+
+        a = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
+        b = x[1]^3 + x[2]^3 + 2x[3]^3 + 3x[4]^3
+        c = x[1]^4 + 2x[2]^4 + 4x[3]^4 - x[4]^4
+        ProductSystem = System([a * c; b * c], x)
+        N_Product = nid(ProductSystem; show_progress = false, threading = false)
+        @test degrees(N_Product) == Dict(2 => [4], 1 => [6])
+        @test ncomponents(N_Product) == 2
     end
 
     @testset "Overdetermined Test" begin

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -18,7 +18,7 @@
         # sorting
         W = regeneration(F; sorted = false, show_progress = false)
         @test degree.(W) == [2, 8, 8]
-        
+
         N = NumericalIrreducibleDecomposition(decompose(W))
         @test seed(N) == s
 

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -124,55 +124,18 @@
     @testset "Homogeneous systems" begin
         @var x[1:4]
 
-        Quadric = System([x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2], x)
-        W_Quadric = regeneration(
-            Quadric;
-            show_progress = false,
-            threading = false,
-            seed = 0x12345678,
-        )
-        @test degree.(W_Quadric) == [2]
-        @test dim.(W_Quadric) == [2]
-        @test all(W -> W.projective, W_Quadric)
-        @test all(W -> is_linear(linear_subspace(W)), W_Quadric)
-        @test membership(solutions(only(W_Quadric))[1], only(W_Quadric); show_progress = false)
-
-        W_GroupedQuadric = regeneration(
-            System(expressions(Quadric), variable_groups = [x]);
-            show_progress = false,
-            threading = false,
-            seed = 0x12345678,
-        )
-        @test degree.(W_GroupedQuadric) == [2]
-        @test dim.(W_GroupedQuadric) == [2]
-        @test all(W -> W.projective, W_GroupedQuadric)
-        @test all(W -> is_linear(linear_subspace(W)), W_GroupedQuadric)
-
-        CompleteIntersection = System(
-            [
-                x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2,
-                x[1]^3 + x[2]^3 + 2x[3]^3 + 3x[4]^3,
-            ],
-            x,
-        )
-        W_CI = regeneration(
-            CompleteIntersection;
-            show_progress = false,
-            threading = false,
-            seed = 0x12345678,
-        )
-        @test degree.(W_CI) == [6]
-        @test dim.(W_CI) == [1]
-        @test all(W -> W.projective, W_CI)
-        @test all(W -> is_linear(linear_subspace(W)), W_CI)
-
         a = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
         b = x[1]^3 + x[2]^3 + 2x[3]^3 + 3x[4]^3
         c = x[1]^4 + 2x[2]^4 + 4x[3]^4 - x[4]^4
-        ProductSystem = System([a * c; b * c], x)
-        N_Product = nid(ProductSystem; show_progress = false, threading = false)
-        @test degrees(N_Product) == Dict(2 => [4], 1 => [6])
-        @test ncomponents(N_Product) == 2
+        G = System([a * c; b * c]; variables = x)
+        N = nid(G; show_progress = false)
+        @test degrees(N) == Dict(2 => [4], 1 => [6])
+        @test ncomponents(N) == 2
+
+        Ws = witness_sets(N)
+        W1, W2 = Ws[1][1], Ws[2][1]
+        @test all(W -> W.projective, [W1; W2])
+        @test all(W -> is_linear(linear_subspace(W)), [W1; W2])
     end
 
     @testset "Overdetermined Test" begin

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -27,36 +27,16 @@
         N = nid(F; threading = false, show_progress = false)
         @test isa(N, NumericalIrreducibleDecomposition)
 
-        # seed
-        s = 0x42c9d504
-        N = nid(F; seed = s, show_progress = false)
-        @test seed(N) == s
-
-        N = nid(F; seed = nothing, show_progress = false)
-        @test isnothing(seed(N))
-
         # bad seed
-        N = nid(F; seed = UInt32(62), show_progress = false)
+        s = UInt32(62)
+        N = nid(F; seed = s, show_progress = false)
         degs = degrees(N)
+        @test seed(N) == s
         @test degs[2] == [2]
         @test degs[1] == [4, 4]
 
-
-        N = nid(F; show_monodromy_progress = true, show_progress = false)
-        @test isa(N, NumericalIrreducibleDecomposition)
-
-        N = nid(F; warning = false, show_progress = false)
-        @test isa(N, NumericalIrreducibleDecomposition)
-
-        N = nid(
-            F;
-            seed = UInt32(62),
-            sorted = true,
-            threading = false,
-            show_progress = false,
-        )
-        @test degrees(N)[2] == [2]
-        @test degrees(N)[1] == [4, 4]
+        N = nid(F; seed = nothing, show_progress = false)
+        @test isnothing(seed(N))
 
         # options
         N_fails = nid(
@@ -68,29 +48,24 @@
 
         N2 = nid(
             F;
-            tracker_options = TrackerOptions(; extended_precision = false),
+            monodromy_options = MonodromyOptions(; trace_test_tol = 1e-5),
             show_progress = false,
         )
         @test isa(N2, NumericalIrreducibleDecomposition)
 
-        N3 = nid(
-            F;
-            monodromy_options = MonodromyOptions(; trace_test_tol = 1e-5),
-            show_progress = false,
-        )
-        @test isa(N3, NumericalIrreducibleDecomposition)
+        N = nid(F; show_monodromy_progress = true, show_progress = false)
+        @test isa(N, NumericalIrreducibleDecomposition)
+
+        N = nid(F; warning = false, show_progress = false)
+        @test isa(N, NumericalIrreducibleDecomposition)
 
         # number of components
-        @test ncomponents(N3) == 11
-        @test ncomponents(N3, dims = [1, 2]) == 3
-        @test ncomponents(N3, 1) == 2
-        @test n_components(N3) == 11
-        @test n_components(N3, dims = [1, 2]) == 3
-        @test n_components(N3, 1) == 2
-
-        # max_codim = 1
-        N4 = nid(F; max_codim = 1, show_progress = false)
-        @test isa(N4, NumericalIrreducibleDecomposition)
+        @test ncomponents(N2) == 11
+        @test ncomponents(N2, dims = [1, 2]) == 3
+        @test ncomponents(N2, 1) == 2
+        @test n_components(N2) == 11
+        @test n_components(N2, dims = [1, 2]) == 3
+        @test n_components(N2, 1) == 2
     end
 
     @testset "rational systems" begin

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -19,9 +19,6 @@
         W = regeneration(F; sorted = false, show_progress = false)
         @test degree.(W) == [2, 8, 8]
 
-        N = NumericalIrreducibleDecomposition(decompose(W))
-        @test seed(N) == s
-
         # limited codimension
         W = regeneration(F; max_codim = 2, show_progress = false)
         @test degree.(W) == [2, 8]

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -18,6 +18,9 @@
         # sorting
         W = regeneration(F; sorted = false, show_progress = false)
         @test degree.(W) == [2, 8, 8]
+        
+        N = NumericalIrreducibleDecomposition(decompose(W))
+        @test seed(N) == s
 
         # limited codimension
         W = regeneration(F; max_codim = 2, show_progress = false)
@@ -36,7 +39,7 @@
         @test isnothing(seed(N))
 
         # bad seed
-        N = nid(F; seed = 0xc770fa47, show_progress = false)
+        N = nid(F; seed = UInt32(62), show_progress = false)
         degs = degrees(N)
         @test degs[2] == [2]
         @test degs[1] == [4, 4]
@@ -47,6 +50,16 @@
 
         N = nid(F; warning = false, show_progress = false)
         @test isa(N, NumericalIrreducibleDecomposition)
+
+        N = nid(
+            F;
+            seed = UInt32(62),
+            sorted = true,
+            threading = false,
+            show_progress = false,
+        )
+        @test degrees(N)[2] == [2]
+        @test degrees(N)[1] == [4, 4]
 
         # options
         N_fails = nid(

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -121,6 +121,51 @@
         @test ncomponents(N_Curve) == 1
     end
 
+    @testset "Homogeneous systems" begin
+        @var x[1:4]
+
+        Quadric = System([x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2], x)
+        W_Quadric = regeneration(
+            Quadric;
+            show_progress = false,
+            threading = false,
+            seed = 0x12345678,
+        )
+        @test degree.(W_Quadric) == [2]
+        @test dim.(W_Quadric) == [2]
+        @test all(W -> W.projective, W_Quadric)
+        @test all(W -> is_linear(linear_subspace(W)), W_Quadric)
+
+        W_GroupedQuadric = regeneration(
+            System(expressions(Quadric), variable_groups = [x]);
+            show_progress = false,
+            threading = false,
+            seed = 0x12345678,
+        )
+        @test degree.(W_GroupedQuadric) == [2]
+        @test dim.(W_GroupedQuadric) == [2]
+        @test all(W -> W.projective, W_GroupedQuadric)
+        @test all(W -> is_linear(linear_subspace(W)), W_GroupedQuadric)
+
+        CompleteIntersection = System(
+            [
+                x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2,
+                x[1]^3 + x[2]^3 + 2x[3]^3 + 3x[4]^3,
+            ],
+            x,
+        )
+        W_CI = regeneration(
+            CompleteIntersection;
+            show_progress = false,
+            threading = false,
+            seed = 0x12345678,
+        )
+        @test degree.(W_CI) == [6]
+        @test dim.(W_CI) == [1]
+        @test all(W -> W.projective, W_CI)
+        @test all(W -> is_linear(linear_subspace(W)), W_CI)
+    end
+
     @testset "Overdetermined Test" begin
         @var x y z
         TwistedCubicSphere =

--- a/test/witness_set_test.jl
+++ b/test/witness_set_test.jl
@@ -116,7 +116,7 @@
     b = x[1]^3 + x[2]^3 + 2x[3]^3 + 3x[4]^3
     c = x[1]^4 + 2x[2]^4 + 4x[3]^4 - x[4]^4
     G = System([a * c; b * c]; variables = x)
-    
+
     @testset "membership projective" begin
         W = witness_set(G; codim = 2)
 

--- a/test/witness_set_test.jl
+++ b/test/witness_set_test.jl
@@ -92,7 +92,6 @@
         p * q * (y - 3) * (y - 5)
         p * (z - 3) * (z - 5)
     ]
-
     @testset "membership" begin
         W = witness_set(F; codim = 2)
 
@@ -101,8 +100,8 @@
 
         @test !membership(p, W)
         @test membership(q, W; show_progress = false)
-        a = membership([p, q], W; show_progress = false)
-        @test a == [false, true]
+        memb = membership([p, q], W; show_progress = false)
+        @test memb == [false, true]
     end
 
     @testset "intersect" begin
@@ -110,6 +109,30 @@
         B = intersect(H[1], H[2])
         C = vcat([intersect(Hi, H[3]; show_progress = false) for Hi in B]...)
         @test degree.(C) == [2, 8, 8]
+    end
+
+    @var x[1:4]
+    a = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
+    b = x[1]^3 + x[2]^3 + 2x[3]^3 + 3x[4]^3
+    c = x[1]^4 + 2x[2]^4 + 4x[3]^4 - x[4]^4
+    G = System([a * c; b * c]; variables = x)
+    
+    @testset "membership projective" begin
+        W = witness_set(G; codim = 2)
+
+        p = randn(4)
+        q = solutions(W)[1]
+
+        @test !membership(p, W)
+        @test membership(q, W; show_progress = false)
+        memb = membership([p, q], W; show_progress = false)
+        @test memb == [false, true]
+    end
+
+    @testset "intersect projective" begin
+        H = [witness_set(g) for g in G]
+        B = intersect(H[1], H[2])
+        @test degree.(B) == [4, 6]
     end
 
 end


### PR DESCRIPTION
This patch notes makes numerical irreducible decomposition work properly for homogeneous systems.

## Patch Notes


* Added support for homogeneous systems in numerical irreducible decomposition.

* Extended witness set membership and intersection workflows to handle projective witness sets consistently.

* Preserved projective normalization behavior in the new NID paths.

* Improved robustness around singular or ill-conditioned witness points during regeneration and intersection.
