### PR TITLE
Fix of small intersection bug

### DIFF
--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2696,7 +2696,8 @@ end
 First computes a witness set `H` for `f` and then runs  `intersect(W, H)`.
 """
 function Base.intersect(W::WitnessSet, f::Expression; kwargs...)
-    H = witness_set(f)
+    F = System([f], variables = variables(system(W)))
+    H = witness_set(F)
     intersect(W, H; kwargs...)
 end
 

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2748,7 +2748,7 @@ function _intersect(
     # transform W and H so that they use the additional variable u
     n = ambient_dim(W.L)
     @unique_var u
-    @unique_var vars[1:n]
+    vars = variables(system(W))
     vars_u = [vars; u]
     projective = W.projective
     W₁, W₂, Hᵤ, f, F, h = prepare_for_u_homotopy(H, W, vars, vars_u, projective)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -2696,7 +2696,11 @@ end
 First computes a witness set `H` for `f` and then runs  `intersect(W, H)`.
 """
 function Base.intersect(W::WitnessSet, f::Expression; kwargs...)
-    F = System([f], variables = variables(system(W)))
+
+    vars = variables(system(W))
+    @assert all(v -> v ∈ vars, variables(f)) "Witness sets must be in the same ambient space."
+
+    F = System([f], variables = vars)
     H = witness_set(F)
     intersect(W, H; kwargs...)
 end
@@ -2722,7 +2726,7 @@ function _intersect(
     kwargs...,
 )
     @assert size(system(H), 1) == 1 "The second argument must be defined by a single polynomial."
-    @assert size(system(W), 2) == size(system(H), 2) "Witness sets must be in the same ambient space."
+    @assert variables(system(W)) == variables(system(H)) "Witness sets must be in the same ambient space."
     W.projective == H.projective ||
         throw(ArgumentError("Witness sets must both be affine or projective."))
 

--- a/test/witness_set_test.jl
+++ b/test/witness_set_test.jl
@@ -111,6 +111,8 @@
         @test degree.(C) == [2, 8, 8]
         D = intersect(H[1], x + y - 1; show_progress = false)
         @test degree(D) == 8
+
+        # test incompatible ambient spaces
         @var t
         @test_throws AssertionError intersect(H[1], x + t - 1; show_progress = false)
         E = witness_set(x + t - 1)

--- a/test/witness_set_test.jl
+++ b/test/witness_set_test.jl
@@ -109,6 +109,12 @@
         B = intersect(H[1], H[2])
         C = vcat([intersect(Hi, H[3]; show_progress = false) for Hi in B]...)
         @test degree.(C) == [2, 8, 8]
+        D = intersect(H[1], x + y - 1; show_progress = false)
+        @test degree(D) == 8
+        @var t
+        @test_throws AssertionError intersect(H[1], x + t - 1; show_progress = false)
+        E = witness_set(x + t - 1)
+        @test_throws AssertionError intersect(H[1], E; show_progress = false)
     end
 
     @var x[1:4]

--- a/test/witness_set_test.jl
+++ b/test/witness_set_test.jl
@@ -21,7 +21,6 @@
         @test linear_subspace(W_L) == L
 
         @test trace_test(W) < 1e-8
-        @test trace_test(W_L) < 1e-8
     end
 
     @testset "projective" begin

--- a/test/witness_set_test.jl
+++ b/test/witness_set_test.jl
@@ -21,6 +21,7 @@
         @test linear_subspace(W_L) == L
 
         @test trace_test(W) < 1e-8
+        @test trace_test(W_L) < 1e-8
     end
 
     @testset "projective" begin


### PR DESCRIPTION
Attempt to resolve #725 by ensuring that the hypersurface V(f) ends up in the same ambient space as the witness set $W$ when we run `intersect(W, f)`.