### PR TITLE
Allow random linear subspaces of full dimension or zero dimension

### DIFF
--- a/src/linear_subspaces.jl
+++ b/src/linear_subspaces.jl
@@ -467,10 +467,10 @@ function rand_subspace(
         throw(ArgumentError("Neither `dim` nor `codim` specified."))
 
     if !isnothing(dim)
-        0 < dim < n || throw(ArgumentError("`dim` has to be between 0 and `n`."))
+        0 ≤ dim ≤ n || throw(ArgumentError("`dim` has to be between 0 and `n`."))
         k = dim
     else
-        0 < codim < n || throw(ArgumentError("`codim` has to be between 0 and `n`."))
+        0 ≤ codim ≤ n || throw(ArgumentError("`codim` has to be between 0 and `n`."))
         k = n - codim
     end
     T = real ? Float64 : ComplexF64
@@ -491,10 +491,10 @@ function rand_subspace(
         throw(ArgumentError("Neither `dim` nor `codim` specified."))
 
     if !isnothing(dim)
-        0 < dim < n || throw(ArgumentError("`dim` has to be between 0 and `n`."))
+        0 ≤ dim ≤ n || throw(ArgumentError("`dim` has to be between 0 and `n`."))
         k = dim
     else
-        0 < codim < n || throw(ArgumentError("`codim` has to be between 0 and `n`."))
+        0 ≤ codim ≤ n || throw(ArgumentError("`codim` has to be between 0 and `n`."))
         k = n - codim
     end
     A = zeros(eltype(x), n - k, n)

--- a/src/numerical_irreducible_decomposition.jl
+++ b/src/numerical_irreducible_decomposition.jl
@@ -627,9 +627,7 @@ end
 function initialize_witness_sets(codim, n; affine::Bool = true)
     # we need an initial slice from which the u-regeneration flag is derived
     dim = affine ? 1 : 2
-    L₀ =
-        dim == n ? LinearSubspace(zeros(ComplexF64, 0, n)) :
-        rand_subspace(n; dim = dim, affine = affine)
+    L₀ = rand_subspace(n; dim = dim, affine = affine)
     flag = get_flag(1:codim, L₀)
 
     map(flag) do F

--- a/test/linear_test.jl
+++ b/test/linear_test.jl
@@ -50,6 +50,24 @@
         L2 = rand_subspace(x; dim = 2, affine = false)
         @test is_linear(L2)
         @test norm(L2(x)) ≈ 0 atol = 1e-8
+
+        # Test dimension 0 and codimension 0 case
+        L3 = rand_subspace(3; dim = 0)
+        @test dim(L3) == 0
+        @test codim(L3) == 3
+
+        L4 = rand_subspace(3; dim = 3)
+        @test dim(L4) == 3
+        @test codim(L4) == 0
+        @test is_linear(L4)
+
+        L5 = rand_subspace(3; codim = 3)
+        @test codim(L5) == 3
+        @test dim(L5) == 0
+
+        L6 = rand_subspace(x; codim = 0)
+        @test codim(L6) == 0
+        @test dim(L6) == length(x)
     end
 
     @testset "Intersect subspaces" begin

--- a/test/witness_set_test.jl
+++ b/test/witness_set_test.jl
@@ -22,7 +22,6 @@
 
         @test trace_test(W) < 1e-8
     end
-
     @testset "projective" begin
         @var x y z
 
@@ -82,6 +81,17 @@
         @test degree(witness_set(f; dim = 2, compile = false)) == 16
         @test degree(witness_set(f; codim = 4, compile = false)) == 16
         @test degree(witness_set(f; compile = false)) == 16
+    end
+
+    @testset "dimension zero" begin
+        @var x y
+
+        F = System([x^2 - 1, y - x], [x, y])
+        W = witness_set(F; dim = 0, compile = false)
+
+        @test dim(W) == 0
+        @test codim(W) == 2
+        @test degree(W) == 2
     end
 
     @var x, y, z


### PR DESCRIPTION
As pointed out in #725, the function `witness_set(F, dim=d)` does not support the trivial edge case $d=0$.

One way to fix it would be to simply allow the full-dimensional case in `rand_subspace` (in which case, the A-matrix has zero rows). This is a quick attempt to implement this.