### PR TITLE
Bug fix in taylor expansion for integer powers

### DIFF
--- a/src/model_kit/taylor.jl
+++ b/src/model_kit/taylor.jl
@@ -767,6 +767,22 @@ end
 #
 # OP_POW_INT # a ^ p where p isa Integer
 
+# Multiplication avoids division by x₀ for nonnegative integer powers.
+function taylor_op_pow_zero_constant(V::Val{K}, x, r::Integer) where {K}
+    result = taylor_op_identity(V, one(x[0]))
+    base = taylor_op_identity(V, x)
+    while r > 0
+        if isodd(r)
+            result = taylor_op_mul(V, result, base)
+        end
+        r = div(r, 2)
+        if r > 0
+            base = taylor_op_sqr(V, base)
+        end
+    end
+    result
+end
+
 function taylor_op_pow_impl(K, dx, op)
     D = DiffMap()
     list = IntermediateRepresentation()
@@ -796,7 +812,12 @@ function taylor_op_pow_impl(K, dx, op)
     quote
         Base.@_inline_meta
         $(untuple(:x, dx))
-        iszero(x0) && return $(taylor_tuple([nothing for _ = 0:K]))
+        if iszero(x0)
+            if r isa Integer && r >= 0
+                return taylor_op_pow_zero_constant(Val($K), x, r)
+            end
+            return $(taylor_tuple([nothing for _ = 0:K]))
+        end
         w₀ = $op(x0, r)
         $((K > 0 ? (:(u₀_inv = op_inv(x0)),) : ())...)
         $(to_julia_expr(list))

--- a/test/model_kit/operations_test.jl
+++ b/test/model_kit/operations_test.jl
@@ -57,3 +57,18 @@
     end
 
 end
+
+@testset "Integer Taylor powers with zero constant coefficient" begin
+    for pow in (ModelKit.taylor_op_pow_int, ModelKit.taylor_op_pow)
+        for r in (0, 1, 2, 5, 8)
+            expected = ntuple(k -> k == r + 1 ? 1.0 : 0.0, 6)
+            @test Tuple(pow(Val(5), (0.0, 1.0), r)) == expected
+        end
+        # (2ε + 3ε²)^3 = 8ε³ + 36ε⁴ + 54ε⁵ + 27ε⁶
+        @test Tuple(pow(Val(6), (0.0, 2.0, 3.0), 3)) ==
+              (0.0, 0.0, 0.0, 8.0, 36.0, 54.0, 27.0)
+        @test Tuple(pow(Val(2), (0.0im, 1.0im), 2)) == (0.0, 0.0, -1.0)
+        @test Tuple(pow(Val(0), (0.0, 1.0), 0)) == (1.0,)
+        @test Tuple(pow(Val(2), (0.0,), 2)) == (0.0, 0.0, 0.0)
+    end
+end


### PR DESCRIPTION
This PR fixes a bug in the computation of Taylor coefficients for nonnegative integer powers when the input series has a zero constant coefficient. Previously, the power routine returned all zeros—for example, squaring \(X(\epsilon)=\epsilon\) lost the \(\epsilon^2\) term. The fix uses truncated series multiplication via exponentiation by squaring in this case.