### PR TITLE
Tune MatrixWorkspace LU and QR solve paths

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -11,6 +11,7 @@ struct MatrixWorkspace{M<:Matrix{ComplexF64}} <: AbstractMatrix{ComplexF64}
     A::M
     d::Vector{Float64} # Inverse of scaling factors
     factorized::Base.RefValue{Bool}
+    upper_singular::Base.RefValue{Bool}
     lu::LA.LU{ComplexF64,M,Vector{Int}} # LU Factorization of D * J
     qr::LA.QR{ComplexF64,Matrix{ComplexF64},Vector{ComplexF64}}
     stdlib_qr::Base.RefValue{
@@ -37,6 +38,7 @@ function MatrixWorkspace(Â::AbstractMatrix; optimize_data_structure = true)
     A = Matrix{ComplexF64}(Â)
     d = ones(m)
     factorized = Ref(false)
+    upper_singular = Ref(false)
     qr = LA.QR{ComplexF64,Matrix{ComplexF64},Vector{ComplexF64}}(
         copy(A),
         zeros(ComplexF64, min(m, n)),
@@ -58,6 +60,7 @@ function MatrixWorkspace(Â::AbstractMatrix; optimize_data_structure = true)
         A,
         d,
         factorized,
+        upper_singular,
         lu,
         qr,
         stdlib_qr,
@@ -263,14 +266,18 @@ function factorize!(WS::MatrixWorkspace)
     if m == n
         if n ≥ LU_STDLIB_BREAKPOINT
             LA.LAPACK.getrf!(WS.lu.factors, WS.lu.ipiv; check = true)
+            WS.upper_singular[] = false
         else
             lu!(WS.lu.factors, WS.lu.ipiv)
+            WS.upper_singular[] = has_zero_diagonal(WS.lu.factors, n)
         end
     else
         if n ≥ QR_STDLIB_BREAKPOINT
             WS.stdlib_qr[] = LA.qr!(WS.qr.factors)
+            WS.upper_singular[] = false
         else
             qr!(WS.qr)
+            WS.upper_singular[] = has_zero_diagonal(WS.qr.factors, n)
         end
     end
     WS.factorized[] = true
@@ -323,19 +330,36 @@ end
 end
 
 @inline function ldiv_upper_stdlib!(A::AbstractMatrix, x::AbstractVector)
+    ldiv_upper_stdlib!(A, x, has_zero_diagonal(A, length(x)))
+end
+@inline function ldiv_upper_stdlib!(
+    A::AbstractMatrix,
+    x::AbstractVector,
+    upper_singular::Bool,
+)
+    upper_singular && return ldiv_upper!(A, x)
     n = length(x)
-    @inbounds for i = 1:n
-        iszero(A[i, i]) && return ldiv_upper!(A, x)
-    end
     R = LA.UpperTriangular(view(A, 1:n, 1:n))
     LA.ldiv!(R, x)
 end
 
-function lu_ldiv_stdlib_upper!(x, LU::LA.LU, b::AbstractVector)
+@inline function has_zero_diagonal(A::AbstractMatrix, n::Integer)
+    @inbounds for i = 1:n
+        iszero(A[i, i]) && return true
+    end
+    false
+end
+
+function lu_ldiv_stdlib_upper!(
+    x,
+    LU::LA.LU,
+    b::AbstractVector,
+    upper_singular::Bool = has_zero_diagonal(LU.factors, length(x)),
+)
     x === b || copyto!(x, b)
     _ipiv!(LU, x)
     ldiv_unit_lower!(LU.factors, x)
-    ldiv_upper_stdlib!(LU.factors, x)
+    ldiv_upper_stdlib!(LU.factors, x, upper_singular)
     x
 end
 
@@ -405,14 +429,19 @@ function lmul_Q_adj!(A::LA.QR, b::AbstractVector)
     end
     b
 end
-function qr_ldiv!(x, QR::LA.QR, b::AbstractVector)
+function qr_ldiv!(
+    x,
+    QR::LA.QR,
+    b::AbstractVector,
+    upper_singular::Bool = has_zero_diagonal(QR.factors, length(x)),
+)
     # overwrites b
     # assumes QR is a tall matrix
     lmul_Q_adj!(QR, b)
     @inbounds for i = 1:length(x)
         x[i] = b[i]
     end
-    ldiv_upper_stdlib!(QR.factors, x)
+    ldiv_upper_stdlib!(QR.factors, x, upper_singular)
     return x
 end
 
@@ -429,13 +458,13 @@ function LA.ldiv!(x::AbstractVector, WS::MatrixWorkspace, b::AbstractVector)
             if n ≥ LU_STDLIB_BREAKPOINT
                 lu_ldiv!(x, WS.lu, x)
             else
-                lu_ldiv_stdlib_upper!(x, WS.lu, x)
+                lu_ldiv_stdlib_upper!(x, WS.lu, x, WS.upper_singular[])
             end
         else
             if n ≥ LU_STDLIB_BREAKPOINT
                 lu_ldiv!(x, WS.lu, b)
             else
-                lu_ldiv_stdlib_upper!(x, WS.lu, b)
+                lu_ldiv_stdlib_upper!(x, WS.lu, b, WS.upper_singular[])
             end
         end
     else
@@ -443,7 +472,7 @@ function LA.ldiv!(x::AbstractVector, WS::MatrixWorkspace, b::AbstractVector)
             LA.ldiv!(x, WS.stdlib_qr[], b)
         else
             WS.r .= b
-            qr_ldiv!(x, WS.qr, WS.r)
+            qr_ldiv!(x, WS.qr, WS.r, WS.upper_singular[])
         end
     end
     x

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -4,12 +4,18 @@
 This is a data structure for the efficient repeated solution of a square or
 overdetermined linear system `Ax=b`.
 """
-struct MatrixWorkspace{M<:AbstractMatrix{ComplexF64}} <: AbstractMatrix{ComplexF64}
-    A::M # Matrix
+const LU_STDLIB_BREAKPOINT = 28
+const QR_STDLIB_BREAKPOINT = 44
+
+struct MatrixWorkspace{M<:Matrix{ComplexF64}} <: AbstractMatrix{ComplexF64}
+    A::M
     d::Vector{Float64} # Inverse of scaling factors
     factorized::Base.RefValue{Bool}
     lu::LA.LU{ComplexF64,M,Vector{Int}} # LU Factorization of D * J
     qr::LA.QR{ComplexF64,Matrix{ComplexF64},Vector{ComplexF64}}
+    stdlib_qr::Base.RefValue{
+        LA.QRCompactWY{ComplexF64,Matrix{ComplexF64},Matrix{ComplexF64}},
+    }
     row_scaling::Vector{Float64}
     scaled::Base.RefValue{Bool}
     # mixed precision iterative refinement
@@ -24,18 +30,18 @@ end
 MatrixWorkspace(m::Integer, n::Integer; kwargs...) =
     MatrixWorkspace(zeros(ComplexF64, m, n); kwargs...)
 function MatrixWorkspace(Â::AbstractMatrix; optimize_data_structure = true)
+    _ = optimize_data_structure
     m, n = size(Â)
     m ≥ n || throw(ArgumentError("Expected system with more rows than columns."))
 
     A = Matrix{ComplexF64}(Â)
     d = ones(m)
     factorized = Ref(false)
-    qr = LA.qrfactUnblocked!(copy(A))
-    # experiments show that for m > 25 the data layout as a
-    # struct array is beneficial
-    if m > 25 && optimize_data_structure
-        A = StructArrays.StructArray(A)
-    end
+    qr = LA.QR{ComplexF64,Matrix{ComplexF64},Vector{ComplexF64}}(
+        copy(A),
+        zeros(ComplexF64, min(m, n)),
+    )
+    stdlib_qr = Ref(LA.qr!(copy(A)))
     row_scaling = ones(m)
     scaled = Ref(false)
 
@@ -54,6 +60,7 @@ function MatrixWorkspace(Â::AbstractMatrix; optimize_data_structure = true)
         factorized,
         lu,
         qr,
+        stdlib_qr,
         row_scaling,
         scaled,
         x̄,
@@ -254,9 +261,17 @@ end
 function factorize!(WS::MatrixWorkspace)
     m, n = size(WS)
     if m == n
-        lu!(WS.lu.factors, WS.lu.ipiv)
+        if n ≥ LU_STDLIB_BREAKPOINT
+            LA.LAPACK.getrf!(WS.lu.factors, WS.lu.ipiv; check = true)
+        else
+            lu!(WS.lu.factors, WS.lu.ipiv)
+        end
     else
-        qr!(WS.qr)
+        if n ≥ QR_STDLIB_BREAKPOINT
+            WS.stdlib_qr[] = LA.qr!(WS.qr.factors)
+        else
+            qr!(WS.qr)
+        end
     end
     WS.factorized[] = true
     WS
@@ -307,11 +322,26 @@ end
     x
 end
 
-function lu_ldiv!(x, LU::LA.LU, b::AbstractVector)
+@inline function ldiv_upper_stdlib!(A::AbstractMatrix, x::AbstractVector)
+    n = length(x)
+    @inbounds for i = 1:n
+        iszero(A[i, i]) && return ldiv_upper!(A, x)
+    end
+    R = LA.UpperTriangular(view(A, 1:n, 1:n))
+    LA.ldiv!(R, x)
+end
+
+function lu_ldiv_stdlib_upper!(x, LU::LA.LU, b::AbstractVector)
     x === b || copyto!(x, b)
     _ipiv!(LU, x)
     ldiv_unit_lower!(LU.factors, x)
-    ldiv_upper!(LU.factors, x)
+    ldiv_upper_stdlib!(LU.factors, x)
+    x
+end
+
+function lu_ldiv!(x, LU::LA.LU, b::AbstractVector)
+    x === b || copyto!(x, b)
+    LA.ldiv!(x, LU, x)
     x
 end
 
@@ -382,7 +412,7 @@ function qr_ldiv!(x, QR::LA.QR, b::AbstractVector)
     @inbounds for i = 1:length(x)
         x[i] = b[i]
     end
-    ldiv_upper!(QR.factors, x)
+    ldiv_upper_stdlib!(QR.factors, x)
     return x
 end
 
@@ -396,13 +426,25 @@ function LA.ldiv!(x::AbstractVector, WS::MatrixWorkspace, b::AbstractVector)
     if m == n
         if WS.scaled[]
             x .= WS.row_scaling .* b
-            lu_ldiv!(x, WS.lu, x)
+            if n ≥ LU_STDLIB_BREAKPOINT
+                lu_ldiv!(x, WS.lu, x)
+            else
+                lu_ldiv_stdlib_upper!(x, WS.lu, x)
+            end
         else
-            lu_ldiv!(x, WS.lu, b)
+            if n ≥ LU_STDLIB_BREAKPOINT
+                lu_ldiv!(x, WS.lu, b)
+            else
+                lu_ldiv_stdlib_upper!(x, WS.lu, b)
+            end
         end
     else
-        WS.r .= b
-        qr_ldiv!(x, WS.qr, WS.r)
+        if n ≥ QR_STDLIB_BREAKPOINT
+            LA.ldiv!(x, WS.stdlib_qr[], b)
+        else
+            WS.r .= b
+            qr_ldiv!(x, WS.qr, WS.r)
+        end
     end
     x
 end

--- a/src/tracker.jl
+++ b/src/tracker.jl
@@ -359,7 +359,7 @@ function TrackerState(H, x₁::AbstractVector, norm::WeightedNorm{InfNorm})
     accepted_steps = rejected_steps = ext_accepted_steps = ext_rejected_steps = 0
     last_steps_failed = 0
 
-    TrackerState(
+    TrackerState{Matrix{ComplexF64}}(
         x,
         x̂,
         x̄,

--- a/test/linear_algebra_test.jl
+++ b/test/linear_algebra_test.jl
@@ -23,9 +23,12 @@
         WS .= C
         @test WS.A == C
 
-        #test struct array switch
+        # The legacy optimization keyword is accepted as a no-op.
         A = rand(ComplexF32, 30, 30)
-        WS = HC.MatrixWorkspace(A)
+        WS = HC.MatrixWorkspace(A; optimize_data_structure = true)
+        @test WS.A isa Matrix{ComplexF64}
+        @test WS.lu.factors isa Matrix{ComplexF64}
+        @test WS.qr.factors isa Matrix{ComplexF64}
     end
 
     @testset "QR" begin
@@ -49,7 +52,7 @@
     end
 
     @testset "ldiv" begin
-        for n in [3, 13, 31] # test that struct array also works
+        for n in [3, 13, 31]
             A = randn(ComplexF64, n, n)
             b = randn(ComplexF64, n)
             x = zeros(ComplexF64, n)
@@ -61,6 +64,49 @@
             @test (@allocated ldiv!(x, WS, b)) == 0
             @test (lu(A) \ b) ≈ x rtol = cond(A) * 10
         end
+    end
+
+    @testset "LU breakpoint" begin
+        for n in (27, 28)
+            A = randn(ComplexF64, n, n)
+            b = randn(ComplexF64, n)
+            x = zeros(ComplexF64, n)
+            WS = HC.MatrixWorkspace(A)
+
+            ldiv!(x, WS, b)
+
+            @test WS.factorized[]
+            @test norm(A * x - b) / norm(b) < 1e-12
+            @test x ≈ A \ b rtol = 1e-12
+        end
+    end
+
+    @testset "QR breakpoint" begin
+        for n in (43, 44)
+            m = n + 5
+            A = randn(ComplexF64, m, n)
+            b = randn(ComplexF64, m)
+            b0 = copy(b)
+            x = zeros(ComplexF64, n)
+            WS = HC.MatrixWorkspace(A)
+
+            ldiv!(x, WS, b)
+
+            @test WS.factorized[]
+            @test b == b0
+            @test norm(x - (A \ b0)) / norm(x) < 1e-12
+        end
+    end
+
+    @testset "QR rectangular" begin
+        A = randn(ComplexF64, 61, 17)
+        b = randn(ComplexF64, 61)
+        x = zeros(ComplexF64, 17)
+        WS = HC.MatrixWorkspace(A)
+
+        ldiv!(x, WS, b)
+
+        @test norm(x - (A \ b)) / norm(x) < 1e-12
     end
 
     @testset "Inf-norm estimator / cond" begin


### PR DESCRIPTION
## Summary

This updates `MatrixWorkspace` to keep its matrix and factor buffers as plain `Matrix{ComplexF64}` storage, then routes larger square/rectangular solves through stdlib/LAPACK paths where the benchmarks favor them.

Changes:
- remove `StructArray` storage from `MatrixWorkspace`; `optimize_data_structure` remains accepted as a no-op
- use custom pivoting/lower solve plus stdlib `UpperTriangular` for the small custom LU/QR solve paths
- cache exact-zero upper diagonal status during custom factorization so repeated workspace solves avoid rescanning the diagonal
- use stdlib LU for square systems with `n >= 28`
- use stdlib QR for rectangular systems with column count `n >= 44`
- add breakpoint correctness tests for LU `n=27/28`, QR `n=43/44`, plus a rectangular QR case

## Validation

- `test/linear_algebra_test.jl`: 54/54 passing
- targeted surrounding tests:
  - `Tracker`: 125/125 passing
  - `Linear Spaces`: 45/45 passing
- upper-solve guard microbenchmark: cached singular flag was faster than per-solve diagonal precheck for 55 / 58 sizes, average cached/precheck ratio `0.984x`
- benchmark comparison: clean `origin/main` at `09484cee` versus this branch, single-threaded BLAS, `BenchmarkTools.@belapsed`, workload is `MatrixWorkspace` full `update! + ldiv!`

## Benchmark Summary

| Shape | Sizes | Wins | Average relative speedup |
|---|---:|---:|---:|
| Square LU `n x n` | `n=3:60` | 55 / 58 | 1.339x |
| Rectangular QR `2n x n` | `n=3:60` | 55 / 58 | 1.100x |

Absolute speedup is `main_time_ns - branch_time_ns`; relative speedup is `main_time_ns / branch_time_ns`. Negative absolute speedups indicate branch was slower for that size.

| n | main ns | branch ns | absolute speedup ns | relative speedup |
|---:|---:|---:|---:|---:|
| 3 | 98 | 118 | -20 | 0.831x |
| 4 | 132 | 140 | -8 | 0.943x |
| 5 | 167 | 169 | -2 | 0.988x |
| 6 | 241 | 230 | 11 | 1.048x |
| 7 | 311 | 286 | 25 | 1.087x |
| 8 | 377 | 361 | 16 | 1.044x |
| 9 | 441 | 413 | 28 | 1.068x |
| 10 | 516 | 470 | 46 | 1.098x |
| 11 | 645 | 586 | 59 | 1.101x |
| 12 | 797 | 719 | 78 | 1.108x |
| 13 | 891 | 801 | 90 | 1.112x |
| 14 | 1012 | 917 | 95 | 1.104x |
| 15 | 1217 | 1083 | 134 | 1.124x |
| 16 | 1375 | 1233 | 142 | 1.115x |
| 17 | 1617 | 1425 | 192 | 1.135x |
| 18 | 1854 | 1633 | 221 | 1.135x |
| 19 | 2009 | 1883 | 126 | 1.067x |
| 20 | 2269 | 2093 | 176 | 1.084x |
| 21 | 2565 | 2384 | 181 | 1.076x |
| 22 | 2907 | 2736 | 171 | 1.062x |
| 23 | 3240 | 3094 | 146 | 1.047x |
| 24 | 3620 | 3338 | 282 | 1.084x |
| 25 | 3979 | 3703 | 276 | 1.075x |
| 26 | 5028 | 4131 | 897 | 1.217x |
| 27 | 5840 | 4696 | 1144 | 1.244x |
| 28 | 6075 | 4827 | 1248 | 1.259x |
| 29 | 6867 | 5430 | 1437 | 1.265x |
| 30 | 7469 | 5826 | 1643 | 1.282x |
| 31 | 7917 | 6425 | 1492 | 1.232x |
| 32 | 8750 | 6542 | 2208 | 1.338x |
| 33 | 9250 | 7417 | 1833 | 1.247x |
| 34 | 9958 | 7136 | 2822 | 1.395x |
| 35 | 10625 | 7917 | 2708 | 1.342x |
| 36 | 11875 | 8180 | 3695 | 1.452x |
| 37 | 12375 | 9041 | 3334 | 1.369x |
| 38 | 13292 | 9056 | 4236 | 1.468x |
| 39 | 14042 | 9959 | 4083 | 1.410x |
| 40 | 15166 | 10042 | 5124 | 1.510x |
| 41 | 16250 | 11000 | 5250 | 1.477x |
| 42 | 17208 | 11583 | 5625 | 1.486x |
| 43 | 18542 | 12583 | 5959 | 1.474x |
| 44 | 20041 | 12500 | 7541 | 1.603x |
| 45 | 21417 | 13833 | 7584 | 1.548x |
| 46 | 23125 | 14125 | 9000 | 1.637x |
| 47 | 24500 | 15750 | 8750 | 1.556x |
| 48 | 25833 | 15375 | 10458 | 1.680x |
| 49 | 27583 | 16792 | 10791 | 1.643x |
| 50 | 27916 | 17166 | 10750 | 1.626x |
| 51 | 30083 | 19125 | 10958 | 1.573x |
| 52 | 31625 | 18833 | 12792 | 1.679x |
| 53 | 33417 | 20166 | 13251 | 1.657x |
| 54 | 35667 | 20917 | 14750 | 1.705x |
| 55 | 38167 | 22833 | 15334 | 1.672x |
| 56 | 39042 | 22500 | 16542 | 1.735x |
| 57 | 50250 | 24125 | 26125 | 2.083x |
| 58 | 43750 | 24958 | 18792 | 1.753x |
| 59 | 45916 | 26958 | 18958 | 1.703x |
| 60 | 48291 | 26417 | 21874 | 1.828x |

| n | m | main ns | branch ns | absolute speedup ns | relative speedup |
|---:|---:|---:|---:|---:|---:|
| 3 | 6 | 144 | 151 | -7 | 0.954x |
| 4 | 8 | 211 | 213 | -2 | 0.991x |
| 5 | 10 | 313 | 304 | 9 | 1.030x |
| 6 | 12 | 445 | 420 | 25 | 1.060x |
| 7 | 14 | 604 | 567 | 37 | 1.065x |
| 8 | 16 | 797 | 752 | 45 | 1.060x |
| 9 | 18 | 1033 | 983 | 50 | 1.051x |
| 10 | 20 | 1338 | 1271 | 67 | 1.053x |
| 11 | 22 | 1692 | 1600 | 92 | 1.058x |
| 12 | 24 | 2088 | 2009 | 79 | 1.039x |
| 13 | 26 | 2713 | 2463 | 250 | 1.102x |
| 14 | 28 | 3271 | 3042 | 229 | 1.075x |
| 15 | 30 | 3932 | 3630 | 302 | 1.083x |
| 16 | 32 | 4810 | 4369 | 441 | 1.101x |
| 17 | 34 | 5583 | 5201 | 382 | 1.073x |
| 18 | 36 | 6617 | 6133 | 484 | 1.079x |
| 19 | 38 | 7636 | 7156 | 480 | 1.067x |
| 20 | 40 | 8750 | 8278 | 472 | 1.057x |
| 21 | 42 | 9917 | 9458 | 459 | 1.049x |
| 22 | 44 | 11333 | 10791 | 542 | 1.050x |
| 23 | 46 | 12833 | 12291 | 542 | 1.044x |
| 24 | 48 | 14416 | 13833 | 583 | 1.042x |
| 25 | 50 | 16125 | 15541 | 584 | 1.038x |
| 26 | 52 | 18042 | 17333 | 709 | 1.041x |
| 27 | 54 | 20083 | 19250 | 833 | 1.043x |
| 28 | 56 | 22208 | 21458 | 750 | 1.035x |
| 29 | 58 | 24417 | 23625 | 792 | 1.034x |
| 30 | 60 | 26875 | 26042 | 833 | 1.032x |
| 31 | 62 | 29416 | 28625 | 791 | 1.028x |
| 32 | 64 | 32250 | 31375 | 875 | 1.028x |
| 33 | 66 | 35250 | 34500 | 750 | 1.022x |
| 34 | 68 | 38458 | 37666 | 792 | 1.021x |
| 35 | 70 | 41833 | 42041 | -208 | 0.995x |
| 36 | 72 | 45542 | 44541 | 1001 | 1.022x |
| 37 | 74 | 49875 | 48583 | 1292 | 1.027x |
| 38 | 76 | 53667 | 52375 | 1292 | 1.025x |
| 39 | 78 | 58083 | 56166 | 1917 | 1.034x |
| 40 | 80 | 62500 | 60875 | 1625 | 1.027x |
| 41 | 82 | 67500 | 65250 | 2250 | 1.034x |
| 42 | 84 | 72375 | 70000 | 2375 | 1.034x |
| 43 | 86 | 77084 | 74833 | 2251 | 1.030x |
| 44 | 88 | 82542 | 73708 | 8834 | 1.120x |
| 45 | 90 | 88083 | 78709 | 9374 | 1.119x |
| 46 | 92 | 93750 | 81709 | 12041 | 1.147x |
| 47 | 94 | 100167 | 87792 | 12375 | 1.141x |
| 48 | 96 | 106208 | 89375 | 16833 | 1.188x |
| 49 | 98 | 113000 | 94833 | 18167 | 1.192x |
| 50 | 100 | 119667 | 100084 | 19583 | 1.196x |
| 51 | 102 | 126792 | 103916 | 22876 | 1.220x |
| 52 | 104 | 133916 | 104250 | 29666 | 1.285x |
| 53 | 106 | 140917 | 111125 | 29792 | 1.268x |
| 54 | 108 | 149833 | 115959 | 33874 | 1.292x |
| 55 | 110 | 157666 | 123334 | 34332 | 1.278x |
| 56 | 112 | 165958 | 125250 | 40708 | 1.325x |
| 57 | 114 | 174792 | 134666 | 40126 | 1.298x |
| 58 | 116 | 183459 | 139541 | 43918 | 1.315x |
| 59 | 118 | 192875 | 145542 | 47333 | 1.325x |
| 60 | 120 | 202417 | 147250 | 55167 | 1.375x |
