### PR TITLE
Implement (principal branch) of logarithm

### DIFF
--- a/docs/src/model_kit.md
+++ b/docs/src/model_kit.md
@@ -12,6 +12,27 @@ Variable
 variables(prefix::Union{Symbol,String}, indices...)
 ```
 
+## Supported operations
+
+`Expression`s support the usual arithmetic operations (`+`, `-`, `*` and `/`), powers `x^r` with a constant exponent  `r`, as well as the following elementary functions:
+
+```julia
+sin(x)
+cos(x)
+tan(x)
+asin(x)
+acos(x)
+sinh(x)
+cosh(x)
+tanh(x)
+exp(x)
+log(x)
+sqrt(x)
+```
+
+!!! note "Branch conventions"
+    The multivalued complex fuctions `asin`, `acos`, `log` and `sqrt`, as well as non-integer powers, are evaluated using their [principal branches](https://en.wikipedia.org/wiki/Principal_value). For these functions to vary analytically during path tracking, the arguments must stay in the domain of the principal branch. In particular, arguments must not cross a branch cut or pass through a branch point.
+
 ## Methods
 ```@docs
 coefficients(f::Expression, vars::AbstractVector{Variable})

--- a/src/model_kit/acb.jl
+++ b/src/model_kit/acb.jl
@@ -43,6 +43,10 @@ Base.@propagate_inbounds function acb_op_invsqr!(t, x, m)
     Arblib.sqr!(m[1], x)
     Arblib.inv!(t, m[1])
 end
+# OP_LOG # log(a)
+Base.@propagate_inbounds function acb_op_log!(t, x, m)
+    Arblib.log!(t, x)
+end
 # OP_NEG # -a
 Base.@propagate_inbounds function acb_op_neg!(t, x, m)
     Arblib.neg!(t, x)

--- a/src/model_kit/intermediate_representation.jl
+++ b/src/model_kit/intermediate_representation.jl
@@ -520,6 +520,9 @@ function expr_to_ir_statements!(
     elseif t == :Exp || t == :exp
         x = expr_to_ir_statements!(ir, args(ex)[1], cse, pse)
         return add_op!(ir, OP_EXP, x)
+    elseif t == :Log || t == :log
+        x = expr_to_ir_statements!(ir, args(ex)[1], cse, pse)
+        return add_op!(ir, OP_LOG, x)
     elseif t == :Sqrt || t == :SquareRott
         x = expr_to_ir_statements!(ir, args(ex)[1], cse, pse)
         return add_op!(ir, OP_SQRT, x)

--- a/src/model_kit/operations.jl
+++ b/src/model_kit/operations.jl
@@ -16,6 +16,7 @@
     OP_INV # 1 / a
     OP_INV_NOT_ZERO # a ≂̸ 0 ? 1 / a : a
     OP_INVSQR # 1 / a^2
+    OP_LOG # log(a)
     OP_NEG # -a
     OP_SIN # sin(a)
     OP_SINH # sinh(a)
@@ -61,6 +62,7 @@ function arity(op_type::OpType)
            op_type == OP_INV ||
            op_type == OP_INV_NOT_ZERO ||
            op_type == OP_INVSQR ||
+           op_type == OP_LOG ||
            op_type == OP_NEG ||
            op_type == OP_SIN ||
            op_type == OP_SINH ||
@@ -118,6 +120,8 @@ function op_call(op_type::OpType)
         :op_inv_not_zero
     elseif op_type == OP_INVSQR
         :op_invsqr
+    elseif op_type == OP_LOG
+        :op_log
     elseif op_type == OP_NEG
         :op_neg
     elseif op_type == OP_SIN
@@ -213,6 +217,7 @@ Invert x unless it is 0, then return 0.
 """
 op_inv_not_zero(x) = ifelse(is_zero(x), x, op_inv(x))
 op_invsqr(x) = op_sqr(op_inv(x))
+op_log(x) = log(x)
 op_neg(x) = -x
 op_sin(x) = sin(x)
 op_sinh(x) = sinh(x)

--- a/src/model_kit/taylor.jl
+++ b/src/model_kit/taylor.jl
@@ -625,24 +625,26 @@ end
 function taylor_op_invsqr(V::Val{K}, x::TruncatedTaylorSeries{M}) where {K,M}
     taylor_op_div(V, 1, taylor_op_sqr(V, x))
 end
-# OP_LOG # log(a) (principal value)
+# OP_LOG # log(a)
 @generated function taylor_op_log(
     ::Val{K},
     x::TruncatedTaylorSeries{M},
 ) where {K,M}
     taylor_impl(K, M - 1) do list, D
-        coefficients = Any[add_op!(list, OP_LOG, D[:x, 0])]
+        # l_0 = log(x_0)
+        ids = Any[add_op!(list, OP_LOG, D[:x, 0])]
+
         for k = 1:K
-            # k*x_k - sum_{j=1}^{k-1} x_j*(k-j)*ℓ_{k-j}
-            numerator = mul!(list, k, D[:x, k])
+            # l_k = 1/(k*x_0) * [k*x_k - sum_{j=1}^{k-1} x_j*(k-j)*l_{k-j}]
+            l_k = mul!(list, k, D[:x, k])
             for j = 1:(k - 1)
-                term = mul!(list, k - j, coefficients[k - j + 1])
-                numerator = submul!(list, D[:x, j], term,  numerator)
+                l_k = submul!(list, D[:x, j], mul!(list, k - j, ids[k - j + 1]), l_k)
             end
-            denominator = mul!(list, k, D[:x, 0])
-            push!(coefficients, div!(list, numerator, denominator))
+            l_k = div!(list, l_k, mul!(list, k, D[:x, 0]))
+            push!(ids, l_k)
         end
-        coefficients
+
+        ids
     end
 end
 # OP_NEG # -a

--- a/src/model_kit/taylor.jl
+++ b/src/model_kit/taylor.jl
@@ -626,10 +626,7 @@ function taylor_op_invsqr(V::Val{K}, x::TruncatedTaylorSeries{M}) where {K,M}
     taylor_op_div(V, 1, taylor_op_sqr(V, x))
 end
 # OP_LOG # log(a)
-@generated function taylor_op_log(
-    ::Val{K},
-    x::TruncatedTaylorSeries{M},
-) where {K,M}
+@generated function taylor_op_log(::Val{K}, x::TruncatedTaylorSeries{M}) where {K,M}
     taylor_impl(K, M - 1) do list, D
         # l_0 = log(x_0)
         ids = Any[add_op!(list, OP_LOG, D[:x, 0])]
@@ -637,8 +634,8 @@ end
         for k = 1:K
             # l_k = 1/(k*x_0) * [k*x_k - sum_{j=1}^{k-1} x_j*(k-j)*l_{k-j}]
             l_k = mul!(list, k, D[:x, k])
-            for j = 1:(k - 1)
-                l_k = submul!(list, D[:x, j], mul!(list, k - j, ids[k - j + 1]), l_k)
+            for j = 1:(k-1)
+                l_k = submul!(list, D[:x, j], mul!(list, k - j, ids[k-j+1]), l_k)
             end
             l_k = div!(list, l_k, mul!(list, k, D[:x, 0]))
             push!(ids, l_k)

--- a/src/model_kit/taylor.jl
+++ b/src/model_kit/taylor.jl
@@ -625,6 +625,26 @@ end
 function taylor_op_invsqr(V::Val{K}, x::TruncatedTaylorSeries{M}) where {K,M}
     taylor_op_div(V, 1, taylor_op_sqr(V, x))
 end
+# OP_LOG # log(a) (principal value)
+@generated function taylor_op_log(
+    ::Val{K},
+    x::TruncatedTaylorSeries{M},
+) where {K,M}
+    taylor_impl(K, M - 1) do list, D
+        coefficients = Any[add_op!(list, OP_LOG, D[:x, 0])]
+        for k = 1:K
+            # k*x_k - sum_{j=1}^{k-1} x_j*(k-j)*ℓ_{k-j}
+            numerator = mul!(list, k, D[:x, k])
+            for j = 1:(k - 1)
+                term = mul!(list, k - j, coefficients[k - j + 1])
+                numerator = submul!(list, D[:x, j], term,  numerator)
+            end
+            denominator = mul!(list, k, D[:x, 0])
+            push!(coefficients, div!(list, numerator, denominator))
+        end
+        coefficients
+    end
+end
 # OP_NEG # -a
 @generated function taylor_op_neg(::Val{K}, x::TruncatedTaylorSeries{M}) where {K,M}
     taylor_impl(K, M - 1) do list, D

--- a/test/homotopies_test.jl
+++ b/test/homotopies_test.jl
@@ -215,9 +215,9 @@ end
         test_homotopy(MixedHomotopy(H), H)
     end
 
-    @testset "Homotopy with trigonometric functions" begin
+    @testset "Homotopy with transcendental functions" begin
         @var x[1:9] t
-        F = [sin(t); cos(t); exp(t); tan(t); asin(t); acos(t); sinh(t); cosh(t); tanh(t)]
+        F = [sin(t); cos(t); exp(t); log(t); tan(t); asin(t); acos(t); sinh(t); cosh(t); tanh(t)]
         x0 = evaluate.(F, t => π / 4)
 
         G = System(x - F, x, [t])

--- a/test/homotopies_test.jl
+++ b/test/homotopies_test.jl
@@ -218,15 +218,15 @@ end
     @testset "Homotopy with transcendental functions" begin
         @var x[1:10] t
         F = [
-            sin(t);
-            cos(t);
-            exp(t);
-            log(t);
-            tan(t);
-            asin(t);
-            acos(t);
-            sinh(t);
-            cosh(t);
+            sin(t)
+            cos(t)
+            exp(t)
+            log(t)
+            tan(t)
+            asin(t)
+            acos(t)
+            sinh(t)
+            cosh(t)
             tanh(t)
         ]
         x0 = evaluate.(F, t => π / 4)

--- a/test/homotopies_test.jl
+++ b/test/homotopies_test.jl
@@ -217,7 +217,18 @@ end
 
     @testset "Homotopy with transcendental functions" begin
         @var x[1:9] t
-        F = [sin(t); cos(t); exp(t); log(t); tan(t); asin(t); acos(t); sinh(t); cosh(t); tanh(t)]
+        F = [
+            sin(t);
+            cos(t);
+            exp(t);
+            log(t);
+            tan(t);
+            asin(t);
+            acos(t);
+            sinh(t);
+            cosh(t);
+            tanh(t)
+        ]
         x0 = evaluate.(F, t => π / 4)
 
         G = System(x - F, x, [t])

--- a/test/homotopies_test.jl
+++ b/test/homotopies_test.jl
@@ -216,7 +216,7 @@ end
     end
 
     @testset "Homotopy with transcendental functions" begin
-        @var x[1:9] t
+        @var x[1:10] t
         F = [
             sin(t);
             cos(t);

--- a/test/model_kit/symbolic_test.jl
+++ b/test/model_kit/symbolic_test.jl
@@ -370,7 +370,8 @@
 
     @testset "transcendental functions" begin
         @var x
-        F = [sin(x)
+        F = [
+            sin(x)
             cos(x)
             exp(x)
             log(x)
@@ -385,7 +386,7 @@
             cos(x)
             -sin(x)
             exp(x)
-            1/x
+            1 / x
             1 + tan(x)^2
             1 / sqrt(1 - x^2)
             -1 / sqrt(1 - x^2)

--- a/test/model_kit/symbolic_test.jl
+++ b/test/model_kit/symbolic_test.jl
@@ -370,12 +370,22 @@
 
     @testset "transcendental functions" begin
         @var x
-        F = [sin(x); cos(x); exp(x); tan(x); asin(x); acos(x); sinh(x); cosh(x); tanh(x)]
+        F = [sin(x)
+            cos(x)
+            exp(x)
+            log(x)
+            tan(x)
+            asin(x)
+            acos(x)
+            sinh(x)
+            cosh(x)
+            tanh(x)
+        ]
         dF_symbolic = [
             cos(x)
             -sin(x)
             exp(x)
-            log(x)
+            1/x
             1 + tan(x)^2
             1 / sqrt(1 - x^2)
             -1 / sqrt(1 - x^2)

--- a/test/model_kit/symbolic_test.jl
+++ b/test/model_kit/symbolic_test.jl
@@ -368,13 +368,14 @@
         @test Q == -1 + y
     end
 
-    @testset "trigonometric functions" begin
+    @testset "transcendental functions" begin
         @var x
         F = [sin(x); cos(x); exp(x); tan(x); asin(x); acos(x); sinh(x); cosh(x); tanh(x)]
         dF_symbolic = [
             cos(x)
             -sin(x)
             exp(x)
+            log(x)
             1 + tan(x)^2
             1 / sqrt(1 - x^2)
             -1 / sqrt(1 - x^2)
@@ -391,6 +392,7 @@
             sin(x0)
             cos(x0)
             exp(x0)
+            log(x0)
             tan(x0)
             asin(x0)
             acos(x0)

--- a/test/model_kit/symbolic_test.jl
+++ b/test/model_kit/symbolic_test.jl
@@ -384,7 +384,7 @@
             1 - tanh(x)^2
         ]
         dF = differentiate(F, x)
-        @test expand.(dF - dF_symbolic) == Vector{Expression}(zeros(Int, 9))
+        @test expand.(dF - dF_symbolic) == Vector{Expression}(zeros(Int, 10))
 
         x0 = 0.1
         F0 = evaluate.(F, x => x0)


### PR DESCRIPTION
I have a project where I need to do homotopies that involve (the principal branch of) the logarithm. Here's an attempt to implement this. I tried to mimic the code that already exists for `sqrt` and trigonometric functions (cf. #703). The only slightly mathematical nontrivial part is how to compute the Taylor series. The idea is this:

Let $X(\epsilon)=\sum_{k=0}^\infty x_k\epsilon^k$ be a Taylor series with $x_0\neq 0$. We want to get the coefficients $\ell_k$ of the Taylor series for $L(\epsilon):=\log(X(\epsilon))$ in terms of the $x_k$'s. The chain rule gives $X(\epsilon)L'(\epsilon)=X'(\epsilon)$. By comparing the coefficients of $\epsilon^{k-1}$ we obtain 

$$k x_0 \ell_k+\sum_{j=1}^{k-1} (k-j)x_j\ell_{k-j}=k x_k$$

from which we get the recursion

$$\ell_0=\log(x_0),\qquad \ell_k=\frac{1}{kx_0}\Big(kx_k-\sum_{j=1}^{k-1}(k-j)x_j\ell_{k-j}\Big).$$

which is used in `taylor_op_log`.

I also added a small "note" about the current convention that multivalued complex functions are evaluated using their **principal branch**. For the future, one could think about handling branches in a nicer way, but for now, having this very basic version of the functions would already help a lot.
