### PR TITLE
Fix membership slice directions: random instead of zero matrix

### DIFF
--- a/src/witness_set.jl
+++ b/src/witness_set.jl
@@ -272,7 +272,7 @@ function MembershipCache(W, EO, TO, progress)
     F = system(W)
     m, n = size(F)
     i = codim(W)
-    A0 = zeros(ComplexF64, n - i, n)
+    A0 = randn(ComplexF64, n - i, n)
     A = LA.svd(A0).Vt # need to orthonormalize A
     b = zeros(ComplexF64, n - i)
     x0 = zeros(ComplexF64, n)


### PR DESCRIPTION
I think this is a bug, since in MembershipCache the linear space was not chosen random.