### PR TITLE
Honor show_progress during polyhedral setup

### DIFF
--- a/src/polyhedral.jl
+++ b/src/polyhedral.jl
@@ -17,9 +17,11 @@ struct PolyhedralStartSolutionsIterator{Iter}
         start_coefficients::Vector{Vector{ComplexF64}},
         lifting::Vector{Vector{Int32}},
         mixed_cells,
+        ;
+        show_progress::Bool = true,
     )
         if isnothing(iterate(mixed_cells))
-            res = MixedSubdivisions.fine_mixed_cells(support)
+            res = MixedSubdivisions.fine_mixed_cells(support; show_progress = show_progress)
             if isnothing(res) || isempty(res[1])
                 throw(OverflowError("Cannot compute a start system."))
             end
@@ -33,13 +35,20 @@ function PolyhedralStartSolutionsIterator(
     support::AbstractVector{<:AbstractMatrix{<:Integer}},
     coeffs::AbstractVector{<:AbstractVector{<:Number}},
     lifting = map(c -> zeros(Int32, length(c)), coeffs),
-    mixed_cells = MixedCell[],
+    mixed_cells = MixedCell[];
+    show_progress::Bool = true,
 )
     support = convert(Vector{Matrix{Int32}}, support)
     start_coefficients = convert(Vector{Vector{ComplexF64}}, coeffs)
     lifting = convert(Vector{Vector{Int32}}, lifting)
 
-    PolyhedralStartSolutionsIterator(support, start_coefficients, lifting, mixed_cells)
+    PolyhedralStartSolutionsIterator(
+        support,
+        start_coefficients,
+        lifting,
+        mixed_cells;
+        show_progress = show_progress,
+    )
 end
 
 Base.show(io::IO, C::PolyhedralStartSolutionsIterator) =
@@ -193,7 +202,8 @@ end
     polyhedral(F::Union{System, AbstractSystem};
         only_non_zero = false,
         endgame_options = EndgameOptions(),
-        tracker_options = TrackerOptions())
+        tracker_options = TrackerOptions(),
+        show_progress = true)
 
 Solve the system `F` in two steps: first solve a generic system derived from the support
 of `F` using a polyhedral homotopy as proposed in [^HS95], then perform a
@@ -209,6 +219,7 @@ In this case the number of paths to track is equal to the
 mixed volume of the convex hulls of ``supp(F_i) ∪ \\{0\\}`` where ``supp(F_i)`` is the support
 of ``F_i``. See also [^LW96].
 
+Set `show_progress = false` to suppress progress output while computing mixed cells.
 
     function polyhedral(
         support::AbstractVector{<:AbstractMatrix},
@@ -364,6 +375,7 @@ function polyhedral(
     only_torus::Bool = false,
     only_non_zero::Bool = only_torus,
     compile::Union{Bool,Symbol} = COMPILE_DEFAULT[],
+    show_progress::Bool = true,
     kwargs...,
 )
     unsupported_kwargs(kwargs)
@@ -405,7 +417,11 @@ function polyhedral(
     generic_tracker =
         EndgameTracker(Tracker(H₂; options = tracker_options), options = endgame_options)
 
-    S = PolyhedralStartSolutionsIterator(support, start_coeffs)
+    S = PolyhedralStartSolutionsIterator(
+        support,
+        start_coeffs;
+        show_progress = show_progress,
+    )
     tracker = PolyhedralTracker(toric_tracker, generic_tracker, S.support, S.lifting)
 
     tracker, S

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -128,6 +128,7 @@ function solver_startsolutions(
     start_subspace = nothing,
     target_subspace = nothing,
     intrinsic = nothing,
+    show_progress::Bool = true,
     kwargs...,
 )
     !isnothing(seed) && Random.seed!(seed)
@@ -164,6 +165,7 @@ function solver_startsolutions(
                 F;
                 compile = compile,
                 target_parameters = target_parameters,
+                show_progress = show_progress,
                 kwargs...,
             )
         elseif start_system == :total_degree
@@ -200,6 +202,7 @@ function solver_startsolutions(
     seed = rand(UInt32),
     tracker_options = TrackerOptions(),
     endgame_options = EndgameOptions(),
+    show_progress::Bool = true,
     kwargs...,
 )
     !isnothing(seed) && Random.seed!(seed)
@@ -355,6 +358,7 @@ function solver_startsolutions(
     starts = nothing;
     compile::Union{Bool,Symbol} = COMPILE_DEFAULT[],
     seed = nothing,
+    show_progress::Bool = true,
     kwargs...,
 )
     !isnothing(seed) && Random.seed!(seed)
@@ -467,6 +471,7 @@ function solve(
         solver, starts = solver_startsolutions(
             args...;
             target_subspace = first(target_subspaces),
+            show_progress = show_progress,
             kwargs...,
         )
         target_parameters = target_subspaces
@@ -477,17 +482,20 @@ function solve(
             solver, starts = solver_startsolutions(
                 args...;
                 target_parameters = transform_parameters(first(target_parameters)),
+                show_progress = show_progress,
                 kwargs...,
             )
         else
             solver, starts = solver_startsolutions(
                 args...;
                 target_parameters = target_parameters,
+                show_progress = show_progress,
                 kwargs...,
             )
         end
     else
-        solver, starts = solver_startsolutions(args...; kwargs...)
+        solver, starts =
+            solver_startsolutions(args...; show_progress = show_progress, kwargs...)
     end
     if many_parameters
         if iterator_only

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -381,35 +381,8 @@
     end
 
     @testset "solve (threading)" begin
-        @var progress_x progress_y
-        progress_system = System([progress_x^2 + progress_y, progress_y^2 + progress_x])
-        capture_setup_stderr =
-            show_progress -> mktemp() do _, io
-                redirect_stderr(io) do
-                    solver_startsolutions(
-                        progress_system;
-                        show_progress = show_progress,
-                        seed = UInt32(1),
-                    )
-                end
-                flush(io)
-                seekstart(io)
-                read(io, String)
-            end
-        hidden_stderr = capture_setup_stderr(false)
-        @test !occursin("unsupported keyword", lowercase(hidden_stderr))
-        @test !occursin("Computing mixed cells", hidden_stderr)
-
-        res, stderr = mktemp() do _, io
-            res = redirect_stderr(io) do
-                solve(cyclic(7), threading = true, show_progress = false)
-            end
-            flush(io)
-            seekstart(io)
-            res, read(io, String)
-        end
+        res = solve(cyclic(7), threading = true, show_progress = false)
         @test nsolutions(res) == 924
-        @test !occursin("Computing mixed cells", stderr)
     end
 
     @testset "stop early callback" begin

--- a/test/solve_test.jl
+++ b/test/solve_test.jl
@@ -381,8 +381,35 @@
     end
 
     @testset "solve (threading)" begin
-        res = solve(cyclic(7), threading = true, show_progress = false)
+        @var progress_x progress_y
+        progress_system = System([progress_x^2 + progress_y, progress_y^2 + progress_x])
+        capture_setup_stderr =
+            show_progress -> mktemp() do _, io
+                redirect_stderr(io) do
+                    solver_startsolutions(
+                        progress_system;
+                        show_progress = show_progress,
+                        seed = UInt32(1),
+                    )
+                end
+                flush(io)
+                seekstart(io)
+                read(io, String)
+            end
+        hidden_stderr = capture_setup_stderr(false)
+        @test !occursin("unsupported keyword", lowercase(hidden_stderr))
+        @test !occursin("Computing mixed cells", hidden_stderr)
+
+        res, stderr = mktemp() do _, io
+            res = redirect_stderr(io) do
+                solve(cyclic(7), threading = true, show_progress = false)
+            end
+            flush(io)
+            seekstart(io)
+            res, read(io, String)
+        end
         @test nsolutions(res) == 924
+        @test !occursin("Computing mixed cells", stderr)
     end
 
     @testset "stop early callback" begin


### PR DESCRIPTION
## Summary

This propagates `show_progress` from `solve` through
`solver_startsolutions` and the polyhedral start-solution iterators to
`MixedSubdivisions.fine_mixed_cells`. Terminal setup methods consume the
keyword, keeping non-polyhedral behavior unchanged and allowing the public
`solver_startsolutions(...; show_progress=false)` path to honor it directly.

The polyhedral option is documented, and the default remains `true`.

## Tests

- Focused regressions for direct `solver_startsolutions` and top-level
  `solve`: 4/4 passed.
- Complete `test/solve_test.jl`: 76/76 passed with four Julia threads.

Closes #719.
