### PR TITLE
Nid stability

### DIFF
--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1378,7 +1378,7 @@ function decompose_with_monodromy!(
 )
     update_progress_dim!(progress, dim(W))
 
-    P = points(W)
+    P = unique_points(points(W))
     L = linear_subspace(W)
     G = system(W)
     n = ambient_dim(L)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1391,7 +1391,7 @@ function decompose_with_monodromy!(
                 if trace(res_orbit) < options.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
-                    if length(orbit) > 1 || iter ≥ 50 || iter ≥ max_iters - 1
+                    if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         complete_orbit =

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -550,7 +550,7 @@ function initialize_hypersurfaces(
         if qᵢ != 1
             res = solve(
                 h,
-                solutions(res);
+                solution.(results(res));
                 start_subspace = L,
                 target_subspace = L,
                 show_progress = false,
@@ -560,7 +560,7 @@ function initialize_hypersurfaces(
         if isnothing(res)
             return nothing
         end
-        S = solutions(res, only_nonsingular = true)
+        S = solution.(results(res))
         out[i] = WitnessSet(h, L, S)
     end
     out
@@ -624,7 +624,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
             if nsolutions(res) == 0
                 W.R = Vector{Vector{ComplexF64}}()
             else
-                W.R = unique_points(solutions(res))
+                W.R = solution.(results(res))
             end
             update_progress!(progress, W)
         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -654,7 +654,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 Fᵢ,
                 W.R,
                 linear_subspace(W);
-                options = regeneration_monodromy_options(monodromy_options, W),
+                options = regeneration_monodromy_options(monodromy_options, W; atol = atol, rtol = rtol),
                 show_progress = show_monodromy_progress,
                 progress = show_monodromy_progress ? nothing : progress,
                 threading = threading,
@@ -676,7 +676,7 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
     end
 end
 
-function regeneration_monodromy_options(M::MonodromyOptions, W)
+function regeneration_monodromy_options(M::MonodromyOptions, W; atol = 1e-14, rtol = sqrt(eps()))
 
     MonodromyOptions(;
         permutations = false,
@@ -697,8 +697,10 @@ function regeneration_monodromy_options(M::MonodromyOptions, W)
         max_loops_no_progress = M.max_loops_no_progress,
         reuse_loops = M.reuse_loops,
         distance = M.distance,
-        unique_points_atol = M.unique_points_atol,
-        unique_points_rtol = M.unique_points_rtol,
+        # Forward the practical tolerances so monodromy's internal add! uses them
+        # rather than the tight per-solution uniqueness_rtol(res) based on ω.
+        unique_points_atol = something(M.unique_points_atol, atol),
+        unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
 end
 
@@ -1723,9 +1725,9 @@ function get_orbits_from_monodromy_permutations(
     orbits
 end
 
-function decompose_with_monodromy_options(M::MonodromyOptions)
+function decompose_with_monodromy_options(M::MonodromyOptions; atol = 1e-14, rtol = sqrt(eps()))
 
-    # we need two copies of the options. 
+    # we need two copies of the options.
     # one with trace test
     # one without to run monodromy populating the permutation matrix
     options_with_trace = MonodromyOptions(;
@@ -1747,8 +1749,8 @@ function decompose_with_monodromy_options(M::MonodromyOptions)
         max_loops_no_progress = M.max_loops_no_progress,
         reuse_loops = M.reuse_loops,
         distance = M.distance,
-        unique_points_atol = M.unique_points_atol,
-        unique_points_rtol = M.unique_points_rtol,
+        unique_points_atol = something(M.unique_points_atol, atol),
+        unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
     options_without_trace = MonodromyOptions(;
         permutations = true,
@@ -1769,8 +1771,8 @@ function decompose_with_monodromy_options(M::MonodromyOptions)
         max_loops_no_progress = M.max_loops_no_progress,
         reuse_loops = M.reuse_loops,
         distance = M.distance,
-        unique_points_atol = M.unique_points_atol,
-        unique_points_rtol = M.unique_points_rtol,
+        unique_points_atol = something(M.unique_points_atol, atol),
+        unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
 
     options_with_trace, options_without_trace
@@ -1830,6 +1832,8 @@ function decompose(
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
+    atol = 1e-14,
+    rtol = sqrt(eps()),
 ) where {WP<:WitnessSet}
 
     if isnothing(seed)
@@ -1838,7 +1842,7 @@ function decompose(
     Random.seed!(seed)
 
     sort!(Ws; by = dim, rev = true)
-    options = decompose_with_monodromy_options(monodromy_options)
+    options = decompose_with_monodromy_options(monodromy_options; atol = atol, rtol = rtol)
     out = Vector{WitnessSet}()
 
     if isempty(Ws)
@@ -2216,6 +2220,8 @@ function numerical_irreducible_decomposition(
         threading = threading,
         warning = warning,
         seed = seed,
+        atol = atol,
+        rtol = rtol,
         kwargs...,
     )
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -829,25 +829,24 @@ end
 function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
     l_start = length(P) * length(roots)
     P1 = Vector{Vector{ComplexF64}}(undef, l_start)
-    accepted1 = falses(l_start)
-    accepted2 = falses(l_start)
+    accepted = falses(l_start)
 
     ntrials = max(cache.max_trials_u_homotopy, 1)
     for trial = 1:ntrials
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
 
-        fill!(accepted1, false)
-        fill!(accepted2, false)
+        fill!(accepted, false)
         track_hom1!(accepted1, P1, P, roots, trackers[1], progress, threading)
-        all(accepted1) || continue
+        all(accepted) || continue
 
         # Hom1 only moves the slice. We still need to verify that its endpoints
         # are usable starts for Hom2; otherwise resample L1 and try again.
-        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
-        all(accepted2) && break
+        fill!(accepted, false)
+        check_hom2_starts!(accepted2, P1, trackers[2], progress, threading)
+        all(accepted) && break
     end
 
-    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
 
     nothing
 end
@@ -923,19 +922,19 @@ function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
     end
 end
 
-function check_hom2_starts!(accepted, P1, accepted1, tracker, progress, threading)
+function check_hom2_starts!(accepted, P1, tracker, progress, threading)
     if threading
-        threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     else
-        serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+        serial_check_hom2_starts!(accepted, P1, tracker, progress)
     end
 end
 
-function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     end
 end
 
@@ -958,12 +957,11 @@ function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
-        accepted1[i] || continue
 
         code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
         accepted[i] = is_success(code)
@@ -972,12 +970,11 @@ function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
-        accepted[i] || continue
 
         code2 = track!(tracker2, P1[i], 1)
         if is_accepted(tracker2, code2)
@@ -1036,7 +1033,7 @@ function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
 
     l_start = length(P1)
 
@@ -1060,7 +1057,6 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
-                        accepted1[idx] || continue
 
                         code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
                         accepted[idx] = is_success(code)
@@ -1073,7 +1069,7 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1098,7 +1094,6 @@ function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
-                        accepted[idx] || continue
 
                         code2 = track!(local_tracker2, P1[idx], 1)
                         if is_accepted(local_tracker2, code2)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -752,6 +752,7 @@ function intersect_with_hypersurface!(
     else
         serial_intersection!(X, P_next, roots, trackers, u_data, cache, progress)
     end
+
     nothing
 end
 
@@ -1405,6 +1406,7 @@ function decompose_with_monodromy!(
             )
             update_progress!(progress; is_monodromy = false)
 
+            prev_count = length(non_complete_points)
             updated_points = indexed_solutions(res)
             d += length(updated_points) - length(non_complete_points) # update total degree in case we found new points.
             non_complete_points = updated_points
@@ -1412,7 +1414,13 @@ function decompose_with_monodromy!(
             k = length(non_complete_points) # and once for counting progress
             update_progress_npts!(progress, k)
 
-            # Get orbits from monodromy result            
+            # If monodromy deduplicated starting solutions, the cached orbit indices are
+            # stale (they reference the old count). Reset to avoid a BoundsError.
+            if length(non_complete_points) < prev_count
+                non_complete_orbits = Vector{Set{Int}}()
+            end
+
+            # Get orbits from monodromy result
             orbits = get_orbits_from_monodromy_permutations(
                 res;
                 initial_orbits = non_complete_orbits,
@@ -1442,7 +1450,12 @@ function decompose_with_monodromy!(
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         complete_orbit =
-                            length(P_certified) == length(orbit) ? orbit :
+                            # matching_indices is only needed when P_certified found more
+                            # witness points than orbit contained. When P_certified has
+                            # fewer points (inner monodromy deduplicated some starts), the
+                            # full orbit is still complete — collapsed elements were just
+                            # numerical duplicates on the same component.
+                            length(P_certified) > length(orbit) ?
                             Set(
                                 matching_indices(
                                     non_complete_points,
@@ -1451,7 +1464,8 @@ function decompose_with_monodromy!(
                                     atol = something(options.unique_points_atol, 1e-14),
                                     rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
-                            )
+                            ) :
+                            orbit
 
                         push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1694,7 +1694,7 @@ This function decomposes a [`WitnessSet`](@ref) or a vector of [`WitnessSet`](@r
 * `show_progress = true`: indicate whether a progress bar should be displayed.
 * `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `decompose`.
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
-* `max_iters = 50`: maximal number of iterations for the decomposition step.
+* `max_iters = 200`: maximal number of iterations for the decomposition step.
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -1736,7 +1736,7 @@ function decompose(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
-    max_iters::Int = 50,
+    max_iters::Int = 200,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -2016,7 +2016,7 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 * `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of each substep.
 * `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed. 
 * `show_monodromy_for_decompose_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`decompose`](@ref) should be displayed.
-* `max_iters = 50`: maximal number of iterations for the decomposition step.
+* `max_iters = 200`: maximal number of iterations for the decomposition step.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).` This option is used for [`regeneration`](@ref).
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
@@ -2084,7 +2084,7 @@ function numerical_irreducible_decomposition(
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
-    max_iters::Int = 50,
+    max_iters::Int = 200,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
     max_trials_u_homotopy::Int = 5,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1494,8 +1494,6 @@ function decompose_with_monodromy!(
             complete_orbits = Vector{Set{Int}}()
 
             for orbit in orbits
-                success = true # this checks if this run was successful
-
                 update_progress!(progress; is_monodromy = true)
 
                 # Strip phantom indices from the orbit before running inner monodromy.
@@ -1535,42 +1533,39 @@ function decompose_with_monodromy!(
 
                         if length(P_certified) > length(clean_orbit)
                             # Inner monodromy found new points beyond the starting orbit.
-                            # First match them against non_complete_points.
+                            # Match them against non_complete_points to detect orbit merging
+                            # and path-jumping phantoms.
                             matched = setdiff(
                                 Set(
                                     matching_indices(
                                         non_complete_points,
                                         P_certified;
                                         atol = atol,
-                                        rtol = something(options.unique_points_rtol, 1e-8),
+                                        rtol = rtol,
                                     ),
                                 ),
                                 phantom_indices,
                             )
-                            # Only check certified_up when matching_indices left points unaccounted for.
-                            # Unmatched points are either genuine new discoveries or path-jumping phantoms.
+                            # If not all P_certified points are accounted for in non_complete_points,
+                            # the result is unreliable (phantom or genuine new point) — skip.
                             if length(matched) < length(P_certified)
-                                success = false
-                            else
-                                complete_orbit = matched
+                                continue
                             end
+                            complete_orbit = matched
                         else
                             complete_orbit = clean_orbit
                         end
 
-                        # postprocessing
-                        if success
-                            push!(complete_orbits, complete_orbit)
-                            k -= length(complete_orbit)
-                            update_progress_npts!(progress, k)
+                        push!(complete_orbits, complete_orbit)
+                        k -= length(complete_orbit)
+                        update_progress_npts!(progress, k)
 
-                            push!(decomposition, W_new)
-                            for p in solutions(W_new)
-                                add!(certified_up, p, 1; atol = atol, rtol = rtol)
-                            end
-                            d += length(P_certified) - length(complete_orbit)
-                            update_progress!(progress, W_new)
+                        push!(decomposition, W_new)
+                        for p in solutions(W_new)
+                            add!(certified_up, p, 1; atol = atol, rtol = rtol)
                         end
+                        d += length(P_certified) - length(complete_orbit)
+                        update_progress!(progress, W_new)
                     end
                 end
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -829,22 +829,25 @@ end
 function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
     l_start = length(P) * length(roots)
     P1 = Vector{Vector{ComplexF64}}(undef, l_start)
-    accepted = falses(l_start)
+    accepted1 = falses(l_start)
+    accepted2 = falses(l_start)
 
     ntrials = max(cache.max_trials_u_homotopy, 1)
     for trial = 1:ntrials
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
-        
-        fill!(accepted, false)
-        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
-        all(accepted) && break
 
-        fill!(accepted, false)
-        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
-        all(accepted) && break
+        fill!(accepted1, false)
+        fill!(accepted2, false)
+        track_hom1!(accepted1, P1, P, roots, trackers[1], progress, threading)
+        all(accepted1) || continue
+
+        # Hom1 only moves the slice. We still need to verify that its endpoints
+        # are usable starts for Hom2; otherwise resample L1 and try again.
+        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
+        all(accepted2) && break
     end
 
-    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
 
     nothing
 end
@@ -920,19 +923,19 @@ function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
     end
 end
 
-function check_hom2_starts!(accepted, P1, tracker, progress, threading)
+function check_hom2_starts!(accepted, P1, accepted1, tracker, progress, threading)
     if threading
-        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
+        threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     else
-        serial_check_hom2_starts!(accepted, P1, tracker, progress)
+        serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     end
 end
 
-function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     end
 end
 
@@ -955,11 +958,12 @@ function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function serial_check_hom2_starts!(accepted, P1, tracker, progress)
+function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
+        accepted1[i] || continue
 
         code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
         accepted[i] = is_success(code)
@@ -968,11 +972,12 @@ function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
+        accepted[i] || continue
 
         code2 = track!(tracker2, P1[i], 1)
         if is_accepted(tracker2, code2)
@@ -1031,7 +1036,7 @@ function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
     nothing
 end
 
-function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
+function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
 
     l_start = length(P1)
 
@@ -1055,6 +1060,7 @@ function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
+                        accepted1[idx] || continue
 
                         code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
                         accepted[idx] = is_success(code)
@@ -1067,7 +1073,7 @@ function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1092,6 +1098,7 @@ function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
+                        accepted[idx] || continue
 
                         code2 = track!(local_tracker2, P1[idx], 1)
                         if is_accepted(local_tracker2, code2)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -49,6 +49,7 @@ Base.@kwdef mutable struct WitnessSetsProgress
     is_membership_test::Bool = false
     is_monodromy::Bool = false
     is_finished::Bool = false
+    path_label::String = "Computing start solutions" # this is the initial stage of the u-homotopy
     current_path::Int = 0
     npaths::Int = 0
     current_task::Int = 0
@@ -163,6 +164,15 @@ function update_progress_paths!(progress::WitnessSetsProgress, i::Int, m::Int)
         showvalues = showvalues(progress),
     )
 end
+update_progress_path_label!(progress::Nothing, label::String) = nothing
+function update_progress_path_label!(progress::WitnessSetsProgress, label::String)
+    progress.path_label = label
+    PM.update!(
+        progress.progress_meter,
+        progress.current_hypersurface,
+        showvalues = showvalues(progress),
+    )
+end
 update_progress!(progress::Nothing, W::Union{WitnessPoints,WitnessSet}) = nothing
 function update_progress!(progress::WitnessSetsProgress, W::Union{WitnessPoints,WitnessSet})
     progress.degrees[codim(W)] = degree(W)
@@ -199,7 +209,7 @@ function showvalues(progress::WitnessSetsProgress)
             if progress.is_solving
                 push!(
                     text,
-                    ("Track paths", "$(progress.current_path) / $(progress.npaths)"),
+                    (progress.path_label, "$(progress.current_path) / $(progress.npaths)"),
                 )
             elseif progress.is_monodromy
                 push!(
@@ -840,6 +850,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         # is nothing left to resample, so we finish the sweep and keep the
         # starts that did pass the check.
         fail_fast = trial < ntrials
+        update_progress_path_label!(progress, "Computing start solutions")
         track_hom1_and_check_hom2_starts!(
             accepted,
             P1,
@@ -857,6 +868,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
     # `accepted` guards against undefined or rejected P1 entries. This matters
     # both after failed trials and when the final trial only validates a subset
     # of the starts.
+    update_progress_path_label!(progress, "Track paths")
     track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2227,6 +2227,7 @@ Base.@kwdef mutable struct IntersectProgress
     is_membership_test::Bool = false
     is_monodromy::Bool = false
     is_finished::Bool = false
+    path_label::String = "Track paths"
     current_task::Int = 0
     ntasks::Int = 0
     current_path::Int = 0
@@ -2294,6 +2295,12 @@ function update_progress_paths!(progress::IntersectProgress, i::Int, m::Int)
     progress.npaths = m
     PM.update!(progress.progress_meter, showvalues = showvalues(progress))
 end
+function start_progress_paths!(progress::IntersectProgress, label::String, m::Int)
+    progress.path_label = label
+    progress.current_path = 0
+    progress.npaths = m
+    PM.update!(progress.progress_meter, showvalues = showvalues(progress))
+end
 function finish_progress!(progress::IntersectProgress)
     progress.is_solving = false
     progress.is_membership_test = false
@@ -2305,8 +2312,11 @@ function showvalues(progress::IntersectProgress)
 
     if !progress.is_finished
         text = [("Status", "")]
-        if progress.is_solving
-            push!(text, ("Track paths", "$(progress.current_task)/$(progress.ntasks)"))
+        if progress.is_solving && progress.npaths > 0
+            push!(
+                text,
+                (progress.path_label, "$(progress.current_path) / $(progress.npaths)"),
+            )
         elseif progress.is_monodromy
             push!(
                 text,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -844,7 +844,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         all(accepted) && break
     end
 
-    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
 
     nothing
 end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1293,7 +1293,7 @@ The core function for decomposing a witness set into irreducible components.
 function decompose_with_monodromy!(
     W,
     show_monodromy_progress,
-    options,
+    _options,
     max_iters,
     warning,
     progress,
@@ -1312,13 +1312,13 @@ function decompose_with_monodromy!(
     if dim(L) < n
         update_progress!(progress; is_monodromy = true)
 
-        options_with_trace, options_without_trace = options
-        MS_with_trace = MonodromySolver(G, L; compile = false, options = options_with_trace)
+        options, options_without_trace = _options
+        MS = MonodromySolver(G, L; compile = false, options = options)
         MS_without_trace =
             MonodromySolver(G, L; compile = false, options = options_without_trace)
-        initial_points = check_start_solutions(MS_with_trace, P, L)
+        initial_points = check_start_solutions(MS, P, L)
         res = monodromy_solve(
-            MS_with_trace,
+            MS,
             solution.(initial_points),
             L,
             seed;
@@ -1329,7 +1329,7 @@ function decompose_with_monodromy!(
         update_progress!(progress; is_monodromy = false)
         update_progress_npts!(progress, nindexed_solutions(res))
 
-        if warning && (trace(res) > options_with_trace.trace_test_tol)
+        if warning && (trace(res) > options.trace_test_tol)
             @warn "Trying to decompose non-complete set of witness points for codimension $(dim(L)) (trace test failed). Will try to compute the missing points. The output will contain all components, for which the trace test was successfull."
         end
 
@@ -1378,7 +1378,7 @@ function decompose_with_monodromy!(
 
                 P_orbit = non_complete_points[collect(orbit)]
                 res_orbit = monodromy_solve(
-                    MS_with_trace,
+                    MS,
                     P_orbit,
                     L,
                     seed;
@@ -1388,7 +1388,7 @@ function decompose_with_monodromy!(
                 )
                 update_progress!(progress; is_monodromy = false)
 
-                if trace(res_orbit) < options_with_trace.trace_test_tol
+                if trace(res_orbit) < options.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
@@ -1400,9 +1400,9 @@ function decompose_with_monodromy!(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
-                                    norm = options_with_trace.distance,
-                                    atol = something(options_with_trace.unique_points_atol, 1e-14),
-                                    rtol = something(options_with_trace.unique_points_rtol, 1e-8),
+                                    norm = options.distance,
+                                    atol = something(options.unique_points_atol, 1e-14),
+                                    rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
                             )
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -808,7 +808,7 @@ end
 # Hom1 moves the linear equation u = c to a random linear space L1 involving (x,u), where x are the variables of F.
 # Hom2 moves u^d - 1 to the new polynomial fᵢ with deg(fᵢ) = d.
 # Hom3 moves the linear space L1 to the linear space given by the initial witness sets. 
-# We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resampel L1. Only then track Hom2 and Hom3. 
+# We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resample L1. Only then track Hom2 and Hom3. 
 
 const HOM2_START_CHECK_TARGET = 0.95
 
@@ -834,19 +834,29 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
 
         fill!(accepted, false)
-        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
-        if !all(accepted)
-            fill!(accepted, false)
-            continue
-        end
-
-        # Hom1 only moves the slice. We still need to verify that its endpoints
-        # are usable starts for Hom2; otherwise resample L1 and try again.
-        fill!(accepted, false)
-        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
+        # Hom1 and the cheap Hom2 start check are paired: as soon as an
+        # intermediate slice produces a start that Hom2 cannot consume, the
+        # slice is considered bad and we resample it. On the final trial there
+        # is nothing left to resample, so we finish the sweep and keep the
+        # starts that did pass the check.
+        fail_fast = trial < ntrials
+        track_hom1_and_check_hom2_starts!(
+            accepted,
+            P1,
+            P,
+            roots,
+            trackers[1],
+            trackers[2],
+            progress,
+            threading,
+            fail_fast,
+        )
         all(accepted) && break
     end
 
+    # `accepted` guards against undefined or rejected P1 entries. This matters
+    # both after failed trials and when the final trial only validates a subset
+    # of the starts.
     track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing
@@ -915,19 +925,39 @@ function set_up_u_homotopy(W, f, X, h, vars, u)
 end
 
 
-function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
+function track_hom1_and_check_hom2_starts!(
+    accepted,
+    P1,
+    P,
+    roots,
+    tracker1,
+    tracker2,
+    progress,
+    threading,
+    fail_fast,
+)
     if threading
-        threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
+        threaded_track_hom1_and_check_hom2_starts!(
+            accepted,
+            P1,
+            P,
+            roots,
+            tracker1,
+            tracker2,
+            progress,
+            fail_fast,
+        )
     else
-        serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
-    end
-end
-
-function check_hom2_starts!(accepted, P1, tracker, progress, threading)
-    if threading
-        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
-    else
-        serial_check_hom2_starts!(accepted, P1, tracker, progress)
+        serial_track_hom1_and_check_hom2_starts!(
+            accepted,
+            P1,
+            P,
+            roots,
+            tracker1,
+            tracker2,
+            progress,
+            fail_fast,
+        )
     end
 end
 
@@ -939,33 +969,39 @@ function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threadi
     end
 end
 
-function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
+function serial_track_hom1_and_check_hom2_starts!(
+    accepted,
+    P1,
+    P,
+    roots,
+    tracker1,
+    tracker2,
+    progress,
+    fail_fast,
+)
     l_start = length(P) * length(roots)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
 
         p = start_solution(P, roots, i)
-        code = track!(tracker, p, 1)
-        if is_accepted(tracker, code)
-            accepted[i] = true
-            P1[i] = solution(tracker)
-        else
+        code1 = track!(tracker1, p, 1)
+        if !is_accepted(tracker1, code1)
             accepted[i] = false
+            fail_fast && break
+            continue
         end
-    end
 
-    nothing
-end
+        p1 = solution(tracker1)
+        code2 = track!(tracker2.tracker, p1, 1, HOM2_START_CHECK_TARGET)
+        if !is_success(code2)
+            accepted[i] = false
+            fail_fast && break
+            continue
+        end
 
-function serial_check_hom2_starts!(accepted, P1, tracker, progress)
-    l_start = length(P1)
-
-    for i = 1:l_start
-        update_progress_paths!(progress, i, l_start)
-
-        code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
-        accepted[i] = is_success(code)
+        accepted[i] = true
+        P1[i] = p1
     end
 
     nothing
@@ -991,23 +1027,35 @@ function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     nothing
 end
 
-function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
+function threaded_track_hom1_and_check_hom2_starts!(
+    accepted,
+    P1,
+    P,
+    roots,
+    tracker1,
+    tracker2,
+    progress,
+    fail_fast,
+)
 
     l_P = length(P)
     l_roots = length(roots)
     l_start = l_P * l_roots
 
     nthr = Threads.nthreads()
-    trackers = [deepcopy(tracker) for _ = 1:nthr]
+    trackers1 = [deepcopy(tracker1) for _ = 1:nthr]
+    trackers2 = [deepcopy(tracker2.tracker) for _ = 1:nthr]
 
     progress_lock = ReentrantLock()
 
     next_idx = Threads.Atomic{Int}(1)
+    failed = Threads.Atomic{Bool}(false)
     Threads.@sync begin
         for tid = 1:nthr
-            let local_tracker = trackers[tid]
+            let local_tracker1 = trackers1[tid], local_tracker2 = trackers2[tid]
                 Threads.@spawn begin
                     while true
+                        fail_fast && failed[] && break
 
                         idx = Threads.atomic_add!(next_idx, 1)
                         if idx > l_start
@@ -1019,49 +1067,26 @@ function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
                         end
 
                         p = start_solution(P, roots, idx)
-                        code = track!(local_tracker, p, 1)
-                        if is_accepted(local_tracker, code)
-                            accepted[idx] = true
-                            P1[idx] = solution(local_tracker)
+                        code1 = track!(local_tracker1, p, 1)
+                        if is_accepted(local_tracker1, code1)
+                            p1 = solution(local_tracker1)
+                            code2 = track!(
+                                local_tracker2,
+                                p1,
+                                1,
+                                HOM2_START_CHECK_TARGET,
+                            )
+                            if is_success(code2)
+                                accepted[idx] = true
+                                P1[idx] = p1
+                            else
+                                accepted[idx] = false
+                                fail_fast && (failed[] = true)
+                            end
                         else
                             accepted[idx] = false
+                            fail_fast && (failed[] = true)
                         end
-                    end
-                end
-            end
-        end
-    end
-
-    nothing
-end
-
-function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
-
-    l_start = length(P1)
-
-    nthr = Threads.nthreads()
-    trackers = [deepcopy(tracker.tracker) for _ = 1:nthr]
-
-    progress_lock = ReentrantLock()
-
-    next_idx = Threads.Atomic{Int}(1)
-    Threads.@sync begin
-        for tid = 1:nthr
-            let local_tracker = trackers[tid]
-                Threads.@spawn begin
-                    while true
-
-                        idx = Threads.atomic_add!(next_idx, 1)
-                        if idx > l_start
-                            break
-                        end
-
-                        lock(progress_lock) do
-                            update_progress_paths!(progress, idx, l_start)
-                        end
-
-                        code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
-                        accepted[idx] = is_success(code)
                     end
                 end
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1820,7 +1820,7 @@ This function decomposes a [`WitnessSet`](@ref) or a vector of [`WitnessSet`](@r
 * `show_progress = true`: indicate whether a progress bar should be displayed.
 * `show_monodromy_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) should be displayed. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of `decompose`.
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
-* `max_iters = 200`: maximal number of iterations for the decomposition step.
+* `max_iters = 500`: maximal number of iterations for the decomposition step.
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -1860,7 +1860,7 @@ function decompose(
     show_progress::Bool = true,
     show_monodromy_progress::Bool = false,
     monodromy_options::MonodromyOptions = MonodromyOptions(),
-    max_iters::Int = 200,
+    max_iters::Int = 500,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -2142,7 +2142,7 @@ Computes the numerical irreducible of the variety defined by ``F=0``.
 * `show_monodromy_progress = false`: if `true`, sets `show_monodromy_for_regeneration_progress` and `show_monodromy_for_decompose_progress` to `true`. If `false`, minimal info about the monodromy computations are still displayed in the progress bar of each substep.
 * `show_monodromy_for_regeneration_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`regeneration`](@ref) should be displayed. 
 * `show_monodromy_for_decompose_progress = false`: indicate whether the progress bar of [`monodromy_solve`](@ref) in [`decompose`](@ref) should be displayed.
-* `max_iters = 200`: maximal number of iterations for the decomposition step.
+* `max_iters = 500`: maximal number of iterations for the decomposition step.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).` This option is used for [`regeneration`](@ref).
 * `warning = true`: if `true` prints a warning when the [`trace_test`](@ref) fails. 
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
@@ -2206,7 +2206,7 @@ function numerical_irreducible_decomposition(
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
-    max_iters::Int = 200,
+    max_iters::Int = 500,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
     max_trials_u_homotopy::Int = 5,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -829,19 +829,19 @@ end
 function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
     l_start = length(P) * length(roots)
     P1 = Vector{Vector{ComplexF64}}(undef, l_start)
-    accepted1 = falses(l_start)
-    accepted2 = falses(l_start)
+    accepted = falses(l_start)
 
     ntrials = max(cache.max_trials_u_homotopy, 1)
     for trial = 1:ntrials
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
-        fill!(accepted1, false)
-        fill!(accepted2, false)
+        
+        fill!(accepted, false)
+        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
+        all(accepted) && break
 
-        track_hom1!(P1, accepted1, P, roots, trackers[1], progress, threading)
-        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
-
-        all(accepted2) && break
+        fill!(accepted, false)
+        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
+        all(accepted) && break
     end
 
     track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
@@ -912,31 +912,31 @@ function set_up_u_homotopy(W, f, X, h, vars, u)
 end
 
 
-function track_hom1!(P1, accepted1, P, roots, tracker, progress, threading)
+function track_hom1!(accepted, P1, P, roots, tracker, progress, threading)
     if threading
-        threaded_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+        threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
     else
-        serial_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+        serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     end
 end
 
-function check_hom2_starts!(accepted2, P1, accepted1, tracker, progress, threading)
+function check_hom2_starts!(accepted, P1, tracker, progress, threading)
     if threading
-        threaded_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+        threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     else
-        serial_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+        serial_check_hom2_starts!(accepted, P1, tracker, progress)
     end
 end
 
-function track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     end
 end
 
-function serial_track_hom1!(P1, accepted, P, roots, tracker, progress)
+function serial_track_hom1!(accepted, P1, P, roots, tracker, progress)
     l_start = length(P) * length(roots)
 
     for i = 1:l_start
@@ -955,37 +955,31 @@ function serial_track_hom1!(P1, accepted, P, roots, tracker, progress)
     nothing
 end
 
-function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
 
-        if accepted1[i]
-            code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
-            accepted[i] = is_success(code)
-        else
-            accepted[i] = false
-        end
+        code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
+        accepted[i] = is_success(code)
     end
 
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
 
-        if accepted2[i]
-            code2 = track!(tracker2, P1[i], 1)
-            if is_accepted(tracker2, code2)
-                p2 = solution(tracker2)
-                code3 = track!(tracker3, p2, 1)
-                if is_accepted(tracker3, code3)
-                    push!(X, solution(tracker3))
-                end
+        code2 = track!(tracker2, P1[i], 1)
+        if is_accepted(tracker2, code2)
+            p2 = solution(tracker2)
+            code3 = track!(tracker3, p2, 1)
+            if is_accepted(tracker3, code3)
+                push!(X, solution(tracker3))
             end
         end
     end
@@ -993,7 +987,7 @@ function serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
     nothing
 end
 
-function threaded_track_hom1!(P1, accepted, P, roots, tracker, progress)
+function threaded_track_hom1!(accepted, P1, P, roots, tracker, progress)
 
     l_P = length(P)
     l_roots = length(roots)
@@ -1037,7 +1031,7 @@ function threaded_track_hom1!(P1, accepted, P, roots, tracker, progress)
     nothing
 end
 
-function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
 
     l_start = length(P1)
 
@@ -1062,13 +1056,8 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
                             update_progress_paths!(progress, idx, l_start)
                         end
 
-                        if accepted1[idx]
-                            code =
-                                track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
-                            accepted[idx] = is_success(code)
-                        else
-                            accepted[idx] = false
-                        end
+                        code = track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
+                        accepted[idx] = is_success(code)
                     end
                 end
             end
@@ -1078,7 +1067,7 @@ function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1104,16 +1093,14 @@ function threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progres
                             update_progress_paths!(progress, idx, l_start)
                         end
 
-                        if accepted2[idx]
-                            code2 = track!(local_tracker2, P1[idx], 1)
-                            if is_accepted(local_tracker2, code2)
-                                p2 = solution(local_tracker2)
-                                code3 = track!(local_tracker3, p2, 1)
-                                if is_accepted(local_tracker3, code3)
-                                    q = solution(local_tracker3)
-                                    lock(progress_lock) do
-                                        push!(X, q)
-                                    end
+                        code2 = track!(local_tracker2, P1[idx], 1)
+                        if is_accepted(local_tracker2, code2)
+                            p2 = solution(local_tracker2)
+                            code3 = track!(local_tracker3, p2, 1)
+                            if is_accepted(local_tracker3, code3)
+                                q = solution(local_tracker3)
+                                lock(progress_lock) do
+                                    push!(X, q)
                                 end
                             end
                         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1526,33 +1526,35 @@ function decompose_with_monodromy!(
                        allow_degree1_iter ≥ 5 ||
                        iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
-
-                        # Check whether inner monodromy jumped into an already-certified component.
-                        # If so, the trace test result is unreliable — skip this orbit.
-                        if any(
-                            p -> !isnothing(search_in_radius(certified_up, p, atol)),
-                            P_certified,
-                        )
-                            continue
-                        end
-
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
                         if length(P_certified) > length(clean_orbit)
-                            # Genuine new points found — compute their indices in non_complete_points,
-                            # excluding any phantom indices that might have matched numerically.
-                            complete_orbit = setdiff(
+                            # Inner monodromy found new points beyond the starting orbit.
+                            # First match them against non_complete_points.
+                            matched = setdiff(
                                 Set(
                                     matching_indices(
                                         non_complete_points,
                                         P_certified;
                                         atol = atol,
-                                        rtol = rtol,
+                                        rtol = something(options.unique_points_rtol, 1e-8),
                                     ),
                                 ),
                                 phantom_indices,
                             )
-                            allow_degree1_iter = 0
+                            # Only check certified_up when matching_indices left points unaccounted for.
+                            # Unmatched points are either genuine new discoveries or path-jumping phantoms.
+                            diff = length(P_certified) - length(matched)
+                            if diff > 0 && any(
+                                p -> !isnothing(search_in_radius(certified_up, p, atol)),
+                                P_certified,
+                            )
+                                continue
+                            end
+                            complete_orbit = matched
+                            if diff == 1
+                                allow_degree1_iter = 0
+                            end
                         else
                             complete_orbit = clean_orbit
                         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1454,7 +1454,9 @@ function decompose_with_monodromy!(
                 initial_orbits = non_complete_orbits,
             )
 
-            # increase the degree1 check only if there are other orbits
+            # update the degree1 check only if there are no orbits of degree > 1
+            # we want to check degree 1 component 
+            # only if there is nothing else to classify
             if all(o -> length(o) == 1, orbits)
                 allow_degree1_iter += 1
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1442,9 +1442,11 @@ function decompose_with_monodromy!(
             update_progress_npts!(progress, k)
 
             # If monodromy deduplicated starting solutions, the cached orbit indices are
-            # stale (they reference the old count). Reset to avoid a BoundsError.
+            # stale (they reference the old count). Reset to avoid a BoundsError
+            # also reset the degree 1 counter in this case
             if length(non_complete_points) < prev_count
                 non_complete_orbits = Vector{Set{Int}}()
+                allow_degree1_iter = 0
             end
 
             # Get orbits from monodromy result

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1476,19 +1476,8 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
-                        # Near-singular solutions tracked in monodromy loops can have
-                        # poor accuracy (~1e-10 error). If they evade monodromy's 
-                        # internal deduplication tolerance, 
-                        # remove near-duplicates here before
-                        # computing the degree of the certified component.
-                        if length(P_certified) > 1
-                            P_certified = unique_points(
-                                P_certified;
-                                atol = something(options.unique_points_atol, 1e-14),
-                                rtol = something(options.unique_points_rtol, sqrt(eps())),
-                            )
-                        end
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
+                        
                         # matching_indices is only needed when P_certified found more
                         # witness points than orbit contained. When P_certified has
                         # fewer points (inner monodromy deduplicated some starts), the

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1415,7 +1415,6 @@ function decompose_with_monodromy!(
 
         while !isempty(non_complete_points)
             iter += 1
-            allow_degree1_iter += 1
             if iter > max_iters
                 break
             end
@@ -1455,6 +1454,10 @@ function decompose_with_monodromy!(
                 initial_orbits = non_complete_orbits,
             )
 
+            # increase the degree1 check only if there are other orbits
+            if all(o -> length(o) == 1, orbits)
+                allow_degree1_iter += 1
+            end
             complete_orbits = Vector{Set{Int}}()
 
             for orbit in orbits
@@ -1477,7 +1480,7 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 10. 
                     # Single orobits tend to have small trace, even if their points are on a irreducible component of degree > 1.
                     # allow_degree1_iter is reset once we we find new points 
-                    if length(orbit) > 1 || allow_degree1_iter ≥ 10 || iter ≥ max_iters - 1
+                    if length(orbit) > 1 || allow_degree1_iter ≥ 5 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -49,7 +49,7 @@ Base.@kwdef mutable struct WitnessSetsProgress
     is_membership_test::Bool = false
     is_monodromy::Bool = false
     is_finished::Bool = false
-    path_label::String = "Computing start solutions" # this is the initial stage of the u-homotopy
+    path_label::String = "Track paths"
     current_path::Int = 0
     npaths::Int = 0
     current_task::Int = 0
@@ -138,6 +138,9 @@ end
 update_progress_hypersurface!(progress::Nothing, i::Int) = nothing
 function update_progress_hypersurface!(progress::WitnessSetsProgress, i::Int)
     progress.current_hypersurface = i
+    progress.current_path = 0
+    progress.npaths = 0
+    progress.path_label = "Track paths"
     PM.update!(
         progress.progress_meter,
         progress.current_hypersurface,
@@ -167,6 +170,13 @@ end
 update_progress_path_label!(progress::Nothing, label::String) = nothing
 function update_progress_path_label!(progress::WitnessSetsProgress, label::String)
     progress.path_label = label
+    nothing
+end
+start_progress_paths!(progress::Nothing, label::String, m::Int) = nothing
+function start_progress_paths!(progress::WitnessSetsProgress, label::String, m::Int)
+    progress.path_label = label
+    progress.current_path = 0
+    progress.npaths = m
     PM.update!(
         progress.progress_meter,
         progress.current_hypersurface,
@@ -206,7 +216,7 @@ function showvalues(progress::WitnessSetsProgress)
                     "$(progress.current_hypersurface) / $(progress.nhypersurfaces)",
                 ),
             )
-            if progress.is_solving
+            if progress.is_solving && progress.npaths > 0
                 push!(
                     text,
                     (progress.path_label, "$(progress.current_path) / $(progress.npaths)"),
@@ -850,7 +860,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         # is nothing left to resample, so we finish the sweep and keep the
         # starts that did pass the check.
         fail_fast = trial < ntrials
-        update_progress_path_label!(progress, "Computing start solutions")
+        start_progress_paths!(progress, "Computing start solutions", l_start)
         track_hom1_and_check_hom2_starts!(
             accepted,
             P1,
@@ -868,7 +878,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
     # `accepted` guards against undefined or rejected P1 entries. This matters
     # both after failed trials and when the final trial only validates a subset
     # of the starts.
-    update_progress_path_label!(progress, "Track paths")
+    start_progress_paths!(progress, "Track paths", l_start)
     track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing
@@ -1082,12 +1092,7 @@ function threaded_track_hom1_and_check_hom2_starts!(
                         code1 = track!(local_tracker1, p, 1)
                         if is_accepted(local_tracker1, code1)
                             p1 = solution(local_tracker1)
-                            code2 = track!(
-                                local_tracker2,
-                                p1,
-                                1,
-                                HOM2_START_CHECK_TARGET,
-                            )
+                            code2 = track!(local_tracker2, p1, 1, HOM2_START_CHECK_TARGET)
                             if is_success(code2)
                                 accepted[idx] = true
                                 P1[idx] = p1

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -493,7 +493,9 @@ function _regeneration(
                         monodromy_options,
                         cache,
                         show_monodromy_progress,
-                        threading,
+                        threading;
+                        atol = atol,
+                        rtol = rtol,
                     )
 
                     update_progress!(progress)
@@ -635,7 +637,7 @@ function intersect_all!(out, H, cache; kwargs...)
     end
 end
 
-function fill_up!(out, monodromy_options, cache, show_monodromy_progress, threading)
+function fill_up!(out, monodromy_options, cache, show_monodromy_progress, threading; atol = 1e-14, rtol = sqrt(eps()))
     progress = cache.progress
     Fᵢ = cache.Fᵢ
 
@@ -662,7 +664,12 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
             if nsolutions(res) == 0
                 W.R = Vector{Vector{ComplexF64}}()
             else
-                W.R = solution.(results(res))
+                sols = solution.(results(res))
+                # Near-singular solutions tracked in monodromy loops can have poor
+                # accuracy (~1e-10 error), which is too large for monodromy's internal
+                # add! tolerance (1e-14 * norm). Deduplicate here with the wider
+                # regeneration tolerances to catch such near-duplicates.
+                W.R = length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
             end
             update_progress!(progress, W)
         end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1479,32 +1479,54 @@ function decompose_with_monodromy!(
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
-                        # matching_indices is only needed when P_certified found more
-                        # witness points than orbit contained. When P_certified has
-                        # fewer points (inner monodromy deduplicated some starts), the
-                        # full orbit is still complete — collapsed elements were just
+                        # when P_certified found more witness points than orbit contained,
+                        # there can be two reasons
+                        # (1) path jumping
+                        # (2) we found genuine new points 
+                        # we first check path jumping using has_point_in_decomposition
+                        # if this returns false, run matching_indices to find the correct indices
+                        # of the points in P_certified
+                        # if P_certified has fewer points (inner monodromy deduplicated some starts), the full orbit is still complete — collapsed elements were just
                         # numerical duplicates on the same component.
                         if length(P_certified) > length(orbit)
-                            complete_orbit = Set(
-                                matching_indices(
-                                    non_complete_points,
-                                    P_certified;
-                                    atol = something(options.unique_points_atol, 1e-14),
-                                    rtol = something(options.unique_points_rtol, 1e-8),
-                                ),
+                            # check if the extra points in P_certified came from path 
+                            # jumping by comparing them to the points in the completed decompositions
+                            has_duplicate = has_point_in_decomposition(
+                                P_certified,
+                                decomposition;
+                                atol = something(options.unique_points_atol, 1e-14),
+                                rtol = something(options.unique_points_rtol, 1e-8),
                             )
-                            allow_degree1_iter = 0
+
+                            if !has_duplicate
+                                # if we have genuine new points find their indices
+                                complete_orbit = Set(
+                                    matching_indices(
+                                        non_complete_points,
+                                        P_certified;
+                                        atol = something(options.unique_points_atol, 1e-14),
+                                        rtol = something(options.unique_points_rtol, 1e-8),
+                                    ),
+                                )
+                                # if we have genuine new points restart the degree 1 check 
+                                allow_degree1_iter = 0
+                            end
                         else
+                            has_duplicate = false
                             complete_orbit = orbit
                         end
 
-                        push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)
-                        d += length(P_certified) - length(complete_orbit)
                         k = k - length(complete_orbit)
-
-                        update_progress!(progress, W_new)
                         update_progress_npts!(progress, k)
+
+                        # put a new witness set into decomposition
+                        # only if has_duplicate == false
+                        if !has_duplicate
+                            push!(decomposition, W_new)
+                            d += length(P_certified) - length(complete_orbit)
+                            update_progress!(progress, W_new)
+                        end
                     end
                 end
             end
@@ -1672,6 +1694,16 @@ function merge_sets(sets)
         end
     end
     return collect(values(result))
+end
+
+# check if we have found points that are already classifiedxw
+function has_point_in_decomposition(P, decomposition; atol, rtol)
+    any(P) do p
+        rad = max(atol, norm(p, Inf) * rtol)
+        any(decomposition) do W
+            any(q -> distance(p, q, InfNorm()) ≤ rad, points(W))
+        end
+    end
 end
 
 # find indices of newly detected points

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1477,7 +1477,7 @@ function decompose_with_monodromy!(
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
-                        
+
                         # matching_indices is only needed when P_certified found more
                         # witness points than orbit contained. When P_certified has
                         # fewer points (inner monodromy deduplicated some starts), the

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -637,7 +637,15 @@ function intersect_all!(out, H, cache; kwargs...)
     end
 end
 
-function fill_up!(out, monodromy_options, cache, show_monodromy_progress, threading; atol = 1e-14, rtol = sqrt(eps()))
+function fill_up!(
+    out,
+    monodromy_options,
+    cache,
+    show_monodromy_progress,
+    threading;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
     progress = cache.progress
     Fᵢ = cache.Fᵢ
 
@@ -654,7 +662,12 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 Fᵢ,
                 W.R,
                 linear_subspace(W);
-                options = regeneration_monodromy_options(monodromy_options, W; atol = atol, rtol = rtol),
+                options = regeneration_monodromy_options(
+                    monodromy_options,
+                    W;
+                    atol = atol,
+                    rtol = rtol,
+                ),
                 show_progress = show_monodromy_progress,
                 progress = show_monodromy_progress ? nothing : progress,
                 threading = threading,
@@ -669,14 +682,20 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 # poor accuracy (~1e-10 error). If they evade monodromy's 
                 # internal deduplication tolerance, 
                 # remove near-duplicates here before continuing
-                W.R = length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
+                W.R =
+                    length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
             end
             update_progress!(progress, W)
         end
     end
 end
 
-function regeneration_monodromy_options(M::MonodromyOptions, W; atol = 1e-14, rtol = sqrt(eps()))
+function regeneration_monodromy_options(
+    M::MonodromyOptions,
+    W;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
 
     MonodromyOptions(;
         permutations = false,
@@ -1725,7 +1744,11 @@ function get_orbits_from_monodromy_permutations(
     orbits
 end
 
-function decompose_with_monodromy_options(M::MonodromyOptions; atol = 1e-14, rtol = sqrt(eps()))
+function decompose_with_monodromy_options(
+    M::MonodromyOptions;
+    atol = 1e-14,
+    rtol = sqrt(eps()),
+)
 
     # we need two copies of the options.
     # one with trace test
@@ -2518,9 +2541,26 @@ function _intersect(
     )
 
     # intersect
-    intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, atol = atol, rtol = rtol, kwargs...)
+    intersect_with_hypersurface!(
+        W₁,
+        Hᵤ,
+        W₂,
+        cache;
+        threading = threading,
+        atol = atol,
+        rtol = rtol,
+        kwargs...,
+    )
     update_Fᵢ!(cache, [f; h], vars_u)
-    fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading; atol = atol, rtol = rtol)
+    fill_up!(
+        [W₁; W₂],
+        monodromy_options,
+        cache,
+        show_monodromy_progress,
+        threading;
+        atol = atol,
+        rtol = rtol,
+    )
 
     # return data 
     G = fixed(System([f; h], variables = vars); compile = false)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1457,6 +1457,9 @@ function decompose_with_monodromy!(
             # Only check when new points were found and certified_up is non-empty.
             phantom_indices = Set{Int}()
             if length(updated_points) > prev_count && !isempty(certified_up)
+                # reset degree1 check if we found new points 
+                allow_degree1_iter = 0
+                # now compute phantom points
                 for (i, p) in pairs(updated_points)
                     if !isnothing(search_in_radius(certified_up, p, atol))
                         push!(phantom_indices, i)
@@ -1491,6 +1494,8 @@ function decompose_with_monodromy!(
             complete_orbits = Vector{Set{Int}}()
 
             for orbit in orbits
+                success = true # this checks if this run was successful
+
                 update_progress!(progress; is_monodromy = true)
 
                 # Strip phantom indices from the orbit before running inner monodromy.
@@ -1544,32 +1549,28 @@ function decompose_with_monodromy!(
                             )
                             # Only check certified_up when matching_indices left points unaccounted for.
                             # Unmatched points are either genuine new discoveries or path-jumping phantoms.
-                            diff = length(P_certified) - length(matched)
-                            if diff > 0 && any(
-                                p -> !isnothing(search_in_radius(certified_up, p, atol)),
-                                P_certified,
-                            )
-                                continue
-                            end
-                            complete_orbit = matched
-                            if diff == 1
-                                allow_degree1_iter = 0
+                            if length(matched) < length(P_certified)
+                                success = false
+                            else
+                                complete_orbit = matched
                             end
                         else
                             complete_orbit = clean_orbit
                         end
 
                         # postprocessing
-                        push!(complete_orbits, complete_orbit)
-                        k -= length(complete_orbit)
-                        update_progress_npts!(progress, k)
+                        if success
+                            push!(complete_orbits, complete_orbit)
+                            k -= length(complete_orbit)
+                            update_progress_npts!(progress, k)
 
-                        push!(decomposition, W_new)
-                        for p in solutions(W_new)
-                            add!(certified_up, p, 1, atol)
+                            push!(decomposition, W_new)
+                            for p in solutions(W_new)
+                                add!(certified_up, p, 1, atol)
+                            end
+                            d += length(P_certified) - length(complete_orbit)
+                            update_progress!(progress, W_new)
                         end
-                        d += length(P_certified) - length(complete_orbit)
-                        update_progress!(progress, W_new)
                     end
                 end
             end

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -256,6 +256,7 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     u::Variable
     i::Int
     codim::Int
+    max_trials_u_homotopy::Int
 
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
@@ -263,7 +264,7 @@ mutable struct RegenerationCache{Sys<:AbstractSystem}
     progress::Union{WitnessSetsProgress,Nothing}
 end
 
-function RegenerationCache(u, f, F, h, codim, EO, TO, progress)
+function RegenerationCache(u, f, F, h, codim, max_trials_u_homotopy, EO, TO, progress)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -271,7 +272,23 @@ function RegenerationCache(u, f, F, h, codim, EO, TO, progress)
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    RegenerationCache(A, b, x0, y0, y, f, F, h, u, 0, codim, EO, TO, progress)
+    RegenerationCache(
+        A,
+        b,
+        x0,
+        y0,
+        y,
+        f,
+        F,
+        h,
+        u,
+        0,
+        codim,
+        max_trials_u_homotopy,
+        EO,
+        TO,
+        progress,
+    )
 end
 function update_Fᵢ!(cache, fᵢ, vars)
     Fᵢ = fixed(System(fᵢ, variables = vars), compile = false)
@@ -304,6 +321,7 @@ The implementation is based on the algorithm [u-regeneration](https://arxiv.org/
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).
 * `endgame_options`: [`EndgameOptions`](@ref) for the [`EndgameTracker`](@ref).
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
+* `max_trials_u_homotopy = 5`: maximal number of random subspaces tried until an intermediate u-regeneration intersection step succeeds.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).`
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 * `seed`: choose the random seed.
@@ -336,6 +354,7 @@ function _regeneration(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
+    max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -409,6 +428,7 @@ function _regeneration(
         Fᵢ,
         f[1],
         codim,
+        max_trials_u_homotopy,
         endgame_options,
         tracker_options,
         progress,
@@ -695,15 +715,8 @@ function intersect_with_hypersurface!(
     # Step 2:
     # the points in P_next are used as starting points for a homotopy.
     # where u^d-1 (u is the extra variable in u-regeneration) is deformed into g 
-    Hom, d = set_up_u_homotopy(W, f, X, h, vars, u)
-
-    trackers = map(Hom) do H
-        EndgameTracker(
-            H;
-            tracker_options = cache.tracker_options,
-            options = cache.endgame_options,
-        )
-    end
+    u_data, d = set_up_u_homotopy(W, f, X, h, vars, u)
+    trackers = initialize_u_homotopy_trackers(u_data, cache)
 
 
     # the start solutions are the Cartesian product between P_next and the d-th roots of unity.
@@ -717,9 +730,9 @@ function intersect_with_hypersurface!(
         is_monodromy = false,
     )
     if threading
-        threaded_intersection!(X, P_next, roots, trackers, progress)
+        threaded_intersection!(X, P_next, roots, trackers, u_data, cache, progress)
     else
-        serial_intersection!(X, P_next, roots, trackers, progress)
+        serial_intersection!(X, P_next, roots, trackers, u_data, cache, progress)
     end
     nothing
 end
@@ -729,117 +742,6 @@ function manage_initial_points!(P, m)
     deleteat!(P, m)
     return P_next
 end
-
-function track_intersection_path(egtrackers, p)
-    # Stage 1: L -> random linear space L1
-    res1 = track(egtrackers[1], p, 1)
-    is_success(res1) && is_finite(res1) && is_nonsingular(res1) || return nothing
-
-    # Stage 2: replace u^d - 1 by hypersurface equation
-    p1 = solution(egtrackers[1])
-    res2 = track(egtrackers[2], p1, 1)
-    is_success(res2) && is_finite(res2) && is_nonsingular(res2) || return nothing
-
-    # Stage 3: L1 -> {u = c}
-    p2 = solution(egtrackers[2])
-    res3 = track(egtrackers[3], p2, 1)
-    is_success(res3) && is_finite(res3) && is_nonsingular(res3) || return nothing
-
-    q = copy(solution(egtrackers[3]))
-
-    q
-end
-
-function serial_intersection!(X, P, roots, egtrackers, progress)
-    start = Iterators.product(P, roots)
-    l_start = length(P) * length(roots)
-
-    for (i, s) in enumerate(start)
-        update_progress_paths!(progress, i, l_start)
-
-        p = s[1]
-        p[end] = s[2] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
-
-        q = track_intersection_path(egtrackers, p)
-        if !isnothing(q)
-            push!(X, q)
-        end
-    end
-
-    nothing
-end
-
-function threaded_intersection!(X, P, roots, trackers, progress)
-
-    l_P = length(P)
-    l_roots = length(roots)
-    l_start = l_P * l_roots
-
-    # Pre-allocate one tracker per thread
-    nthr = Threads.nthreads()
-    trackers_per_thread = [deepcopy(trackers) for _ = 1:nthr]
-
-    # Use a lock for thread-safe operations on X and progress
-    progress_lock = ReentrantLock()
-
-    next_idx = Threads.Atomic{Int}(1)
-    Threads.@sync begin
-        for tid = 1:nthr
-            let local_egtrackers = trackers_per_thread[tid]
-                Threads.@spawn begin
-                    while true
-
-                        idx = Threads.atomic_add!(next_idx, 1)
-                        if idx > l_start
-                            break
-                        end
-
-                        lock(progress_lock) do
-                            update_progress_paths!(progress, idx, l_start)
-                        end
-
-                        p_idx = rem(idx - 1, l_P) + 1
-                        r_idx = div(idx - 1, l_P) + 1
-                        p = copy(P[p_idx])
-                        p[end] = roots[r_idx] # the last entry of s[1] is zero. we replace it with a d-th root of unity.
-
-                        q = track_intersection_path(local_egtrackers, p)
-                        if !isnothing(q)
-                            lock(progress_lock) do
-                                push!(X, q)
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-
-    nothing
-end
-
-function set_up_u_homotopy(W, f, X, h, vars, u)
-
-    P, Q = get_num_den(h)
-    d = degree(P)
-    h0 = (u^d - 1) / Q
-
-    # we start with the linear space L which does not use pose conditions on u, so that u^d=1
-    # we end with the linear space L2 with u=c.
-    L = linear_subspace_u(W)
-    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
-    L2 = linear_subspace(X)
-
-    F = fixed(System([f; h0], variables = vars); compile = false)
-    G = fixed(System([f; h], variables = vars); compile = false)
-
-    Hom1 = linear_subspace_homotopy(F, L, L1)
-    Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
-    Hom3 = linear_subspace_homotopy(G, L1, L2)
-
-    return (Hom1, Hom2, Hom3), d
-end
-
 
 
 function is_contained(X::WitnessPoints, Y::WitnessSet, F, cache; kwargs...)
@@ -900,6 +802,329 @@ function set_up_linear_spaces!(cache, LX, LY)
         end
         b[ℓ] = bX[i]
     end
+end
+
+
+# The following piece of the code implements the core part of u-regeneration
+# It consists of three subhomotopies: Hom1, Hom2, Hom3.
+# Hom1 moves the linear equation u = c to a random linear space L1 involving (x,u), where x are the variables of F.
+# Hom2 moves u^d - 1 to the new polynomial fᵢ with deg(fᵢ) = d.
+# Hom3 moves the linear space L1 to the linear space given by the initial witness sets. 
+# We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resampel L1. Only then track Hom2 and Hom3. 
+
+const HOM2_START_CHECK_TARGET = 0.95
+
+is_accepted(T::EndgameTracker, code) =
+    is_success(code) && !T.state.singular && !T.state.at_infinity
+
+function start_solution(P, roots, idx)
+    l_P = length(P)
+    p_idx = rem(idx - 1, l_P) + 1
+    r_idx = div(idx - 1, l_P) + 1
+    p = copy(P[p_idx])
+    p[end] = roots[r_idx]
+
+    p
+end
+
+function track_intersection!(X, P, roots, trackers, u_data, cache, progress, threading)
+    l_start = length(P) * length(roots)
+    P1 = Vector{Vector{ComplexF64}}(undef, l_start)
+    accepted1 = falses(l_start)
+    accepted2 = falses(l_start)
+
+    ntrials = max(cache.max_trials_u_homotopy, 1)
+    for trial = 1:ntrials
+        trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
+        fill!(accepted1, false)
+        fill!(accepted2, false)
+
+        track_hom1!(P1, accepted1, P, roots, trackers[1], progress, threading)
+        check_hom2_starts!(accepted2, P1, accepted1, trackers[2], progress, threading)
+
+        all(accepted2) && break
+    end
+
+    track_hom2_hom3!(X, P1, accepted2, trackers[2], trackers[3], progress, threading)
+
+    nothing
+end
+
+function serial_intersection!(X, P, roots, trackers, u_data, cache, progress)
+    track_intersection!(X, P, roots, trackers, u_data, cache, progress, false)
+end
+
+function threaded_intersection!(X, P, roots, trackers, u_data, cache, progress)
+    track_intersection!(X, P, roots, trackers, u_data, cache, progress, true)
+end
+
+function u_homotopy_tracker(H, cache)
+    EndgameTracker(
+        H;
+        tracker_options = cache.tracker_options,
+        options = cache.endgame_options,
+    )
+end
+
+function initialize_u_homotopy_trackers(u_data, cache)
+    F, G, L, L2 = u_data
+    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
+
+    Hom1 = linear_subspace_homotopy(F, L, L1)
+    Hom2 = StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand()))
+    Hom3 = linear_subspace_homotopy(G, L1, L2)
+
+    [
+        u_homotopy_tracker(Hom1, cache),
+        u_homotopy_tracker(Hom2, cache),
+        u_homotopy_tracker(Hom3, cache),
+    ]
+end
+
+function reset_u_homotopy_trackers!(trackers, u_data, cache)
+    F, G, L, L2 = u_data
+    L1 = rand_subspace(ambient_dim(L); dim = dim(L))
+
+    target_parameters!(trackers[1], L1)
+    trackers[2] = u_homotopy_tracker(
+        StraightLineHomotopy(slice(F, L1), slice(G, L1); gamma = cis(2 * pi * rand())),
+        cache,
+    )
+    start_parameters!(trackers[3], L1)
+
+    trackers
+end
+
+function set_up_u_homotopy(W, f, X, h, vars, u)
+
+    P, Q = get_num_den(h)
+    d = degree(P)
+    h0 = (u^d - 1) / Q
+
+    # we start with the linear space L which does not use pose conditions on u, so that u^d=1
+    # we end with the linear space L2 with u=c.
+    L = linear_subspace_u(W)
+    L2 = linear_subspace(X)
+
+    F = fixed(System([f; h0], variables = vars); compile = false)
+    G = fixed(System([f; h], variables = vars); compile = false)
+
+    return (F, G, L, L2), d
+end
+
+
+function track_hom1!(P1, accepted1, P, roots, tracker, progress, threading)
+    if threading
+        threaded_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+    else
+        serial_track_hom1!(P1, accepted1, P, roots, tracker, progress)
+    end
+end
+
+function check_hom2_starts!(accepted2, P1, accepted1, tracker, progress, threading)
+    if threading
+        threaded_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+    else
+        serial_check_hom2_starts!(accepted2, P1, accepted1, tracker, progress)
+    end
+end
+
+function track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress, threading)
+    if threading
+        threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+    else
+        serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+    end
+end
+
+function serial_track_hom1!(P1, accepted, P, roots, tracker, progress)
+    l_start = length(P) * length(roots)
+
+    for i = 1:l_start
+        update_progress_paths!(progress, i, l_start)
+
+        p = start_solution(P, roots, i)
+        code = track!(tracker, p, 1)
+        if is_accepted(tracker, code)
+            accepted[i] = true
+            P1[i] = solution(tracker)
+        else
+            accepted[i] = false
+        end
+    end
+
+    nothing
+end
+
+function serial_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+    l_start = length(P1)
+
+    for i = 1:l_start
+        update_progress_paths!(progress, i, l_start)
+
+        if accepted1[i]
+            code = track!(tracker.tracker, P1[i], 1, HOM2_START_CHECK_TARGET)
+            accepted[i] = is_success(code)
+        else
+            accepted[i] = false
+        end
+    end
+
+    nothing
+end
+
+function serial_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+    l_start = length(P1)
+
+    for i = 1:l_start
+        update_progress_paths!(progress, i, l_start)
+
+        if accepted2[i]
+            code2 = track!(tracker2, P1[i], 1)
+            if is_accepted(tracker2, code2)
+                p2 = solution(tracker2)
+                code3 = track!(tracker3, p2, 1)
+                if is_accepted(tracker3, code3)
+                    push!(X, solution(tracker3))
+                end
+            end
+        end
+    end
+
+    nothing
+end
+
+function threaded_track_hom1!(P1, accepted, P, roots, tracker, progress)
+
+    l_P = length(P)
+    l_roots = length(roots)
+    l_start = l_P * l_roots
+
+    nthr = Threads.nthreads()
+    trackers = [deepcopy(tracker) for _ = 1:nthr]
+
+    progress_lock = ReentrantLock()
+
+    next_idx = Threads.Atomic{Int}(1)
+    Threads.@sync begin
+        for tid = 1:nthr
+            let local_tracker = trackers[tid]
+                Threads.@spawn begin
+                    while true
+
+                        idx = Threads.atomic_add!(next_idx, 1)
+                        if idx > l_start
+                            break
+                        end
+
+                        lock(progress_lock) do
+                            update_progress_paths!(progress, idx, l_start)
+                        end
+
+                        p = start_solution(P, roots, idx)
+                        code = track!(local_tracker, p, 1)
+                        if is_accepted(local_tracker, code)
+                            accepted[idx] = true
+                            P1[idx] = solution(local_tracker)
+                        else
+                            accepted[idx] = false
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    nothing
+end
+
+function threaded_check_hom2_starts!(accepted, P1, accepted1, tracker, progress)
+
+    l_start = length(P1)
+
+    nthr = Threads.nthreads()
+    trackers = [deepcopy(tracker.tracker) for _ = 1:nthr]
+
+    progress_lock = ReentrantLock()
+
+    next_idx = Threads.Atomic{Int}(1)
+    Threads.@sync begin
+        for tid = 1:nthr
+            let local_tracker = trackers[tid]
+                Threads.@spawn begin
+                    while true
+
+                        idx = Threads.atomic_add!(next_idx, 1)
+                        if idx > l_start
+                            break
+                        end
+
+                        lock(progress_lock) do
+                            update_progress_paths!(progress, idx, l_start)
+                        end
+
+                        if accepted1[idx]
+                            code =
+                                track!(local_tracker, P1[idx], 1, HOM2_START_CHECK_TARGET)
+                            accepted[idx] = is_success(code)
+                        else
+                            accepted[idx] = false
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    nothing
+end
+
+function threaded_track_hom2_hom3!(X, P1, accepted2, tracker2, tracker3, progress)
+
+    l_start = length(P1)
+
+    nthr = Threads.nthreads()
+    trackers2 = [deepcopy(tracker2) for _ = 1:nthr]
+    trackers3 = [deepcopy(tracker3) for _ = 1:nthr]
+
+    progress_lock = ReentrantLock()
+
+    next_idx = Threads.Atomic{Int}(1)
+    Threads.@sync begin
+        for tid = 1:nthr
+            let local_tracker2 = trackers2[tid], local_tracker3 = trackers3[tid]
+                Threads.@spawn begin
+                    while true
+
+                        idx = Threads.atomic_add!(next_idx, 1)
+                        if idx > l_start
+                            break
+                        end
+
+                        lock(progress_lock) do
+                            update_progress_paths!(progress, idx, l_start)
+                        end
+
+                        if accepted2[idx]
+                            code2 = track!(local_tracker2, P1[idx], 1)
+                            if is_accepted(local_tracker2, code2)
+                                p2 = solution(local_tracker2)
+                                code3 = track!(local_tracker3, p2, 1)
+                                if is_accepted(local_tracker3, code3)
+                                    q = solution(local_tracker3)
+                                    lock(progress_lock) do
+                                        push!(X, q)
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    nothing
 end
 
 
@@ -1862,6 +2087,7 @@ function numerical_irreducible_decomposition(
     max_iters::Int = 50,
     sorted::Bool = true,
     max_codim::Union{Int,Nothing} = nothing,
+    max_trials_u_homotopy::Int = 5,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
     seed = nothing,
@@ -1884,6 +2110,7 @@ function numerical_irreducible_decomposition(
         tracker_options = tracker_options,
         endgame_options = endgame_options,
         monodromy_options = monodromy_options_for_regeneration,
+        max_trials_u_homotopy = max_trials_u_homotopy,
         show_monodromy_progress = show_monodromy_for_regeneration_progress,
         threading = threading,
         seed = nothing,
@@ -2066,13 +2293,15 @@ mutable struct IntersectCache{Sys<:AbstractSystem}
     h::Expression
     u::Variable
 
+    max_trials_u_homotopy::Int
+
     endgame_options::EndgameOptions
     tracker_options::TrackerOptions
 
     progress::Union{IntersectProgress,Nothing}
 end
 
-function IntersectCache(u, f, F, h, EO, TO, progress)
+function IntersectCache(u, f, F, h, EO, TO, progress; max_trials_u_homotopy::Int = 5)
     m, N = size(F)
     A = zeros(ComplexF64, N - 1, N)
     b = zeros(ComplexF64, N - 1)
@@ -2080,7 +2309,7 @@ function IntersectCache(u, f, F, h, EO, TO, progress)
     y0 = zeros(ComplexF64, m)
     y = zeros(ComplexF64, m)
 
-    IntersectCache(A, b, x0, y0, y, f, F, h, u, EO, TO, progress)
+    IntersectCache(A, b, x0, y0, y, f, F, h, u, max_trials_u_homotopy, EO, TO, progress)
 end
 
 
@@ -2096,6 +2325,7 @@ This intersects the witness sets `W` and `H`, where `H` is a hypersurface define
 * `tracker_options`: [`TrackerOptions`](@ref) for the [`Tracker`](@ref).
 * `endgame_options`: [`EndgameOptions`](@ref) for the [`EndgameTracker`](@ref).
 * `monodromy_options`: [`MonodromyOptions`](@ref) for [`monodromy_solve`](@ref).
+* `max_trials_u_homotopy = 5`: maximal number of random subspaces tried until an intermediate u-regeneration intersection step succeeds.
 * `atol = 1e-14` and `rtol = sqrt(eps())`: a point `y` is considered equal to `x` when the distance between `x`and `y` is smaller than `max(atol, norm(x, Inf) * rtol).`
 * `threading = true`: Enable multi-threading for the computation. The number of available threads is controlled by the environment variable `JULIA_NUM_THREADS`. You can run `Julia` with `n` threads using the command `julia -t n`; e.g., `julia -t 8` for `n=8`. (Some CPUs hang when using multiple threads. To avoid this run Julia with 1 interactive thread for the REPL; e.g., `julia -t 8,1` for `n=8`. Note that some CPUs seem to let `Julia` crash when using that option.)
 
@@ -2144,6 +2374,7 @@ function _intersect(
     monodromy_options::MonodromyOptions = MonodromyOptions(;
         parameter_sampler = weighted_normal,
     ),
+    max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading = Threads.nthreads() > 1,
     kwargs...,
@@ -2173,7 +2404,16 @@ function _intersect(
     W₁, W₂, Hᵤ, f, F, h, vars_u = prepare_for_u_homotopy(H, W, vars, u)
 
     # cache
-    cache = IntersectCache(u, f, F, h, endgame_options, tracker_options, progress)
+    cache = IntersectCache(
+        u,
+        f,
+        F,
+        h,
+        endgame_options,
+        tracker_options,
+        progress;
+        max_trials_u_homotopy = max_trials_u_homotopy,
+    )
 
     # intersect
     intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, kwargs...)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1407,6 +1407,7 @@ function decompose_with_monodromy!(
         end
 
         iter = 0
+        allow_degree1_iter = 0
         non_complete_points = indexed_solutions(res)
         d = length(non_complete_points) # the total degree (i.e., number of points on all irreducible components)
         non_complete_orbits = Vector{Set{Int}}()
@@ -1414,6 +1415,7 @@ function decompose_with_monodromy!(
 
         while !isempty(non_complete_points)
             iter += 1
+            allow_degree1_iter += 1
             if iter > max_iters
                 break
             end
@@ -1470,8 +1472,10 @@ function decompose_with_monodromy!(
 
                 if trace(res_orbit) < options.trace_test_tol
 
-                    # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
-                    if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
+                    # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 10. 
+                    # Single orobits tend to have small trace, even if their points are on a irreducible component of degree > 1.
+                    # allow_degree1_iter is reset once we we find new points 
+                    if length(orbit) > 1 || allow_degree1_iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
@@ -1485,11 +1489,11 @@ function decompose_with_monodromy!(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
-                                    norm = options.distance,
                                     atol = something(options.unique_points_atol, 1e-14),
                                     rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
                             )
+                            allow_degree1_iter = 0
                         else
                             complete_orbit = orbit
                         end
@@ -1671,14 +1675,14 @@ function merge_sets(sets)
 end
 
 # find indices of newly detected points
-function matching_indices(points, certified_points; norm, atol, rtol)
+function matching_indices(points, certified_points; atol, rtol)
     indices = Int[]
     matched = falses(length(certified_points))
     for (i, p) in pairs(points)
-        tol = max(atol, rtol * distance(p, zero(p), norm))
+        rad = max(atol, norm(p, Inf) * rtol)
         for (j, q) in pairs(certified_points)
             matched[j] && continue
-            if distance(p, q, norm) ≤ tol
+            if distance(p, q, InfNorm()) ≤ rad
                 push!(indices, i)
                 matched[j] = true
                 break

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1456,7 +1456,7 @@ function decompose_with_monodromy!(
             # Identify phantom points: new points that jumped into an already-certified component.
             # Only check when new points were found and certified_up is non-empty.
             phantom_indices = Set{Int}()
-            if length(updated_points) > prev_count && !isempty(certified_up)
+            if length(updated_points) > prev_count && length(certified_up) > 0
                 # reset degree1 check if we found new points 
                 allow_degree1_iter = 0
                 # now compute phantom points

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1369,7 +1369,7 @@ The core function for decomposing a witness set into irreducible components.
 function decompose_with_monodromy!(
     W,
     show_monodromy_progress,
-    _options,
+    options,
     max_iters,
     warning,
     progress,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -814,8 +814,7 @@ end
 
 const HOM2_START_CHECK_TARGET = 0.95
 
-is_accepted(T::EndgameTracker, code) =
-    is_success(code) && !T.state.singular && !T.state.at_infinity
+is_accepted(T::EndgameTracker, code) = is_success(code) && !T.state.singular
 
 function start_solution(P, roots, idx)
     l_P = length(P)
@@ -1326,10 +1325,13 @@ function decompose_with_monodromy!(
     if dim(L) < n
         update_progress!(progress; is_monodromy = true)
 
-        MS = MonodromySolver(G, L; compile = false, options = options)
-        initial_points = check_start_solutions(MS, P, L)
+        options_with_trace, options_without_trace = options
+        MS_with_trace = MonodromySolver(G, L; compile = false, options = options_with_trace)
+        MS_without_trace =
+            MonodromySolver(G, L; compile = false, options = options_without_trace)
+        initial_points = check_start_solutions(MS_with_trace, P, L)
         res = monodromy_solve(
-            MS,
+            MS_with_trace,
             solution.(initial_points),
             L,
             seed;
@@ -1340,7 +1342,7 @@ function decompose_with_monodromy!(
         update_progress!(progress; is_monodromy = false)
         update_progress_npts!(progress, nindexed_solutions(res))
 
-        if warning && (trace(res) > options.trace_test_tol)
+        if warning && (trace(res) > options_with_trace.trace_test_tol)
             @warn "Trying to decompose non-complete set of witness points for codimension $(dim(L)) (trace test failed). Will try to compute the missing points. The output will contain all components, for which the trace test was successfull."
         end
 
@@ -1356,20 +1358,18 @@ function decompose_with_monodromy!(
                 break
             end
 
-            if iter > 1
-                # for safety an additional monodromy when iter > 1
-                update_progress!(progress; is_monodromy = true)
-                res = monodromy_solve(
-                    MS,
-                    non_complete_points,
-                    L,
-                    seed;
-                    threading = threading,
-                    show_progress = show_monodromy_progress,
-                    progress = show_monodromy_progress ? nothing : progress,
-                )
-                update_progress!(progress; is_monodromy = false)
-            end
+
+            update_progress!(progress; is_monodromy = true)
+            res = monodromy_solve(
+                MS_without_trace, # without trace to populate the permutation matrix
+                non_complete_points,
+                L,
+                seed;
+                threading = threading,
+                show_progress = show_monodromy_progress,
+                progress = show_monodromy_progress ? nothing : progress,
+            )
+            update_progress!(progress; is_monodromy = false)
 
             updated_points = indexed_solutions(res)
             d += length(updated_points) - length(non_complete_points) # update total degree in case we found new points.
@@ -1377,7 +1377,6 @@ function decompose_with_monodromy!(
             ℓ = length(non_complete_points) # once for a later check
             k = length(non_complete_points) # and once for counting progress
             update_progress_npts!(progress, k)
-
 
             # Get orbits from monodromy result            
             orbits = get_orbits_from_monodromy_permutations(
@@ -1392,7 +1391,7 @@ function decompose_with_monodromy!(
 
                 P_orbit = non_complete_points[collect(orbit)]
                 res_orbit = monodromy_solve(
-                    MS,
+                    MS_with_trace,
                     P_orbit,
                     L,
                     seed;
@@ -1402,7 +1401,7 @@ function decompose_with_monodromy!(
                 )
                 update_progress!(progress; is_monodromy = false)
 
-                if trace(res_orbit) < options.trace_test_tol
+                if trace(res_orbit) < options_with_trace.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
@@ -1539,8 +1538,6 @@ function decompose_with_monodromy!(
     decomposition
 end
 
-
-
 # Helper function to merge two sets
 function merge_sets_find(parent, i)
     root = i
@@ -1660,7 +1657,10 @@ end
 
 function decompose_with_monodromy_options(M::MonodromyOptions)
 
-    MonodromyOptions(;
+    # we need two copies of the options. 
+    # one with trace test
+    # one without to run monodromy populating the permutation matrix
+    options_with_trace = MonodromyOptions(;
         permutations = true,
         trace_test = true,
         single_loop_per_start_solution = true,
@@ -1682,6 +1682,30 @@ function decompose_with_monodromy_options(M::MonodromyOptions)
         unique_points_atol = M.unique_points_atol,
         unique_points_rtol = M.unique_points_rtol,
     )
+    options_without_trace = MonodromyOptions(;
+        permutations = true,
+        trace_test = false,
+        single_loop_per_start_solution = true,
+        check_startsolutions = false,
+        group_actions = M.group_actions,
+        loop_finished_callback = M.loop_finished_callback,
+        parameter_sampler = M.parameter_sampler,
+        equivalence_classes = M.equivalence_classes,
+        duplicate_check = M.duplicate_check,
+        certification_max_precision = M.certification_max_precision,
+        certification_refine_solution = M.certification_refine_solution,
+        trace_test_tol = M.trace_test_tol,
+        target_solutions_count = M.target_solutions_count,
+        timeout = M.timeout,
+        min_solutions = M.min_solutions,
+        max_loops_no_progress = M.max_loops_no_progress,
+        reuse_loops = M.reuse_loops,
+        distance = M.distance,
+        unique_points_atol = M.unique_points_atol,
+        unique_points_rtol = M.unique_points_rtol,
+    )
+
+    options_with_trace, options_without_trace
 end
 
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -665,10 +665,10 @@ function fill_up!(out, monodromy_options, cache, show_monodromy_progress, thread
                 W.R = Vector{Vector{ComplexF64}}()
             else
                 sols = solution.(results(res))
-                # Near-singular solutions tracked in monodromy loops can have poor
-                # accuracy (~1e-10 error), which is too large for monodromy's internal
-                # add! tolerance (1e-14 * norm). Deduplicate here with the wider
-                # regeneration tolerances to catch such near-duplicates.
+                # Near-singular solutions tracked in monodromy loops can have
+                # poor accuracy (~1e-10 error). If they evade monodromy's 
+                # internal deduplication tolerance, 
+                # remove near-duplicates here before continuing
                 W.R = length(sols) > 1 ? unique_points(sols; atol = atol, rtol = rtol) : sols
             end
             update_progress!(progress, W)
@@ -1455,6 +1455,18 @@ function decompose_with_monodromy!(
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
+                        # Near-singular solutions tracked in monodromy loops can have
+                        # poor accuracy (~1e-10 error). If they evade monodromy's 
+                        # internal deduplication tolerance, 
+                        # remove near-duplicates here before
+                        # computing the degree of the certified component.
+                        if length(P_certified) > 1
+                            P_certified = unique_points(
+                                P_certified;
+                                atol = something(options.unique_points_atol, 1e-14),
+                                rtol = something(options.unique_points_rtol, sqrt(eps())),
+                            )
+                        end
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         # matching_indices is only needed when P_certified found more
                         # witness points than orbit contained. When P_certified has

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -859,7 +859,7 @@ end
 # Hom3 moves the linear space L1 to the linear space given by the initial witness sets. 
 # We first run Hom1. Then we check if the output of Hom1 works as input for Hom2. If this fails, resample L1. Only then track Hom2 and Hom3. 
 
-const HOM2_START_CHECK_TARGET = 0.95
+const HOM2_START_CHECK_TARGET = 0.99
 
 is_accepted(T::EndgameTracker, code) = is_success(code) && !T.state.singular
 
@@ -889,7 +889,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         # is nothing left to resample, so we finish the sweep and keep the
         # starts that did pass the check.
         fail_fast = trial < ntrials
-        start_progress_paths!(progress, "Computing start solutions", l_start)
+        start_progress_paths!(progress, "Compute start solutions", l_start)
         track_hom1_and_check_hom2_starts!(
             accepted,
             P1,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1400,9 +1400,9 @@ function decompose_with_monodromy!(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
-                                    norm = options.distance,
-                                    atol = something(options.unique_points_atol, 1e-14),
-                                    rtol = something(options.unique_points_rtol, 1e-8),
+                                    norm = options_with_trace.distance,
+                                    atol = something(options_with_trace.unique_points_atol, 1e-14),
+                                    rtol = something(options_with_trace.unique_points_rtol, 1e-8),
                                 ),
                             )
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1389,8 +1389,7 @@ function decompose_with_monodromy!(
 
     # first check that all points in P are unique
     id = 1
-    certified_up =
-        UniquePoints(first(P₀), 1; distance = InfNorm())
+    certified_up = UniquePoints(first(P₀), 1; distance = InfNorm())
     P = Vector{eltype(P₀)}()
     for (i, pᵢ) in enumerate(P₀)
         _, new_point = add!(certified_up, pᵢ, i; atol = atol, rtol = rtol)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1449,14 +1449,13 @@ function decompose_with_monodromy!(
                     if length(orbit) > 1 || iter ≥ 10 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
-                        complete_orbit =
-                            # matching_indices is only needed when P_certified found more
-                            # witness points than orbit contained. When P_certified has
-                            # fewer points (inner monodromy deduplicated some starts), the
-                            # full orbit is still complete — collapsed elements were just
-                            # numerical duplicates on the same component.
-                            length(P_certified) > length(orbit) ?
-                            Set(
+                        # matching_indices is only needed when P_certified found more
+                        # witness points than orbit contained. When P_certified has
+                        # fewer points (inner monodromy deduplicated some starts), the
+                        # full orbit is still complete — collapsed elements were just
+                        # numerical duplicates on the same component.
+                        if length(P_certified) > length(orbit)
+                            complete_orbit = Set(
                                 matching_indices(
                                     non_complete_points,
                                     P_certified;
@@ -1464,8 +1463,10 @@ function decompose_with_monodromy!(
                                     atol = something(options.unique_points_atol, 1e-14),
                                     rtol = something(options.unique_points_rtol, 1e-8),
                                 ),
-                            ) :
-                            orbit
+                            )
+                        else
+                            complete_orbit = orbit
+                        end
 
                         push!(decomposition, W_new)
                         push!(complete_orbits, complete_orbit)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -836,13 +836,13 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         trial > 1 && reset_u_homotopy_trackers!(trackers, u_data, cache)
 
         fill!(accepted, false)
-        track_hom1!(accepted1, P1, P, roots, trackers[1], progress, threading)
+        track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
         all(accepted) || continue
 
         # Hom1 only moves the slice. We still need to verify that its endpoints
         # are usable starts for Hom2; otherwise resample L1 and try again.
         fill!(accepted, false)
-        check_hom2_starts!(accepted2, P1, trackers[2], progress, threading)
+        check_hom2_starts!(accepted, P1, trackers[2], progress, threading)
         all(accepted) && break
     end
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -351,9 +351,7 @@ function _regeneration(
         max_endgame_extended_steps = 100,
         sing_cond = 1e12,
     ),
-    monodromy_options::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options::MonodromyOptions = MonodromyOptions(),
     max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading::Bool = Threads.nthreads() > 1,
@@ -1746,9 +1744,7 @@ function decompose(
     Ws::Vector{WP};
     show_progress::Bool = true,
     show_monodromy_progress::Bool = false,
-    monodromy_options::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options::MonodromyOptions = MonodromyOptions(),
     max_iters::Int = 200,
     warning::Bool = true,
     threading::Bool = Threads.nthreads() > 1,
@@ -2088,12 +2084,8 @@ function numerical_irreducible_decomposition(
         max_endgame_extended_steps = 100,
         sing_accuracy = 1e-10,
     ),
-    monodromy_options_for_regeneration = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
-    monodromy_options_for_decompose::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options_for_regeneration = MonodromyOptions(),
+    monodromy_options_for_decompose::MonodromyOptions = MonodromyOptions(),
     show_monodromy_progress::Bool = false,
     show_monodromy_for_regeneration_progress::Bool = false,
     show_monodromy_for_decompose_progress::Bool = false,
@@ -2384,9 +2376,7 @@ function _intersect(
         max_endgame_extended_steps = 100,
         sing_cond = 1e12,
     ),
-    monodromy_options::MonodromyOptions = MonodromyOptions(;
-        parameter_sampler = weighted_normal,
-    ),
+    monodromy_options::MonodromyOptions = MonodromyOptions(),
     max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading = Threads.nthreads() > 1,

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1526,7 +1526,7 @@ function decompose_with_monodromy!(
                     # Single orbits tend to have small trace, even if their points are on an irreducible component of degree > 1.
                     # allow_degree1_iter is reset once we find new points.
                     if length(clean_orbit) > 1 ||
-                       allow_degree1_iter ≥ 5 ||
+                       allow_degree1_iter ≥ 10 ||
                        iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1566,7 +1566,7 @@ function decompose_with_monodromy!(
 
                             push!(decomposition, W_new)
                             for p in solutions(W_new)
-                                add!(certified_up, p, 1, atol)
+                                add!(certified_up, p, 1; atol = atol, rtol = rtol)
                             end
                             d += length(P_certified) - length(complete_orbit)
                             update_progress!(progress, W_new)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1378,10 +1378,27 @@ function decompose_with_monodromy!(
 )
     update_progress_dim!(progress, dim(W))
 
-    P = unique_points(points(W))
+    P₀ = points(W)
     L = linear_subspace(W)
     G = system(W)
     n = ambient_dim(L)
+
+    # tolerances for comparing points
+    atol = something(options.unique_points_atol, 1e-14)
+    rtol = something(options.unique_points_rtol, 1e-8)
+
+    # first check that all points in P are unique
+    id = 1
+    certified_up =
+        UniquePoints(first(P₀), 1; distance = InfNorm())
+    P = Vector{eltype(P₀)}()
+    for (i, pᵢ) in enumerate(P₀)
+        _, new_point = add!(certified_up, pᵢ, i; atol = atol, rtol = rtol)
+        if new_point
+            push!(P, pᵢ)
+        end
+    end
+    empty!(certified_up) # we reuse this later
 
     decomposition = Vector{WitnessSet}()
 
@@ -1436,6 +1453,18 @@ function decompose_with_monodromy!(
             updated_points = indexed_solutions(res)
             d += length(updated_points) - length(non_complete_points) # update total degree in case we found new points.
             non_complete_points = updated_points
+
+            # Identify phantom points: new points that jumped into an already-certified component.
+            # Only check when new points were found and certified_up is non-empty.
+            phantom_indices = Set{Int}()
+            if length(updated_points) > prev_count && !isempty(certified_up)
+                for (i, p) in pairs(updated_points)
+                    if !isnothing(search_in_radius(certified_up, p, atol))
+                        push!(phantom_indices, i)
+                    end
+                end
+                d -= length(phantom_indices)
+            end
             ℓ = length(non_complete_points) # once for a later check
             k = length(non_complete_points) # and once for counting progress
             update_progress_npts!(progress, k)
@@ -1465,7 +1494,18 @@ function decompose_with_monodromy!(
             for orbit in orbits
                 update_progress!(progress; is_monodromy = true)
 
-                P_orbit = non_complete_points[collect(orbit)]
+                # Strip phantom indices from the orbit before running inner monodromy.
+                clean_orbit =
+                    isempty(phantom_indices) ? orbit : setdiff(orbit, phantom_indices)
+                if isempty(clean_orbit)
+                    push!(complete_orbits, orbit)
+                    k -= length(orbit)
+                    update_progress_npts!(progress, k)
+                    update_progress!(progress; is_monodromy = false)
+                    continue
+                end
+
+                P_orbit = non_complete_points[sort!(collect(clean_orbit))]
                 res_orbit = monodromy_solve(
                     MS,
                     P_orbit,
@@ -1477,63 +1517,58 @@ function decompose_with_monodromy!(
                 )
                 update_progress!(progress; is_monodromy = false)
 
+                # only continue when trace test succeeds
                 if trace(res_orbit) < options.trace_test_tol
 
-                    # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 10. 
-                    # Single orobits tend to have small trace, even if their points are on a irreducible component of degree > 1.
-                    # allow_degree1_iter is reset once we we find new points 
-                    if length(orbit) > 1 || allow_degree1_iter ≥ 5 || iter ≥ max_iters - 1
+                    # We do not want to add orbits of degree 1 as long as allow_degree1_iter < 5.
+                    # Single orbits tend to have small trace, even if their points are on an irreducible component of degree > 1.
+                    # allow_degree1_iter is reset once we find new points.
+                    if length(clean_orbit) > 1 ||
+                       allow_degree1_iter ≥ 5 ||
+                       iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
+
+                        # Check whether inner monodromy jumped into an already-certified component.
+                        # If so, the trace test result is unreliable — skip this orbit.
+                        if any(
+                            p -> !isnothing(search_in_radius(certified_up, p, atol)),
+                            P_certified,
+                        )
+                            continue
+                        end
+
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
 
-                        # when P_certified found more witness points than orbit contained,
-                        # there can be two reasons
-                        # (1) path jumping
-                        # (2) we found genuine new points 
-                        # we first check path jumping using has_point_in_decomposition
-                        # if this returns false, run matching_indices to find the correct indices
-                        # of the points in P_certified
-                        # if P_certified has fewer points (inner monodromy deduplicated some starts), the full orbit is still complete — collapsed elements were just
-                        # numerical duplicates on the same component.
-                        if length(P_certified) > length(orbit)
-                            # check if the extra points in P_certified came from path 
-                            # jumping by comparing them to the points in the completed decompositions
-                            has_duplicate = has_point_in_decomposition(
-                                P_certified,
-                                decomposition;
-                                atol = something(options.unique_points_atol, 1e-14),
-                                rtol = something(options.unique_points_rtol, 1e-8),
-                            )
-
-                            if !has_duplicate
-                                # if we have genuine new points find their indices
-                                complete_orbit = Set(
+                        if length(P_certified) > length(clean_orbit)
+                            # Genuine new points found — compute their indices in non_complete_points,
+                            # excluding any phantom indices that might have matched numerically.
+                            complete_orbit = setdiff(
+                                Set(
                                     matching_indices(
                                         non_complete_points,
                                         P_certified;
-                                        atol = something(options.unique_points_atol, 1e-14),
-                                        rtol = something(options.unique_points_rtol, 1e-8),
+                                        atol = atol,
+                                        rtol = rtol,
                                     ),
-                                )
-                                # if we have genuine new points restart the degree 1 check 
-                                allow_degree1_iter = 0
-                            end
+                                ),
+                                phantom_indices,
+                            )
+                            allow_degree1_iter = 0
                         else
-                            has_duplicate = false
-                            complete_orbit = orbit
+                            complete_orbit = clean_orbit
                         end
 
+                        # postprocessing
                         push!(complete_orbits, complete_orbit)
-                        k = k - length(complete_orbit)
+                        k -= length(complete_orbit)
                         update_progress_npts!(progress, k)
 
-                        # put a new witness set into decomposition
-                        # only if has_duplicate == false
-                        if !has_duplicate
-                            push!(decomposition, W_new)
-                            d += length(P_certified) - length(complete_orbit)
-                            update_progress!(progress, W_new)
+                        push!(decomposition, W_new)
+                        for p in solutions(W_new)
+                            add!(certified_up, p, 1, atol)
                         end
+                        d += length(P_certified) - length(complete_orbit)
+                        update_progress!(progress, W_new)
                     end
                 end
             end
@@ -1564,7 +1599,9 @@ function decompose_with_monodromy!(
             for orbit in complete_orbits
                 append!(complete_orbit_indices, orbit)
             end
+            append!(complete_orbit_indices, phantom_indices)
             sort!(complete_orbit_indices)
+            unique!(complete_orbit_indices)
 
             deleteat!(non_complete_points, complete_orbit_indices)
 
@@ -1587,15 +1624,18 @@ function decompose_with_monodromy!(
                 i += 1
             end
 
-            shift_orbit(orbit) = Set(orbit_indices_mapping[i] for i in orbit)
+            # Skip phantom indices when shifting — they have been removed from non_complete_points.
+            shift_orbit(orbit) =
+                Set(orbit_indices_mapping[i] for i in orbit if i ∉ phantom_indices)
             # 1. shift existing non complete orbits to new mapping
             non_complete_orbits =
                 shift_orbit.(
                     merge_sets(
                         [
-                            # Remove all orbits that are contained in a complete orbit
+                            # Remove all orbits that overlap with a complete orbit or phantom indices
                             filter(non_complete_orbits) do o
-                                all(co -> isdisjoint(co, o), complete_orbits)
+                                all(co -> isdisjoint(co, o), complete_orbits) &&
+                                    isdisjoint(o, phantom_indices)
                             end
                             setdiff(orbits, complete_orbits)
                         ],
@@ -1704,15 +1744,6 @@ function merge_sets(sets)
 end
 
 # check if we have found points that are already classifiedxw
-function has_point_in_decomposition(P, decomposition; atol, rtol)
-    any(P) do p
-        rad = max(atol, norm(p, Inf) * rtol)
-        any(decomposition) do W
-            any(q -> distance(p, q, InfNorm()) ≤ rad, points(W))
-        end
-    end
-end
-
 # find indices of newly detected points
 function matching_indices(points, certified_points; atol, rtol)
     indices = Int[]

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2477,6 +2477,8 @@ function _intersect(
     max_trials_u_homotopy::Int = 5,
     show_monodromy_progress::Bool = false,
     threading = Threads.nthreads() > 1,
+    atol = 1e-14,
+    rtol = sqrt(eps()),
     kwargs...,
 )
     @assert size(system(H), 1) == 1 "The second argument must be defined by a single polynomial."
@@ -2516,9 +2518,9 @@ function _intersect(
     )
 
     # intersect
-    intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, kwargs...)
+    intersect_with_hypersurface!(W₁, Hᵤ, W₂, cache; threading = threading, atol = atol, rtol = rtol, kwargs...)
     update_Fᵢ!(cache, [f; h], vars_u)
-    fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading)
+    fill_up!([W₁; W₂], monodromy_options, cache, show_monodromy_progress, threading; atol = atol, rtol = rtol)
 
     # return data 
     G = fixed(System([f; h], variables = vars); compile = false)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1391,7 +1391,7 @@ function decompose_with_monodromy!(
                 if trace(res_orbit) < options.trace_test_tol
 
                     # We do not want to add orbits of length 1 in the beginning. Even if they are on an irreducible component of degree > 1, they tend to have small trace.
-                    if length(orbit) > 1 || iter ≥ 5 || iter ≥ max_iters - 1
+                    if length(orbit) > 1 || iter ≥ 50 || iter ≥ max_iters - 1
                         P_certified = indexed_solutions(res_orbit)
                         W_new = WitnessSet(G, L, P_certified; is_irreducible = true)
                         complete_orbit =

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1765,6 +1765,8 @@ function get_orbits_from_monodromy_permutations(
             end
         end
     end
+    sort!(orbits; by = length, rev = true)
+
     orbits
 end
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -1388,10 +1388,7 @@ function decompose_with_monodromy!(
     if dim(L) < n
         update_progress!(progress; is_monodromy = true)
 
-        options, options_without_trace = _options
         MS = MonodromySolver(G, L; compile = false, options = options)
-        MS_without_trace =
-            MonodromySolver(G, L; compile = false, options = options_without_trace)
         initial_points = check_start_solutions(MS, P, L)
         res = monodromy_solve(
             MS,
@@ -1424,7 +1421,7 @@ function decompose_with_monodromy!(
 
             update_progress!(progress; is_monodromy = true)
             res = monodromy_solve(
-                MS_without_trace, # without trace to populate the permutation matrix
+                MS,
                 non_complete_points,
                 L,
                 seed;
@@ -1742,7 +1739,7 @@ function decompose_with_monodromy_options(
     # we need two copies of the options.
     # one with trace test
     # one without to run monodromy populating the permutation matrix
-    options_with_trace = MonodromyOptions(;
+    options = MonodromyOptions(;
         permutations = true,
         trace_test = true,
         single_loop_per_start_solution = true,
@@ -1764,30 +1761,8 @@ function decompose_with_monodromy_options(
         unique_points_atol = something(M.unique_points_atol, atol),
         unique_points_rtol = something(M.unique_points_rtol, rtol),
     )
-    options_without_trace = MonodromyOptions(;
-        permutations = true,
-        trace_test = false,
-        single_loop_per_start_solution = true,
-        check_startsolutions = false,
-        group_actions = M.group_actions,
-        loop_finished_callback = M.loop_finished_callback,
-        parameter_sampler = M.parameter_sampler,
-        equivalence_classes = M.equivalence_classes,
-        duplicate_check = M.duplicate_check,
-        certification_max_precision = M.certification_max_precision,
-        certification_refine_solution = M.certification_refine_solution,
-        trace_test_tol = M.trace_test_tol,
-        target_solutions_count = M.target_solutions_count,
-        timeout = M.timeout,
-        min_solutions = M.min_solutions,
-        max_loops_no_progress = M.max_loops_no_progress,
-        reuse_loops = M.reuse_loops,
-        distance = M.distance,
-        unique_points_atol = something(M.unique_points_atol, atol),
-        unique_points_rtol = something(M.unique_points_rtol, rtol),
-    )
 
-    options_with_trace, options_without_trace
+    options
 end
 
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -835,7 +835,10 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
 
         fill!(accepted, false)
         track_hom1!(accepted, P1, P, roots, trackers[1], progress, threading)
-        all(accepted) || continue
+        if !all(accepted)
+            fill!(accepted, false)
+            continue
+        end
 
         # Hom1 only moves the slice. We still need to verify that its endpoints
         # are usable starts for Hom2; otherwise resample L1 and try again.
@@ -844,7 +847,7 @@ function track_intersection!(X, P, roots, trackers, u_data, cache, progress, thr
         all(accepted) && break
     end
 
-    track_hom2_hom3!(X, P1, trackers[2], trackers[3], progress, threading)
+    track_hom2_hom3!(X, P1, accepted, trackers[2], trackers[3], progress, threading)
 
     nothing
 end
@@ -928,11 +931,11 @@ function check_hom2_starts!(accepted, P1, tracker, progress, threading)
     end
 end
 
-function track_hom2_hom3!(X, P1, tracker2, tracker3, progress, threading)
+function track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress, threading)
     if threading
-        threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     else
-        serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+        serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     end
 end
 
@@ -968,11 +971,12 @@ function serial_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function serial_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function serial_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
     l_start = length(P1)
 
     for i = 1:l_start
         update_progress_paths!(progress, i, l_start)
+        accepted[i] || continue
 
         code2 = track!(tracker2, P1[i], 1)
         if is_accepted(tracker2, code2)
@@ -1067,7 +1071,7 @@ function threaded_check_hom2_starts!(accepted, P1, tracker, progress)
     nothing
 end
 
-function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
+function threaded_track_hom2_hom3!(X, P1, accepted, tracker2, tracker3, progress)
 
     l_start = length(P1)
 
@@ -1092,6 +1096,7 @@ function threaded_track_hom2_hom3!(X, P1, tracker2, tracker3, progress)
                         lock(progress_lock) do
                             update_progress_paths!(progress, idx, l_start)
                         end
+                        accepted[idx] || continue
 
                         code2 = track!(local_tracker2, P1[idx], 1)
                         if is_accepted(local_tracker2, code2)

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -18,7 +18,7 @@
         # sorting
         W = regeneration(F; sorted = false, show_progress = false)
         @test degree.(W) == [2, 8, 8]
-        
+
         N = NumericalIrreducibleDecomposition(decompose(W))
         @test seed(N) == s
 

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -27,36 +27,16 @@
         N = nid(F; threading = false, show_progress = false)
         @test isa(N, NumericalIrreducibleDecomposition)
 
-        # seed
-        s = 0x42c9d504
-        N = nid(F; seed = s, show_progress = false)
-        @test seed(N) == s
-
-        N = nid(F; seed = nothing, show_progress = false)
-        @test isnothing(seed(N))
-
         # bad seed
-        N = nid(F; seed = UInt32(62), show_progress = false)
+        s = UInt32(62)
+        N = nid(F; seed = s, show_progress = false)
         degs = degrees(N)
+        @test seed(N) == s
         @test degs[2] == [2]
         @test degs[1] == [4, 4]
 
-
-        N = nid(F; show_monodromy_progress = true, show_progress = false)
-        @test isa(N, NumericalIrreducibleDecomposition)
-
-        N = nid(F; warning = false, show_progress = false)
-        @test isa(N, NumericalIrreducibleDecomposition)
-
-        N = nid(
-            F;
-            seed = UInt32(62),
-            sorted = true,
-            threading = false,
-            show_progress = false,
-        )
-        @test degrees(N)[2] == [2]
-        @test degrees(N)[1] == [4, 4]
+        N = nid(F; seed = nothing, show_progress = false)
+        @test isnothing(seed(N))
 
         # options
         N_fails = nid(
@@ -68,29 +48,24 @@
 
         N2 = nid(
             F;
-            tracker_options = TrackerOptions(; extended_precision = false),
+            monodromy_options = MonodromyOptions(; trace_test_tol = 1e-5),
             show_progress = false,
         )
         @test isa(N2, NumericalIrreducibleDecomposition)
 
-        N3 = nid(
-            F;
-            monodromy_options = MonodromyOptions(; trace_test_tol = 1e-5),
-            show_progress = false,
-        )
-        @test isa(N3, NumericalIrreducibleDecomposition)
+        N = nid(F; show_monodromy_progress = true, show_progress = false)
+        @test isa(N, NumericalIrreducibleDecomposition)
+
+        N = nid(F; warning = false, show_progress = false)
+        @test isa(N, NumericalIrreducibleDecomposition)
 
         # number of components
-        @test ncomponents(N3) == 11
-        @test ncomponents(N3, dims = [1, 2]) == 3
-        @test ncomponents(N3, 1) == 2
-        @test n_components(N3) == 11
-        @test n_components(N3, dims = [1, 2]) == 3
-        @test n_components(N3, 1) == 2
-
-        # max_codim = 1
-        N4 = nid(F; max_codim = 1, show_progress = false)
-        @test isa(N4, NumericalIrreducibleDecomposition)
+        @test ncomponents(N2) == 11
+        @test ncomponents(N2, dims = [1, 2]) == 3
+        @test ncomponents(N2, 1) == 2
+        @test n_components(N2) == 11
+        @test n_components(N2, dims = [1, 2]) == 3
+        @test n_components(N2, 1) == 2
     end
 
     @testset "rational systems" begin

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -19,9 +19,6 @@
         W = regeneration(F; sorted = false, show_progress = false)
         @test degree.(W) == [2, 8, 8]
 
-        N = NumericalIrreducibleDecomposition(decompose(W))
-        @test seed(N) == s
-
         # limited codimension
         W = regeneration(F; max_codim = 2, show_progress = false)
         @test degree.(W) == [2, 8]

--- a/test/nid_test.jl
+++ b/test/nid_test.jl
@@ -18,6 +18,9 @@
         # sorting
         W = regeneration(F; sorted = false, show_progress = false)
         @test degree.(W) == [2, 8, 8]
+        
+        N = NumericalIrreducibleDecomposition(decompose(W))
+        @test seed(N) == s
 
         # limited codimension
         W = regeneration(F; max_codim = 2, show_progress = false)
@@ -36,7 +39,7 @@
         @test isnothing(seed(N))
 
         # bad seed
-        N = nid(F; seed = 0xc770fa47, show_progress = false)
+        N = nid(F; seed = UInt32(62), show_progress = false)
         degs = degrees(N)
         @test degs[2] == [2]
         @test degs[1] == [4, 4]
@@ -47,6 +50,16 @@
 
         N = nid(F; warning = false, show_progress = false)
         @test isa(N, NumericalIrreducibleDecomposition)
+
+        N = nid(
+            F;
+            seed = UInt32(62),
+            sorted = true,
+            threading = false,
+            show_progress = false,
+        )
+        @test degrees(N)[2] == [2]
+        @test degrees(N)[1] == [4, 4]
 
         # options
         N_fails = nid(


### PR DESCRIPTION
This PR increases the stability of NID computations: 

* The $u$-homotopy step that moves from $u^d - 1$ to $f_i$ with $\mathrm{deg}(f_i)=d$ failed with too high probability. The reason is that intermediate linear subspaces can sample badly (about a 5% change). To remedy this we implement a multiple trials algorithm: if the first attempt fails, try another one, until it works.

* The first monodromy run in every step of `decompose` now has no trace test to populate the permutation matrix more quickly. Moreover, the default value for the maximal number of iterations has been increased to 200.

* There was a bug in `decompose` that didnt let monodromy use the tolerances given by `atol` and `rtol`. This is now fixed.

* `decompose` no has detailed safeguards against path jumping