### PR TITLE
Preserve results after threaded early stop

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -636,7 +636,6 @@ function threaded_solve(
     N = length(S)
     path_results = Vector{PathResult}(undef, N)
     interrupted = Threads.Atomic{Bool}(false)
-    started = Threads.Atomic{Int}(0)
     finished = Threads.Atomic{Int}(0)
     next_k = Threads.Atomic{Int}(1)  # next index k to process
 
@@ -693,10 +692,10 @@ function threaded_solve(
             rethrow(e)
         end
     end
-    # if we got interrupted we need to remove the unassigned filedds
+    # if we got interrupted we need to remove the unassigned fields
     if interrupted[]
         assigned_results = Vector{PathResult}()
-        for i = 1:started[]
+        for i in eachindex(path_results)
             if isassigned(path_results, i)
                 push!(assigned_results, path_results[i])
             end

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -431,6 +431,7 @@
             show_progress = false,
             start_system = :total_degree,
         )
+        @test !isempty(results)
         @test length(results) < 125
     end
 


### PR DESCRIPTION
## Summary

Threaded early-stop cleanup scanned `1:started[]`, but `started` was never
incremented, so every completed result could be discarded.

This removes `started`. After worker tasks join, cleanup scans all
`path_results` slots and keeps assigned ones in path-index order. The full scan
is necessary because workers can finish out of order. The regression now
rejects empty results. A nearby comment typo is also fixed.

## Tests

- Focused threaded early-stop test: 2/2 passed with four Julia threads.
- Complete `test/solve_test.jl`: 74/74 passed with four Julia threads.

## Out of scope

This does not serialize `stop_early_cb`; callbacks may still overlap across
worker tasks.

Closes #718.
